### PR TITLE
Update tests with recommended convention

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,10 +8,12 @@
 			"name": "ld-explorer",
 			"version": "0.1.1",
 			"license": "Apache-2.0",
+			"dependencies": {
+				"@testing-library/user-event": "^14.6.0"
+			},
 			"devDependencies": {
 				"@axe-core/playwright": "^4.10.1",
 				"@comunica/bindings-factory": "^3.3.0",
-				"@comunica/data-factory": "^3.1.0",
 				"@comunica/query-sparql": "^4.0.2",
 				"@comunica/types": "^4.0.2",
 				"@playwright/test": "^1.49.1",
@@ -40,7 +42,6 @@
 				"postcss": "^8.5.1",
 				"prettier": "^3.4.2",
 				"prettier-plugin-svelte": "^3.3.3",
-				"rdf-data-factory": "^2.0.2",
 				"rdfa-streaming-parser": "^3.0.1",
 				"shadow-dom-testing-library": "^1.11.3",
 				"svelte": "^4.2.19",
@@ -119,7 +120,6 @@
 			"version": "7.26.2",
 			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.26.2.tgz",
 			"integrity": "sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@babel/helper-validator-identifier": "^7.25.9",
@@ -144,7 +144,6 @@
 			"version": "7.25.9",
 			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.9.tgz",
 			"integrity": "sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=6.9.0"
@@ -170,7 +169,6 @@
 			"version": "7.26.0",
 			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.26.0.tgz",
 			"integrity": "sha512-FDSOghenHTiToteC/QRlv2q3DhPZ/oOXTBoirfWNx1Cx3TMVcGWQtMMmQcSvb/JjpNeGzx8Pq/b4fKEJuWm1sw==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"regenerator-runtime": "^0.14.0"
@@ -8161,16 +8159,6 @@
 				"sparqlalgebrajs": "^4.3.7"
 			}
 		},
-		"node_modules/@comunica/data-factory": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/@comunica/data-factory/-/data-factory-3.1.0.tgz",
-			"integrity": "sha512-kNEgK+3HPzej8m53//RkZTq9WPYrja9CjrkJqvdgawpMTbg+zEeCoQZ3BGD0LiWiphADpyvYfRFCVpgcHjKvLQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@rdfjs/types": "*"
-			}
-		},
 		"node_modules/@comunica/logger-pretty": {
 			"version": "4.0.2",
 			"resolved": "https://registry.npmjs.org/@comunica/logger-pretty/-/logger-pretty-4.0.2.tgz",
@@ -10389,7 +10377,6 @@
 			"version": "10.4.0",
 			"resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.0.tgz",
 			"integrity": "sha512-pemlzrSESWbdAloYml3bAJMEfNh1Z7EduzqPKprCH5S341frlpYnUEW0H72dLxa6IsYr+mPno20GiSm+h9dEdQ==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@babel/code-frame": "^7.10.4",
@@ -10473,11 +10460,23 @@
 				}
 			}
 		},
