### PR TITLE
Update example prefixes

### DIFF
--- a/src/lib/data/prefixes.json
+++ b/src/lib/data/prefixes.json
@@ -81,7 +81,11 @@
 	},
 	{
 		"label": "ex",
-		"iri": "http://www.example.com"
+		"iri": "http://example.com/"
+	},
+	{
+		"label": "ex1",
+		"iri": "http://example.org/"
 	},
 	{
 		"label": "dcat",


### PR DESCRIPTION
Update prefixes with a few examples (.org/ and .com/) - note that to get this functionality, users will need to "Restore Defaults" under settings/prefixes.