### PR TITLE
Update settings code

### DIFF
--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -2,3 +2,7 @@
 
 // PUBLIC_VERSION will be set to the version number from package.json
 export const version = PUBLIC_VERSION;
+
+// As we will not be the only application hosted out of this github pages domain,
+// we need to namespace any domain specific keys (such as those written to localstorage).
+export const namespace = 'ld-explorer/';

--- a/src/lib/stores/localStorage.store.test.ts
+++ b/src/lib/stores/localStorage.store.test.ts
@@ -2,6 +2,7 @@
 
 import { createLocalStorageStore } from './localStorage.store';
 import { get } from 'svelte/store';
+import { namespace } from '$lib/constants';
 
 const exampleKey = 'test';
 const exampleDefault = {
@@ -23,17 +24,23 @@ describe('localStorage store', () => {
 			expect(get(store)).toStrictEqual(exampleDefault);
 		});
 
-		it('Adds the store to localStorage', () => {
-			expect(JSON.parse(localStorage.getItem(exampleKey) || '""')).toStrictEqual(exampleDefault);
+		it('has not just written the key away with no namespace', () => {
+			expect(JSON.parse(localStorage.getItem(exampleKey) || '""')).toBeFalsy();
+		});
+
+		it('Adds the store to localStorage with a namespace', () => {
+			expect(JSON.parse(localStorage.getItem(`${namespace}${exampleKey}`) || '""')).toStrictEqual(
+				exampleDefault
+			);
 		});
 	});
 
 	describe('On store update', () => {
-		it('Updates localStorage accordingly', () => {
+		it('Updates localStorage accordingly, with a namespace', () => {
 			const newSetting = { setting__biz: null };
 			store.update((current) => ({ ...current, ...newSetting }));
 
-			expect(JSON.parse(localStorage.getItem(exampleKey) || '""')).toStrictEqual({
+			expect(JSON.parse(localStorage.getItem(`${namespace}${exampleKey}`) || '""')).toStrictEqual({
 				...exampleDefault,
 				...newSetting
 			});
@@ -45,12 +52,14 @@ describe('localStorage store', () => {
 			const newSetting = { setting__biz: null };
 			store.update((current) => ({ ...current, ...newSetting }));
 
-			expect(JSON.parse(localStorage.getItem(exampleKey) || '""')).not.toStrictEqual(
-				exampleDefault
-			);
+			expect(
+				JSON.parse(localStorage.getItem(`${namespace}${exampleKey}`) || '""')
+			).not.toStrictEqual(exampleDefault);
 
 			store.restore();
-			expect(JSON.parse(localStorage.getItem(exampleKey) || '""')).toStrictEqual(exampleDefault);
+			expect(JSON.parse(localStorage.getItem(`${namespace}${exampleKey}`) || '""')).toStrictEqual(
+				exampleDefault
+			);
 		});
 	});
 });

--- a/src/lib/stores/localStorage.store.ts
+++ b/src/lib/stores/localStorage.store.ts
@@ -1,13 +1,16 @@
 /* (c) Crown Copyright GCHQ */
 
 import { getObject, setObject } from '$lib/util/storage.utils';
+import { namespace } from '$lib/constants';
 import { writable } from 'svelte/store';
 
 export function createLocalStorageStore<T>(key: string, defaultStore: T) {
-	const { set, subscribe, update } = writable<T>(getObject(key) || defaultStore);
+	const namespacedKey = `${namespace}${key}`;
+
+	const { set, subscribe, update } = writable<T>(getObject(namespacedKey) || defaultStore);
 
 	subscribe((store) => {
-		setObject<T>(key, store);
+		setObject<T>(namespacedKey, store);
 	});
 
 	return {

--- a/src/routes/policy/cookies/+page.svelte
+++ b/src/routes/policy/cookies/+page.svelte
@@ -51,4 +51,19 @@
 		are not essential for the use of the application.
 	</P>
 	<P>LD Explorer does not include any non-essential cookies.</P>
+
+	<Heading variant="h3" text="Cookies from other applications" />
+	<P
+		>LD Explorer is hosted on github pages under the GCHQ organization, as is the case with other
+		GCHQ applications. These will all be hosted under the same domain, as github pages only varies
+		the subfolder between repositories.</P
+	>
+	<P
+		>As cookies and cookie-like features are tied to domains, if you've used other GCHQ applications
+		hosted on github pages then you may see local data items in your browser that were not added and
+		are not used by LD Explorer itself. You can identify any LD Explorer related items by looking
+		for keys that start with
+		<pre class="inline bg-gray-100">ld-explorer/</pre>
+		.</P
+	>
 </PageView>


### PR DESCRIPTION
As we are hosted on github pages, we are sharing a domain with other applications. This means that local keys (such as those used for the browser's `localStorage` feature) will need to be namespaced so as not to impact or be-impacted-by other applications running on the same domain.