+		"node_modules/@testing-library/user-event": {
+			"version": "14.6.0",
+			"resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.0.tgz",
+			"integrity": "sha512-+jsfK7kVJbqnCYtLTln8Ja/NmVrZRwBJHmHR9IxIVccMWSOZ6Oy0FkDJNeyVu4QSpMNmRfy10Xb76ObRDlWWBQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=12",
+				"npm": ">=6"
+			},
+			"peerDependencies": {
+				"@testing-library/dom": ">=7.21.4"
+			}
+		},
 		"node_modules/@types/aria-query": {
 			"version": "5.0.4",
 			"resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
 			"integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@types/cookie": {
@@ -11087,7 +11086,6 @@
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
 			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
@@ -11097,7 +11095,6 @@
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
 			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"color-convert": "^2.0.1"
@@ -11161,7 +11158,6 @@
 			"version": "5.3.0",
 			"resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
 			"integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
-			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"dequal": "^2.0.3"
@@ -11485,7 +11481,6 @@
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
 			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"ansi-styles": "^4.1.0",
@@ -11631,7 +11626,6 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
 			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"color-name": "~1.1.4"
@@ -11644,7 +11638,6 @@
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
 			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/color-string": {
@@ -11968,7 +11961,6 @@
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
 			"integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=6"
@@ -11999,7 +11991,6 @@
 			"version": "0.5.16",
 			"resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
 			"integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/dom-serializer": {
@@ -12910,7 +12901,6 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
 			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
@@ -13324,7 +13314,6 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
 			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/js-yaml": {
@@ -13680,7 +13669,6 @@
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
 			"integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
-			"dev": true,
 			"license": "MIT",
 			"bin": {
 				"lz-string": "bin/bin.js"
@@ -14264,7 +14252,6 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
 			"integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
-			"dev": true,
 			"license": "ISC"
 		},
 		"node_modules/picomatch": {
@@ -14576,7 +14563,6 @@
 			"version": "27.5.1",
 			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
 			"integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"ansi-regex": "^5.0.1",
@@ -14591,7 +14577,6 @@
 			"version": "5.2.0",
 			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
 			"integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=10"
@@ -15483,7 +15468,6 @@
 			"version": "17.0.2",
 			"resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
 			"integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/read-cache": {
@@ -15563,7 +15547,6 @@
 			"version": "0.14.1",
 			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
 			"integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/relative-to-absolute-iri": {
@@ -16299,7 +16282,6 @@
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
 			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"has-flag": "^4.0.0"

--- a/package.json
+++ b/package.json
@@ -64,5 +64,8 @@
 		"vite": "^5.4.11",
 		"vitest": "^3.0.2"
 	},
-	"type": "module"
+	"type": "module",
+	"dependencies": {
+		"@testing-library/user-event": "^14.6.0"
+	}
 }

--- a/src/lib/components/ui/Button.spec.ts
+++ b/src/lib/components/ui/Button.spec.ts
@@ -2,9 +2,9 @@
 
 import '@testing-library/jest-dom';
 import Button from './Button.svelte';
-import { fireEvent } from '@testing-library/svelte';
 import { hydratedRender as render } from '$test-helpers/render';
 import { screen } from 'shadow-dom-testing-library';
+import userEvent from '@testing-library/user-event';
 
 describe('Button component', () => {
 	describe('default behavior', () => {
@@ -23,11 +23,12 @@ describe('Button component', () => {
 		});
 
 		it('dispatches a click event when clicked', async () => {
+			const user = userEvent.setup();
 			const clicked = vi.fn();
 			component.$on('click', clicked);
 
 			const theButton = await screen.findByShadowRole('button');
-			await fireEvent.click(theButton);
+			await user.click(theButton);
 
 			expect(clicked).toHaveBeenCalledOnce();
 		});

--- a/src/lib/components/ui/Switch.spec.ts
+++ b/src/lib/components/ui/Switch.spec.ts
@@ -2,9 +2,9 @@
 
 import '@testing-library/jest-dom';
 import Switch from './Switch.svelte';
-import { fireEvent } from '@testing-library/svelte';
 import { hydratedRender as render } from '$test-helpers/render';
 import { screen } from 'shadow-dom-testing-library';
+import userEvent from '@testing-library/user-event';
 
 describe('Switch component', () => {
 	const exampleProps = {
@@ -24,12 +24,14 @@ describe('Switch component', () => {
 	});
 
 	it('dispatches a change event when clicked', async () => {
+		const user = userEvent.setup();
+
 		const component = (await render(Switch, exampleProps)).component as Switch;
 		const changed = vi.fn();
 		component.$on('change', changed);
 
 		const theSwitch = await screen.findByShadowLabelText(exampleProps.label);
-		await fireEvent.click(theSwitch);
+		await user.click(theSwitch);
 
 		expect(changed).toHaveBeenCalledOnce();
 	});

--- a/src/lib/components/ui/tabs/Tab.spec.ts
+++ b/src/lib/components/ui/tabs/Tab.spec.ts
@@ -1,9 +1,10 @@
 /* (c) Crown Copyright GCHQ */
 
 import '@testing-library/jest-dom';
-import { fireEvent, screen } from '@testing-library/svelte';
+import { screen } from '@testing-library/svelte';
 import Tab from './Tab.svelte';
 import { hydratedRender as render } from '$test-helpers/render';
+import userEvent from '@testing-library/user-event';
 
 describe('Tab component', () => {
 	describe('default behavior', () => {
@@ -20,9 +21,11 @@ describe('Tab component', () => {
 		});
 
 		it('dispatches a click event when clicked', async () => {
+			const user = userEvent.setup();
+
 			const clicked = vi.fn();
 			component.$on('click', clicked);
-			await fireEvent.click(tab);
+			await user.click(tab);
 
 			expect(clicked).toHaveBeenCalledOnce();
 		});


### PR DESCRIPTION
In anticipation of an eventual Svelte 5 upgrade, switch tests to use newer user event convention to hopefully make migration easier.