### PR TITLE
Svelte 5 Upgrade

### DIFF
--- a/e2e/fixtures/pageFixtures.ts
+++ b/e2e/fixtures/pageFixtures.ts
@@ -12,6 +12,7 @@ import ExploreClassesPage from '$e2e/pages/explore/ExploreClassesPage';
 import ExploreIndividualsPage from '$e2e/pages/explore/ExploreIndividualsPage';
 import ExploreTriplesPage from '$e2e/pages/explore/ExploreTriplesPage';
 import GeneralSettingsPage from '$e2e/pages/settings/GeneralSettingsPage';
+import LogsPage from '$e2e/pages/LogsPage';
 import ImportToLocalDataSourcePage from '$e2e/pages/data-sources/ImportToLocalDataSourcePage';
 import ListSourcesPage from '$e2e/pages/data-sources/ListSourcesPage';
 import ShowDataSource from '$e2e/pages/data-sources/ShowDataSourcePage';
@@ -25,6 +26,7 @@ const pages = {
 	addRemoteDataSourcePage: AddRemoteDataSourcePage,
 	showDataSource: ShowDataSource,
 	listSourcesPage: ListSourcesPage,
+	logsPage: LogsPage,
 	exploreClassesPage: ExploreClassesPage,
 	exploreIndividualsPage: ExploreIndividualsPage,
 	exploreTriplesPage: ExploreTriplesPage,

--- a/e2e/pages/LogsPage.ts
+++ b/e2e/pages/LogsPage.ts
@@ -1,0 +1,26 @@
+/* (c) Crown Copyright GCHQ */
+
+import { Locator, Page } from '@playwright/test';
+import { LDExplorerPage } from './BasePages';
+import { navigateTo } from '$e2e/helpers/navigation';
+
+export default class LogsPage extends LDExplorerPage {
+	readonly clearLogsButton: Locator;
+
+	constructor(public readonly page: Page) {
+		super(page);
+		this.clearLogsButton = page.getByRole('button', { name: 'Clear Logs' });
+	}
+
+	async goto() {
+		await this.page.goto('/logs');
+	}
+
+	async navigateTo() {
+		await navigateTo(this.page, /Logs$/);
+	}
+
+	async clickClearLogs() {
+		await this.clearLogsButton.click();
+	}
+}

--- a/e2e/tests/features/logs/view-logs.test.ts
+++ b/e2e/tests/features/logs/view-logs.test.ts
@@ -1,0 +1,40 @@
+/* (c) Crown Copyright GCHQ */
+
+import { expect, test } from '$e2e/test';
+
+const exampleSourceName = 'Test Name';
+const exampleDescription = 'Test Description';
+
+test.describe('Logs page', () => {
+	test.beforeEach(
+		async ({ addLocalDataSourcePage, importToLocalDataSourcePage, sherlockExampleDataTTL }) => {
+			addLocalDataSourcePage.goto();
+			await addLocalDataSourcePage.createLocalDataSource(exampleSourceName, exampleDescription);
+			await importToLocalDataSourcePage.navigateTo(exampleSourceName);
+			await importToLocalDataSourcePage.importRdfData(sherlockExampleDataTTL);
+		}
+	);
+
+	test('displays logs and enables users to clear them', async ({ page, logsPage }) => {
+		logsPage.navigateTo();
+		await expect(page).toHaveTitle('Logs - LD-Explorer');
+		await expect(page.getByText('Logs Empty')).not.toBeVisible();
+
+		// Check the logs
+		await expect(page.getByText('Finished importing document')).toBeVisible();
+
+		// Check the detail display
+		await expect(page.getByTestId('log-details')).not.toBeVisible();
+		await page.getByText('Details').click();
+		await expect(page.getByTestId('log-details')).toBeVisible();
+		await page.getByText('Details').click();
+		await expect(page.getByTestId('log-details')).not.toBeVisible();
+
+		// Clear them
+		await logsPage.clickClearLogs();
+
+		// Logs should be gone now!
+		await expect(page.getByText('Finished importing document')).not.toBeVisible();
+		await expect(page.getByText('Logs Empty')).toBeVisible();
+	});
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,6 @@
 			"name": "ld-explorer",
 			"version": "0.1.1",
 			"license": "Apache-2.0",
-			"dependencies": {
-				"@testing-library/user-event": "^14.6.1"
-			},
 			"devDependencies": {
 				"@axe-core/playwright": "^4.10.1",
 				"@comunica/bindings-factory": "^3.3.0",
@@ -19,9 +16,10 @@
 				"@playwright/test": "^1.49.1",
 				"@sveltejs/adapter-static": "^3.0.8",
 				"@sveltejs/kit": "^2.16.1",
-				"@sveltejs/vite-plugin-svelte": "^3.1.2",
+				"@sveltejs/vite-plugin-svelte": "^5.0.3",
 				"@testing-library/jest-dom": "^6.6.3",
 				"@testing-library/svelte": "^5.2.6",
+				"@testing-library/user-event": "^14.6.1",
 				"@types/cytoscape": "^3.21.8",
 				"@types/eslint": "^9.6.1",
 				"@ukic/fonts": "^2.6.5",
@@ -44,14 +42,14 @@
 				"prettier-plugin-svelte": "^3.3.3",
 				"rdfa-streaming-parser": "^3.0.1",
 				"shadow-dom-testing-library": "^1.11.3",
-				"svelte": "^4.2.19",
+				"svelte": "^5.19.2",
 				"svelte-check": "^4.1.4",
 				"tailwindcss": "^3.4.17",
 				"tslib": "^2.8.1",
 				"typescript": "^5.7.3",
 				"typescript-eslint": "^8.21.0",
 				"uuid": "^11.0.5",
-				"vite": "^5.4.11",
+				"vite": "^6.0.11",
 				"vitest": "^3.0.3"
 			}
 		},
@@ -120,6 +118,7 @@
 			"version": "7.26.2",
 			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.26.2.tgz",
 			"integrity": "sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@babel/helper-validator-identifier": "^7.25.9",
@@ -144,6 +143,7 @@
 			"version": "7.25.9",
 			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.9.tgz",
 			"integrity": "sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=6.9.0"
@@ -169,6 +169,7 @@
 			"version": "7.26.0",
 			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.26.0.tgz",
 			"integrity": "sha512-FDSOghenHTiToteC/QRlv2q3DhPZ/oOXTBoirfWNx1Cx3TMVcGWQtMMmQcSvb/JjpNeGzx8Pq/b4fKEJuWm1sw==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"regenerator-runtime": "^0.14.0"
@@ -741,26 +742,6 @@
 				"url": "https://opencollective.com/comunica-association"
 			}
 		},
-		"node_modules/@comunica/actor-context-preprocess-set-defaults/node_modules/@rdfjs/types": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/@rdfjs/types/-/types-1.1.2.tgz",
-			"integrity": "sha512-wqpOJK1QCbmsGNtyzYnojPU8gRDPid2JO0Q0kMtb4j65xhCK880cnKAfEOwC+dX85VJcCByQx5zOwyyfCjDJsg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@types/node": "*"
-			}
-		},
-		"node_modules/@comunica/actor-context-preprocess-set-defaults/node_modules/rdf-data-factory": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/rdf-data-factory/-/rdf-data-factory-1.1.3.tgz",
-			"integrity": "sha512-ny6CI7m2bq4lfQQmDYvcb2l1F9KtGwz9chipX4oWu2aAtVoXjb7k3d8J1EsgAsEbMXnBipB/iuRen5H2fwRWWQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@rdfjs/types": "^1.0.0"
-			}
-		},
 		"node_modules/@comunica/actor-context-preprocess-source-to-destination": {
 			"version": "4.0.2",
 			"resolved": "https://registry.npmjs.org/@comunica/actor-context-preprocess-source-to-destination/-/actor-context-preprocess-source-to-destination-4.0.2.tgz",
@@ -1000,26 +981,6 @@
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/comunica-association"
-			}
-		},
-		"node_modules/@comunica/actor-function-factory-expression-extensions/node_modules/@rdfjs/types": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/@rdfjs/types/-/types-1.1.2.tgz",
-			"integrity": "sha512-wqpOJK1QCbmsGNtyzYnojPU8gRDPid2JO0Q0kMtb4j65xhCK880cnKAfEOwC+dX85VJcCByQx5zOwyyfCjDJsg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@types/node": "*"
-			}
-		},
-		"node_modules/@comunica/actor-function-factory-expression-extensions/node_modules/rdf-data-factory": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/rdf-data-factory/-/rdf-data-factory-1.1.3.tgz",
-			"integrity": "sha512-ny6CI7m2bq4lfQQmDYvcb2l1F9KtGwz9chipX4oWu2aAtVoXjb7k3d8J1EsgAsEbMXnBipB/iuRen5H2fwRWWQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@rdfjs/types": "^1.0.0"
 			}
 		},
 		"node_modules/@comunica/actor-function-factory-expression-if": {
@@ -2589,26 +2550,6 @@
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/comunica-association"
-			}
-		},
-		"node_modules/@comunica/actor-optimize-query-operation-rewrite-add/node_modules/@rdfjs/types": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/@rdfjs/types/-/types-1.1.2.tgz",
-			"integrity": "sha512-wqpOJK1QCbmsGNtyzYnojPU8gRDPid2JO0Q0kMtb4j65xhCK880cnKAfEOwC+dX85VJcCByQx5zOwyyfCjDJsg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@types/node": "*"
-			}
-		},
-		"node_modules/@comunica/actor-optimize-query-operation-rewrite-add/node_modules/rdf-data-factory": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/rdf-data-factory/-/rdf-data-factory-1.1.3.tgz",
-			"integrity": "sha512-ny6CI7m2bq4lfQQmDYvcb2l1F9KtGwz9chipX4oWu2aAtVoXjb7k3d8J1EsgAsEbMXnBipB/iuRen5H2fwRWWQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@rdfjs/types": "^1.0.0"
 			}
 		},
 		"node_modules/@comunica/actor-optimize-query-operation-rewrite-copy": {
@@ -6173,16 +6114,6 @@
 				"url": "https://opencollective.com/comunica-association"
 			}
 		},
-		"node_modules/@comunica/actor-rdf-parse-html-rdfa/node_modules/@rdfjs/types": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/@rdfjs/types/-/types-1.1.2.tgz",
-			"integrity": "sha512-wqpOJK1QCbmsGNtyzYnojPU8gRDPid2JO0Q0kMtb4j65xhCK880cnKAfEOwC+dX85VJcCByQx5zOwyyfCjDJsg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@types/node": "*"
-			}
-		},
 		"node_modules/@comunica/actor-rdf-parse-html-rdfa/node_modules/htmlparser2": {
 			"version": "8.0.2",
 			"resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.2.tgz",
@@ -6201,16 +6132,6 @@
 				"domhandler": "^5.0.3",
 				"domutils": "^3.0.1",
 				"entities": "^4.4.0"
-			}
-		},
-		"node_modules/@comunica/actor-rdf-parse-html-rdfa/node_modules/rdf-data-factory": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/rdf-data-factory/-/rdf-data-factory-1.1.3.tgz",
-			"integrity": "sha512-ny6CI7m2bq4lfQQmDYvcb2l1F9KtGwz9chipX4oWu2aAtVoXjb7k3d8J1EsgAsEbMXnBipB/iuRen5H2fwRWWQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@rdfjs/types": "^1.0.0"
 			}
 		},
 		"node_modules/@comunica/actor-rdf-parse-html-rdfa/node_modules/rdfa-streaming-parser": {
@@ -6323,20 +6244,10 @@
 				"url": "https://opencollective.com/comunica-association"
 			}
 		},
-		"node_modules/@comunica/actor-rdf-parse-jsonld/node_modules/@rdfjs/types": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/@rdfjs/types/-/types-1.1.2.tgz",
-			"integrity": "sha512-wqpOJK1QCbmsGNtyzYnojPU8gRDPid2JO0Q0kMtb4j65xhCK880cnKAfEOwC+dX85VJcCByQx5zOwyyfCjDJsg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@types/node": "*"
-			}
-		},
 		"node_modules/@comunica/actor-rdf-parse-jsonld/node_modules/@types/node": {
-			"version": "18.19.71",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.71.tgz",
-			"integrity": "sha512-evXpcgtZm8FY4jqBSN8+DmOTcVkkvTmAayeo4Wf3m1xAruyVGzGuDh/Fb/WWX2yLItUiho42ozyJjB0dw//Tkw==",
+			"version": "18.19.74",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.74.tgz",
+			"integrity": "sha512-HMwEkkifei3L605gFdV+/UwtpxP6JSzM+xFk2Ia6DNFSwSVBRh9qp5Tgf4lNFOMfPVuU0WnkcWpXZpgn5ufO4A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -6380,16 +6291,6 @@
 			},
 			"bin": {
 				"jsonld-context-parse": "bin/jsonld-context-parse.js"
-			}
-		},
-		"node_modules/@comunica/actor-rdf-parse-jsonld/node_modules/rdf-data-factory": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/rdf-data-factory/-/rdf-data-factory-1.1.3.tgz",
-			"integrity": "sha512-ny6CI7m2bq4lfQQmDYvcb2l1F9KtGwz9chipX4oWu2aAtVoXjb7k3d8J1EsgAsEbMXnBipB/iuRen5H2fwRWWQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@rdfjs/types": "^1.0.0"
 			}
 		},
 		"node_modules/@comunica/actor-rdf-parse-jsonld/node_modules/undici-types": {
@@ -6465,16 +6366,6 @@
 				"url": "https://opencollective.com/comunica-association"
 			}
 		},
-		"node_modules/@comunica/actor-rdf-parse-xml-rdfa/node_modules/@rdfjs/types": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/@rdfjs/types/-/types-1.1.2.tgz",
-			"integrity": "sha512-wqpOJK1QCbmsGNtyzYnojPU8gRDPid2JO0Q0kMtb4j65xhCK880cnKAfEOwC+dX85VJcCByQx5zOwyyfCjDJsg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@types/node": "*"
-			}
-		},
 		"node_modules/@comunica/actor-rdf-parse-xml-rdfa/node_modules/htmlparser2": {
 			"version": "8.0.2",
 			"resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.2.tgz",
@@ -6493,16 +6384,6 @@
 				"domhandler": "^5.0.3",
 				"domutils": "^3.0.1",
 				"entities": "^4.4.0"
-			}
-		},
-		"node_modules/@comunica/actor-rdf-parse-xml-rdfa/node_modules/rdf-data-factory": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/rdf-data-factory/-/rdf-data-factory-1.1.3.tgz",
-			"integrity": "sha512-ny6CI7m2bq4lfQQmDYvcb2l1F9KtGwz9chipX4oWu2aAtVoXjb7k3d8J1EsgAsEbMXnBipB/iuRen5H2fwRWWQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@rdfjs/types": "^1.0.0"
 			}
 		},
 		"node_modules/@comunica/actor-rdf-parse-xml-rdfa/node_modules/rdfa-streaming-parser": {
@@ -6894,26 +6775,6 @@
 				"sparqlalgebrajs": "^4.3.7"
 			}
 		},
-		"node_modules/@comunica/bindings-factory/node_modules/@rdfjs/types": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/@rdfjs/types/-/types-1.1.2.tgz",
-			"integrity": "sha512-wqpOJK1QCbmsGNtyzYnojPU8gRDPid2JO0Q0kMtb4j65xhCK880cnKAfEOwC+dX85VJcCByQx5zOwyyfCjDJsg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@types/node": "*"
-			}
-		},
-		"node_modules/@comunica/bindings-factory/node_modules/rdf-data-factory": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/rdf-data-factory/-/rdf-data-factory-1.1.3.tgz",
-			"integrity": "sha512-ny6CI7m2bq4lfQQmDYvcb2l1F9KtGwz9chipX4oWu2aAtVoXjb7k3d8J1EsgAsEbMXnBipB/iuRen5H2fwRWWQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@rdfjs/types": "^1.0.0"
-			}
-		},
 		"node_modules/@comunica/bus-bindings-aggregator-factory": {
 			"version": "4.0.2",
 			"resolved": "https://registry.npmjs.org/@comunica/bus-bindings-aggregator-factory/-/bus-bindings-aggregator-factory-4.0.2.tgz",
@@ -7199,26 +7060,6 @@
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/comunica-association"
-			}
-		},
-		"node_modules/@comunica/bus-hash-quads/node_modules/@rdfjs/types": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/@rdfjs/types/-/types-1.1.2.tgz",
-			"integrity": "sha512-wqpOJK1QCbmsGNtyzYnojPU8gRDPid2JO0Q0kMtb4j65xhCK880cnKAfEOwC+dX85VJcCByQx5zOwyyfCjDJsg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@types/node": "*"
-			}
-		},
-		"node_modules/@comunica/bus-hash-quads/node_modules/rdf-data-factory": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/rdf-data-factory/-/rdf-data-factory-1.1.3.tgz",
-			"integrity": "sha512-ny6CI7m2bq4lfQQmDYvcb2l1F9KtGwz9chipX4oWu2aAtVoXjb7k3d8J1EsgAsEbMXnBipB/iuRen5H2fwRWWQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@rdfjs/types": "^1.0.0"
 			}
 		},
 		"node_modules/@comunica/bus-http": {
@@ -8956,26 +8797,6 @@
 				"url": "https://opencollective.com/comunica-association"
 			}
 		},
-		"node_modules/@comunica/utils-expression-evaluator/node_modules/@rdfjs/types": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/@rdfjs/types/-/types-1.1.2.tgz",
-			"integrity": "sha512-wqpOJK1QCbmsGNtyzYnojPU8gRDPid2JO0Q0kMtb4j65xhCK880cnKAfEOwC+dX85VJcCByQx5zOwyyfCjDJsg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@types/node": "*"
-			}
-		},
-		"node_modules/@comunica/utils-expression-evaluator/node_modules/rdf-data-factory": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/rdf-data-factory/-/rdf-data-factory-1.1.3.tgz",
-			"integrity": "sha512-ny6CI7m2bq4lfQQmDYvcb2l1F9KtGwz9chipX4oWu2aAtVoXjb7k3d8J1EsgAsEbMXnBipB/iuRen5H2fwRWWQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@rdfjs/types": "^1.0.0"
-			}
-		},
 		"node_modules/@comunica/utils-iterator": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/@comunica/utils-iterator/-/utils-iterator-4.0.1.tgz",
@@ -9173,9 +8994,9 @@
 			}
 		},
 		"node_modules/@esbuild/aix-ppc64": {
-			"version": "0.21.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
-			"integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+			"version": "0.24.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.24.2.tgz",
+			"integrity": "sha512-thpVCb/rhxE/BnMLQ7GReQLLN8q9qbHmI55F4489/ByVg2aQaQ6kbcLb6FHkocZzQhxc4gx0sCk0tJkKBFzDhA==",
 			"cpu": [
 				"ppc64"
 			],
@@ -9186,13 +9007,13 @@
 				"aix"
 			],
 			"engines": {
-				"node": ">=12"
+				"node": ">=18"
 			}
 		},
 		"node_modules/@esbuild/android-arm": {
-			"version": "0.21.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
-			"integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+			"version": "0.24.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.24.2.tgz",
+			"integrity": "sha512-tmwl4hJkCfNHwFB3nBa8z1Uy3ypZpxqxfTQOcHX+xRByyYgunVbZ9MzUUfb0RxaHIMnbHagwAxuTL+tnNM+1/Q==",
 			"cpu": [
 				"arm"
 			],
@@ -9203,13 +9024,13 @@
 				"android"
 			],
 			"engines": {
-				"node": ">=12"
+				"node": ">=18"
 			}
 		},
 		"node_modules/@esbuild/android-arm64": {
-			"version": "0.21.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
-			"integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+			"version": "0.24.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.24.2.tgz",
+			"integrity": "sha512-cNLgeqCqV8WxfcTIOeL4OAtSmL8JjcN6m09XIgro1Wi7cF4t/THaWEa7eL5CMoMBdjoHOTh/vwTO/o2TRXIyzg==",
 			"cpu": [
 				"arm64"
 			],
@@ -9220,13 +9041,13 @@
 				"android"
 			],
 			"engines": {
-				"node": ">=12"
+				"node": ">=18"
 			}
 		},
 		"node_modules/@esbuild/android-x64": {
-			"version": "0.21.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
-			"integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+			"version": "0.24.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.24.2.tgz",
+			"integrity": "sha512-B6Q0YQDqMx9D7rvIcsXfmJfvUYLoP722bgfBlO5cGvNVb5V/+Y7nhBE3mHV9OpxBf4eAS2S68KZztiPaWq4XYw==",
 			"cpu": [
 				"x64"
 			],
@@ -9237,13 +9058,13 @@
 				"android"
 			],
 			"engines": {
-				"node": ">=12"
+				"node": ">=18"
 			}
 		},
 		"node_modules/@esbuild/darwin-arm64": {
-			"version": "0.21.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
-			"integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+			"version": "0.24.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.24.2.tgz",
+			"integrity": "sha512-kj3AnYWc+CekmZnS5IPu9D+HWtUI49hbnyqk0FLEJDbzCIQt7hg7ucF1SQAilhtYpIujfaHr6O0UHlzzSPdOeA==",
 			"cpu": [
 				"arm64"
 			],
@@ -9254,13 +9075,13 @@
 				"darwin"
 			],
 			"engines": {
-				"node": ">=12"
+				"node": ">=18"
 			}
 		},
 		"node_modules/@esbuild/darwin-x64": {
-			"version": "0.21.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
-			"integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+			"version": "0.24.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.24.2.tgz",
+			"integrity": "sha512-WeSrmwwHaPkNR5H3yYfowhZcbriGqooyu3zI/3GGpF8AyUdsrrP0X6KumITGA9WOyiJavnGZUwPGvxvwfWPHIA==",
 			"cpu": [
 				"x64"
 			],
@@ -9271,13 +9092,13 @@
 				"darwin"
 			],
 			"engines": {
-				"node": ">=12"
+				"node": ">=18"
 			}
 		},
 		"node_modules/@esbuild/freebsd-arm64": {
-			"version": "0.21.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
-			"integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+			"version": "0.24.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.24.2.tgz",
+			"integrity": "sha512-UN8HXjtJ0k/Mj6a9+5u6+2eZ2ERD7Edt1Q9IZiB5UZAIdPnVKDoG7mdTVGhHJIeEml60JteamR3qhsr1r8gXvg==",
 			"cpu": [
 				"arm64"
 			],
@@ -9288,13 +9109,13 @@
 				"freebsd"
 			],
 			"engines": {
-				"node": ">=12"
+				"node": ">=18"
 			}
 		},
 		"node_modules/@esbuild/freebsd-x64": {
-			"version": "0.21.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
-			"integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+			"version": "0.24.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.24.2.tgz",
+			"integrity": "sha512-TvW7wE/89PYW+IevEJXZ5sF6gJRDY/14hyIGFXdIucxCsbRmLUcjseQu1SyTko+2idmCw94TgyaEZi9HUSOe3Q==",
 			"cpu": [
 				"x64"
 			],
@@ -9305,13 +9126,13 @@
 				"freebsd"
 			],
 			"engines": {
-				"node": ">=12"
+				"node": ">=18"
 			}
 		},
 		"node_modules/@esbuild/linux-arm": {
-			"version": "0.21.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
-			"integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+			"version": "0.24.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.24.2.tgz",
+			"integrity": "sha512-n0WRM/gWIdU29J57hJyUdIsk0WarGd6To0s+Y+LwvlC55wt+GT/OgkwoXCXvIue1i1sSNWblHEig00GBWiJgfA==",
 			"cpu": [
 				"arm"
 			],
@@ -9322,13 +9143,13 @@
 				"linux"
 			],
 			"engines": {
-				"node": ">=12"
+				"node": ">=18"
 			}
 		},
 		"node_modules/@esbuild/linux-arm64": {
-			"version": "0.21.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
-			"integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+			"version": "0.24.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.24.2.tgz",
+			"integrity": "sha512-7HnAD6074BW43YvvUmE/35Id9/NB7BeX5EoNkK9obndmZBUk8xmJJeU7DwmUeN7tkysslb2eSl6CTrYz6oEMQg==",
 			"cpu": [
 				"arm64"
 			],
@@ -9339,13 +9160,13 @@
 				"linux"
 			],
 			"engines": {
-				"node": ">=12"
+				"node": ">=18"
 			}
 		},
 		"node_modules/@esbuild/linux-ia32": {
-			"version": "0.21.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
-			"integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+			"version": "0.24.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.24.2.tgz",
+			"integrity": "sha512-sfv0tGPQhcZOgTKO3oBE9xpHuUqguHvSo4jl+wjnKwFpapx+vUDcawbwPNuBIAYdRAvIDBfZVvXprIj3HA+Ugw==",
 			"cpu": [
 				"ia32"
 			],
@@ -9356,13 +9177,13 @@
 				"linux"
 			],
 			"engines": {
-				"node": ">=12"
+				"node": ">=18"
 			}
 		},
 		"node_modules/@esbuild/linux-loong64": {
-			"version": "0.21.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
-			"integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+			"version": "0.24.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.24.2.tgz",
+			"integrity": "sha512-CN9AZr8kEndGooS35ntToZLTQLHEjtVB5n7dl8ZcTZMonJ7CCfStrYhrzF97eAecqVbVJ7APOEe18RPI4KLhwQ==",
 			"cpu": [
 				"loong64"
 			],
@@ -9373,13 +9194,13 @@
 				"linux"
 			],
 			"engines": {
-				"node": ">=12"
+				"node": ">=18"
 			}
 		},
 		"node_modules/@esbuild/linux-mips64el": {
-			"version": "0.21.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
-			"integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+			"version": "0.24.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.24.2.tgz",
+			"integrity": "sha512-iMkk7qr/wl3exJATwkISxI7kTcmHKE+BlymIAbHO8xanq/TjHaaVThFF6ipWzPHryoFsesNQJPE/3wFJw4+huw==",
 			"cpu": [
 				"mips64el"
 			],
@@ -9390,13 +9211,13 @@
 				"linux"
 			],
 			"engines": {
-				"node": ">=12"
+				"node": ">=18"
 			}
 		},
 		"node_modules/@esbuild/linux-ppc64": {
-			"version": "0.21.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
-			"integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+			"version": "0.24.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.24.2.tgz",
+			"integrity": "sha512-shsVrgCZ57Vr2L8mm39kO5PPIb+843FStGt7sGGoqiiWYconSxwTiuswC1VJZLCjNiMLAMh34jg4VSEQb+iEbw==",
 			"cpu": [
 				"ppc64"
 			],
@@ -9407,13 +9228,13 @@
 				"linux"
 			],
 			"engines": {
-				"node": ">=12"
+				"node": ">=18"
 			}
 		},
 		"node_modules/@esbuild/linux-riscv64": {
-			"version": "0.21.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
-			"integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+			"version": "0.24.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.24.2.tgz",
+			"integrity": "sha512-4eSFWnU9Hhd68fW16GD0TINewo1L6dRrB+oLNNbYyMUAeOD2yCK5KXGK1GH4qD/kT+bTEXjsyTCiJGHPZ3eM9Q==",
 			"cpu": [
 				"riscv64"
 			],
@@ -9424,13 +9245,13 @@
 				"linux"
 			],
 			"engines": {
-				"node": ">=12"
+				"node": ">=18"
 			}
 		},
 		"node_modules/@esbuild/linux-s390x": {
-			"version": "0.21.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
-			"integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+			"version": "0.24.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.24.2.tgz",
+			"integrity": "sha512-S0Bh0A53b0YHL2XEXC20bHLuGMOhFDO6GN4b3YjRLK//Ep3ql3erpNcPlEFed93hsQAjAQDNsvcK+hV90FubSw==",
 			"cpu": [
 				"s390x"
 			],
@@ -9441,13 +9262,13 @@
 				"linux"
 			],
 			"engines": {
-				"node": ">=12"
+				"node": ">=18"
 			}
 		},
 		"node_modules/@esbuild/linux-x64": {
-			"version": "0.21.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
-			"integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+			"version": "0.24.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.24.2.tgz",
+			"integrity": "sha512-8Qi4nQcCTbLnK9WoMjdC9NiTG6/E38RNICU6sUNqK0QFxCYgoARqVqxdFmWkdonVsvGqWhmm7MO0jyTqLqwj0Q==",
 			"cpu": [
 				"x64"
 			],
@@ -9458,13 +9279,30 @@
 				"linux"
 			],
 			"engines": {
-				"node": ">=12"
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/netbsd-arm64": {
+			"version": "0.24.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.24.2.tgz",
+			"integrity": "sha512-wuLK/VztRRpMt9zyHSazyCVdCXlpHkKm34WUyinD2lzK07FAHTq0KQvZZlXikNWkDGoT6x3TD51jKQ7gMVpopw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"netbsd"
+			],
+			"engines": {
+				"node": ">=18"
 			}
 		},
 		"node_modules/@esbuild/netbsd-x64": {
-			"version": "0.21.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
-			"integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+			"version": "0.24.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.24.2.tgz",
+			"integrity": "sha512-VefFaQUc4FMmJuAxmIHgUmfNiLXY438XrL4GDNV1Y1H/RW3qow68xTwjZKfj/+Plp9NANmzbH5R40Meudu8mmw==",
 			"cpu": [
 				"x64"
 			],
@@ -9475,13 +9313,30 @@
 				"netbsd"
 			],
 			"engines": {
-				"node": ">=12"
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/openbsd-arm64": {
+			"version": "0.24.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.24.2.tgz",
+			"integrity": "sha512-YQbi46SBct6iKnszhSvdluqDmxCJA+Pu280Av9WICNwQmMxV7nLRHZfjQzwbPs3jeWnuAhE9Jy0NrnJ12Oz+0A==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openbsd"
+			],
+			"engines": {
+				"node": ">=18"
 			}
 		},
 		"node_modules/@esbuild/openbsd-x64": {
-			"version": "0.21.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
-			"integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+			"version": "0.24.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.24.2.tgz",
+			"integrity": "sha512-+iDS6zpNM6EnJyWv0bMGLWSWeXGN/HTaF/LXHXHwejGsVi+ooqDfMCCTerNFxEkM3wYVcExkeGXNqshc9iMaOA==",
 			"cpu": [
 				"x64"
 			],
@@ -9492,13 +9347,13 @@
 				"openbsd"
 			],
 			"engines": {
-				"node": ">=12"
+				"node": ">=18"
 			}
 		},
 		"node_modules/@esbuild/sunos-x64": {
-			"version": "0.21.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
-			"integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+			"version": "0.24.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.24.2.tgz",
+			"integrity": "sha512-hTdsW27jcktEvpwNHJU4ZwWFGkz2zRJUz8pvddmXPtXDzVKTTINmlmga3ZzwcuMpUvLw7JkLy9QLKyGpD2Yxig==",
 			"cpu": [
 				"x64"
 			],
@@ -9509,13 +9364,13 @@
 				"sunos"
 			],
 			"engines": {
-				"node": ">=12"
+				"node": ">=18"
 			}
 		},
 		"node_modules/@esbuild/win32-arm64": {
-			"version": "0.21.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
-			"integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+			"version": "0.24.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.24.2.tgz",
+			"integrity": "sha512-LihEQ2BBKVFLOC9ZItT9iFprsE9tqjDjnbulhHoFxYQtQfai7qfluVODIYxt1PgdoyQkz23+01rzwNwYfutxUQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -9526,13 +9381,13 @@
 				"win32"
 			],
 			"engines": {
-				"node": ">=12"
+				"node": ">=18"
 			}
 		},
 		"node_modules/@esbuild/win32-ia32": {
-			"version": "0.21.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
-			"integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+			"version": "0.24.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.24.2.tgz",
+			"integrity": "sha512-q+iGUwfs8tncmFC9pcnD5IvRHAzmbwQ3GPS5/ceCyHdjXubwQWI12MKWSNSMYLJMq23/IUCvJMS76PDqXe1fxA==",
 			"cpu": [
 				"ia32"
 			],
@@ -9543,13 +9398,13 @@
 				"win32"
 			],
 			"engines": {
-				"node": ">=12"
+				"node": ">=18"
 			}
 		},
 		"node_modules/@esbuild/win32-x64": {
-			"version": "0.21.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
-			"integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+			"version": "0.24.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.24.2.tgz",
+			"integrity": "sha512-7VTgWzgMGvup6aSqDPLiW5zHaxYJGTO4OokMjIlrCtf+VpEL+cXKtCvg723iguPYI5oaUNdS+/V7OU2gvXVWEg==",
 			"cpu": [
 				"x64"
 			],
@@ -9560,7 +9415,7 @@
 				"win32"
 			],
 			"engines": {
-				"node": ">=12"
+				"node": ">=18"
 			}
 		},
 		"node_modules/@eslint-community/eslint-utils": {
@@ -10278,9 +10133,9 @@
 			}
 		},
 		"node_modules/@stencil/core": {
-			"version": "4.24.0",
-			"resolved": "https://registry.npmjs.org/@stencil/core/-/core-4.24.0.tgz",
-			"integrity": "sha512-v0CYQkfd+id3dXoRSYp7yLsx/kogsfwJBE0YUm/5SBpxy4tcdXNaRrWFVwV//fkdcFmjm3awwS3edxbW+X7pmw==",
+			"version": "4.25.0",
+			"resolved": "https://registry.npmjs.org/@stencil/core/-/core-4.25.0.tgz",
+			"integrity": "sha512-mLyaGCCGaHh6M4n1Hs3CXytD8MLQEt/eBBEoeJvAKE82S3CaqT5n5STXNHnv+qRz3btaSzqEfn2DBTurHYgKeQ==",
 			"dev": true,
 			"license": "MIT",
 			"bin": {
@@ -10333,50 +10188,50 @@
 			}
 		},
 		"node_modules/@sveltejs/vite-plugin-svelte": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-3.1.2.tgz",
-			"integrity": "sha512-Txsm1tJvtiYeLUVRNqxZGKR/mI+CzuIQuc2gn+YCs9rMTowpNZ2Nqt53JdL8KF9bLhAf2ruR/dr9eZCwdTriRA==",
+			"version": "5.0.3",
+			"resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-5.0.3.tgz",
+			"integrity": "sha512-MCFS6CrQDu1yGwspm4qtli0e63vaPCehf6V7pIMP15AsWgMKrqDGCPFF/0kn4SP0ii4aySu4Pa62+fIRGFMjgw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@sveltejs/vite-plugin-svelte-inspector": "^2.1.0",
-				"debug": "^4.3.4",
+				"@sveltejs/vite-plugin-svelte-inspector": "^4.0.1",
+				"debug": "^4.4.0",
 				"deepmerge": "^4.3.1",
 				"kleur": "^4.1.5",
-				"magic-string": "^0.30.10",
-				"svelte-hmr": "^0.16.0",
-				"vitefu": "^0.2.5"
+				"magic-string": "^0.30.15",
+				"vitefu": "^1.0.4"
 			},
 			"engines": {
-				"node": "^18.0.0 || >=20"
+				"node": "^18.0.0 || ^20.0.0 || >=22"
 			},
 			"peerDependencies": {
-				"svelte": "^4.0.0 || ^5.0.0-next.0",
-				"vite": "^5.0.0"
+				"svelte": "^5.0.0",
+				"vite": "^6.0.0"
 			}
 		},
 		"node_modules/@sveltejs/vite-plugin-svelte-inspector": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte-inspector/-/vite-plugin-svelte-inspector-2.1.0.tgz",
-			"integrity": "sha512-9QX28IymvBlSCqsCll5t0kQVxipsfhFFL+L2t3nTWfXnddYwxBuAEtTtlaVQpRz9c37BhJjltSeY4AJSC03SSg==",
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte-inspector/-/vite-plugin-svelte-inspector-4.0.1.tgz",
+			"integrity": "sha512-J/Nmb2Q2y7mck2hyCX4ckVHcR5tu2J+MtBEQqpDrrgELZ2uvraQcK/ioCV61AqkdXFgriksOKIceDcQmqnGhVw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"debug": "^4.3.4"
+				"debug": "^4.3.7"
 			},
 			"engines": {
-				"node": "^18.0.0 || >=20"
+				"node": "^18.0.0 || ^20.0.0 || >=22"
 			},
 			"peerDependencies": {
-				"@sveltejs/vite-plugin-svelte": "^3.0.0",
-				"svelte": "^4.0.0 || ^5.0.0-next.0",
-				"vite": "^5.0.0"
+				"@sveltejs/vite-plugin-svelte": "^5.0.0",
+				"svelte": "^5.0.0",
+				"vite": "^6.0.0"
 			}
 		},
 		"node_modules/@testing-library/dom": {
 			"version": "10.4.0",
 			"resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.0.tgz",
 			"integrity": "sha512-pemlzrSESWbdAloYml3bAJMEfNh1Z7EduzqPKprCH5S341frlpYnUEW0H72dLxa6IsYr+mPno20GiSm+h9dEdQ==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@babel/code-frame": "^7.10.4",
@@ -10464,6 +10319,7 @@
 			"version": "14.6.1",
 			"resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
 			"integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=12",
@@ -10477,6 +10333,7 @@
 			"version": "5.0.4",
 			"resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
 			"integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@types/cookie": {
@@ -10564,9 +10421,9 @@
 			}
 		},
 		"node_modules/@types/node": {
-			"version": "22.10.7",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.7.tgz",
-			"integrity": "sha512-V09KvXxFiutGp6B7XkpaDXlNadZxrzajcY50EuoLIpQ6WWYCSvf19lVIazzfIzQvhUN2HjX12spLojTnhuKlGg==",
+			"version": "22.10.9",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.9.tgz",
+			"integrity": "sha512-Ir6hwgsKyNESl/gLOcEz3krR4CBGgliDqBQ2ma4wIhEx0w+xnoeTq3tdrNw15kU3SxogDjOgv9sqdtLW8mIHaw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -11055,6 +10912,16 @@
 				"acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
 			}
 		},
+		"node_modules/acorn-typescript": {
+			"version": "1.4.13",
+			"resolved": "https://registry.npmjs.org/acorn-typescript/-/acorn-typescript-1.4.13.tgz",
+			"integrity": "sha512-xsc9Xv0xlVfwp2o7sQ+GCQ1PgbkdcpWdTzrwXxO3xDMTAywVS3oXVOcOHuRjAPkS4P9b+yc/qNF15460v+jp4Q==",
+			"dev": true,
+			"license": "MIT",
+			"peerDependencies": {
+				"acorn": ">=8.9.0"
+			}
+		},
 		"node_modules/agent-base": {
 			"version": "7.1.3",
 			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.3.tgz",
@@ -11086,6 +10953,7 @@
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
 			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
@@ -11095,6 +10963,7 @@
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
 			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"color-convert": "^2.0.1"
@@ -11158,6 +11027,7 @@
 			"version": "5.3.0",
 			"resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
 			"integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"dequal": "^2.0.3"
@@ -11481,6 +11351,7 @@
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
 			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"ansi-styles": "^4.1.0",
@@ -11597,20 +11468,6 @@
 				"node": ">=6"
 			}
 		},
-		"node_modules/code-red": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/code-red/-/code-red-1.0.4.tgz",
-			"integrity": "sha512-7qJWqItLA8/VPVlKJlFXU+NBlo/qyfs39aJcuMT/2ere32ZqvF5OSxgdM5xOfJJ7O429gg2HM47y8v9P+9wrNw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jridgewell/sourcemap-codec": "^1.4.15",
-				"@types/estree": "^1.0.1",
-				"acorn": "^8.10.0",
-				"estree-walker": "^3.0.3",
-				"periscopic": "^3.1.0"
-			}
-		},
 		"node_modules/color": {
 			"version": "3.2.1",
 			"resolved": "https://registry.npmjs.org/color/-/color-3.2.1.tgz",
@@ -11626,6 +11483,7 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
 			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"color-name": "~1.1.4"
@@ -11638,6 +11496,7 @@
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
 			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/color-string": {
@@ -11728,20 +11587,10 @@
 				"componentsjs-compile-config": "bin/compile-config.js"
 			}
 		},
-		"node_modules/componentsjs/node_modules/@rdfjs/types": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/@rdfjs/types/-/types-1.1.2.tgz",
-			"integrity": "sha512-wqpOJK1QCbmsGNtyzYnojPU8gRDPid2JO0Q0kMtb4j65xhCK880cnKAfEOwC+dX85VJcCByQx5zOwyyfCjDJsg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@types/node": "*"
-			}
-		},
 		"node_modules/componentsjs/node_modules/@types/node": {
-			"version": "18.19.71",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.71.tgz",
-			"integrity": "sha512-evXpcgtZm8FY4jqBSN8+DmOTcVkkvTmAayeo4Wf3m1xAruyVGzGuDh/Fb/WWX2yLItUiho42ozyJjB0dw//Tkw==",
+			"version": "18.19.74",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.74.tgz",
+			"integrity": "sha512-HMwEkkifei3L605gFdV+/UwtpxP6JSzM+xFk2Ia6DNFSwSVBRh9qp5Tgf4lNFOMfPVuU0WnkcWpXZpgn5ufO4A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -11762,16 +11611,6 @@
 			},
 			"bin": {
 				"jsonld-context-parse": "bin/jsonld-context-parse.js"
-			}
-		},
-		"node_modules/componentsjs/node_modules/rdf-data-factory": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/rdf-data-factory/-/rdf-data-factory-1.1.3.tgz",
-			"integrity": "sha512-ny6CI7m2bq4lfQQmDYvcb2l1F9KtGwz9chipX4oWu2aAtVoXjb7k3d8J1EsgAsEbMXnBipB/iuRen5H2fwRWWQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@rdfjs/types": "^1.0.0"
 			}
 		},
 		"node_modules/componentsjs/node_modules/undici-types": {
@@ -11821,20 +11660,6 @@
 			},
 			"engines": {
 				"node": ">= 8"
-			}
-		},
-		"node_modules/css-tree": {
-			"version": "2.3.1",
-			"resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.3.1.tgz",
-			"integrity": "sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"mdn-data": "2.0.30",
-				"source-map-js": "^1.0.1"
-			},
-			"engines": {
-				"node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
 			}
 		},
 		"node_modules/css.escape": {
@@ -11961,9 +11786,25 @@
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
 			"integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=6"
+			}
+		},
+		"node_modules/detect-libc": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
+			"integrity": "sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"peer": true,
+			"bin": {
+				"detect-libc": "bin/detect-libc.js"
+			},
+			"engines": {
+				"node": ">=0.10"
 			}
 		},
 		"node_modules/devalue": {
@@ -11991,6 +11832,7 @@
 			"version": "0.5.16",
 			"resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
 			"integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/dom-serializer": {
@@ -12060,9 +11902,9 @@
 			"license": "MIT"
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.5.83",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.83.tgz",
-			"integrity": "sha512-LcUDPqSt+V0QmI47XLzZrz5OqILSMGsPFkDYus22rIbgorSvBYEFqq854ltTmUdHkY92FSdAAvsh4jWEULMdfQ==",
+			"version": "1.5.86",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.86.tgz",
+			"integrity": "sha512-/D7GAAaCRBQFBBcop6SfAAGH37djtpWkOuYhyAajw0l5vsfeSsUQYxaFPwr1c/mC/flARCDdKFo5gpFqNI+18w==",
 			"dev": true,
 			"license": "ISC"
 		},
@@ -12101,9 +11943,9 @@
 			"license": "MIT"
 		},
 		"node_modules/esbuild": {
-			"version": "0.21.5",
-			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
-			"integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+			"version": "0.24.2",
+			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.24.2.tgz",
+			"integrity": "sha512-+9egpBW8I3CD5XPe0n6BfT5fxLzxrlDzqydF3aviG+9ni1lDC/OvMHcxqEFV0+LANZG5R1bFMWfUrjVsdwxJvA==",
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
@@ -12111,32 +11953,34 @@
 				"esbuild": "bin/esbuild"
 			},
 			"engines": {
-				"node": ">=12"
+				"node": ">=18"
 			},
 			"optionalDependencies": {
-				"@esbuild/aix-ppc64": "0.21.5",
-				"@esbuild/android-arm": "0.21.5",
-				"@esbuild/android-arm64": "0.21.5",
-				"@esbuild/android-x64": "0.21.5",
-				"@esbuild/darwin-arm64": "0.21.5",
-				"@esbuild/darwin-x64": "0.21.5",
-				"@esbuild/freebsd-arm64": "0.21.5",
-				"@esbuild/freebsd-x64": "0.21.5",
-				"@esbuild/linux-arm": "0.21.5",
-				"@esbuild/linux-arm64": "0.21.5",
-				"@esbuild/linux-ia32": "0.21.5",
-				"@esbuild/linux-loong64": "0.21.5",
-				"@esbuild/linux-mips64el": "0.21.5",
-				"@esbuild/linux-ppc64": "0.21.5",
-				"@esbuild/linux-riscv64": "0.21.5",
-				"@esbuild/linux-s390x": "0.21.5",
-				"@esbuild/linux-x64": "0.21.5",
-				"@esbuild/netbsd-x64": "0.21.5",
-				"@esbuild/openbsd-x64": "0.21.5",
-				"@esbuild/sunos-x64": "0.21.5",
-				"@esbuild/win32-arm64": "0.21.5",
-				"@esbuild/win32-ia32": "0.21.5",
-				"@esbuild/win32-x64": "0.21.5"
+				"@esbuild/aix-ppc64": "0.24.2",
+				"@esbuild/android-arm": "0.24.2",
+				"@esbuild/android-arm64": "0.24.2",
+				"@esbuild/android-x64": "0.24.2",
+				"@esbuild/darwin-arm64": "0.24.2",
+				"@esbuild/darwin-x64": "0.24.2",
+				"@esbuild/freebsd-arm64": "0.24.2",
+				"@esbuild/freebsd-x64": "0.24.2",
+				"@esbuild/linux-arm": "0.24.2",
+				"@esbuild/linux-arm64": "0.24.2",
+				"@esbuild/linux-ia32": "0.24.2",
+				"@esbuild/linux-loong64": "0.24.2",
+				"@esbuild/linux-mips64el": "0.24.2",
+				"@esbuild/linux-ppc64": "0.24.2",
+				"@esbuild/linux-riscv64": "0.24.2",
+				"@esbuild/linux-s390x": "0.24.2",
+				"@esbuild/linux-x64": "0.24.2",
+				"@esbuild/netbsd-arm64": "0.24.2",
+				"@esbuild/netbsd-x64": "0.24.2",
+				"@esbuild/openbsd-arm64": "0.24.2",
+				"@esbuild/openbsd-x64": "0.24.2",
+				"@esbuild/sunos-x64": "0.24.2",
+				"@esbuild/win32-arm64": "0.24.2",
+				"@esbuild/win32-ia32": "0.24.2",
+				"@esbuild/win32-x64": "0.24.2"
 			}
 		},
 		"node_modules/escalade": {
@@ -12383,6 +12227,16 @@
 			},
 			"engines": {
 				"node": ">=0.10"
+			}
+		},
+		"node_modules/esrap": {
+			"version": "1.4.3",
+			"resolved": "https://registry.npmjs.org/esrap/-/esrap-1.4.3.tgz",
+			"integrity": "sha512-Xddc1RsoFJ4z9nR7W7BFaEPIp4UXoeQ0+077UdWLxbafMQFyU79sQJMk7kxNgRwQ9/aVgaKacCHC2pUACGwmYw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jridgewell/sourcemap-codec": "^1.4.15"
 			}
 		},
 		"node_modules/esrecurse": {
@@ -12844,20 +12698,10 @@
 				"url": "https://github.com/sponsors/rubensworks/"
 			}
 		},
-		"node_modules/graphql-to-sparql/node_modules/@rdfjs/types": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/@rdfjs/types/-/types-1.1.2.tgz",
-			"integrity": "sha512-wqpOJK1QCbmsGNtyzYnojPU8gRDPid2JO0Q0kMtb4j65xhCK880cnKAfEOwC+dX85VJcCByQx5zOwyyfCjDJsg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@types/node": "*"
-			}
-		},
 		"node_modules/graphql-to-sparql/node_modules/@types/node": {
-			"version": "18.19.71",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.71.tgz",
-			"integrity": "sha512-evXpcgtZm8FY4jqBSN8+DmOTcVkkvTmAayeo4Wf3m1xAruyVGzGuDh/Fb/WWX2yLItUiho42ozyJjB0dw//Tkw==",
+			"version": "18.19.74",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.74.tgz",
+			"integrity": "sha512-HMwEkkifei3L605gFdV+/UwtpxP6JSzM+xFk2Ia6DNFSwSVBRh9qp5Tgf4lNFOMfPVuU0WnkcWpXZpgn5ufO4A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -12880,16 +12724,6 @@
 				"jsonld-context-parse": "bin/jsonld-context-parse.js"
 			}
 		},
-		"node_modules/graphql-to-sparql/node_modules/rdf-data-factory": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/rdf-data-factory/-/rdf-data-factory-1.1.3.tgz",
-			"integrity": "sha512-ny6CI7m2bq4lfQQmDYvcb2l1F9KtGwz9chipX4oWu2aAtVoXjb7k3d8J1EsgAsEbMXnBipB/iuRen5H2fwRWWQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@rdfjs/types": "^1.0.0"
-			}
-		},
 		"node_modules/graphql-to-sparql/node_modules/undici-types": {
 			"version": "5.26.5",
 			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
@@ -12901,6 +12735,7 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
 			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
@@ -13301,19 +13136,22 @@
 			}
 		},
 		"node_modules/jiti": {
-			"version": "1.21.7",
-			"resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
-			"integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
+			"version": "2.4.2",
+			"resolved": "https://registry.npmjs.org/jiti/-/jiti-2.4.2.tgz",
+			"integrity": "sha512-rg9zJN+G4n2nfJl5MW3BMygZX56zKPNVEYYqq7adpmMh4Jn2QNEwhvQlFy6jPVdcod7txZtKHWnyZiA3a0zP7A==",
 			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"bin": {
-				"jiti": "bin/jiti.js"
+				"jiti": "lib/jiti-cli.mjs"
 			}
 		},
 		"node_modules/js-tokens": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
 			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/js-yaml": {
@@ -13409,9 +13247,9 @@
 			}
 		},
 		"node_modules/jsonld-context-parser/node_modules/@types/node": {
-			"version": "18.19.71",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.71.tgz",
-			"integrity": "sha512-evXpcgtZm8FY4jqBSN8+DmOTcVkkvTmAayeo4Wf3m1xAruyVGzGuDh/Fb/WWX2yLItUiho42ozyJjB0dw//Tkw==",
+			"version": "18.19.74",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.74.tgz",
+			"integrity": "sha512-HMwEkkifei3L605gFdV+/UwtpxP6JSzM+xFk2Ia6DNFSwSVBRh9qp5Tgf4lNFOMfPVuU0WnkcWpXZpgn5ufO4A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -13448,9 +13286,9 @@
 			}
 		},
 		"node_modules/jsonld-streaming-parser/node_modules/@types/node": {
-			"version": "18.19.71",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.71.tgz",
-			"integrity": "sha512-evXpcgtZm8FY4jqBSN8+DmOTcVkkvTmAayeo4Wf3m1xAruyVGzGuDh/Fb/WWX2yLItUiho42ozyJjB0dw//Tkw==",
+			"version": "18.19.74",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.74.tgz",
+			"integrity": "sha512-HMwEkkifei3L605gFdV+/UwtpxP6JSzM+xFk2Ia6DNFSwSVBRh9qp5Tgf4lNFOMfPVuU0WnkcWpXZpgn5ufO4A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -13471,6 +13309,20 @@
 			},
 			"bin": {
 				"jsonld-context-parse": "bin/jsonld-context-parse.js"
+			}
+		},
+		"node_modules/jsonld-streaming-parser/node_modules/rdf-data-factory": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/rdf-data-factory/-/rdf-data-factory-2.0.2.tgz",
+			"integrity": "sha512-WzPoYHwQYWvIP9k+7IBLY1b4nIDitzAK4mA37WumAF/Cjvu/KOtYJH9IPZnUTWNSd5K2+pq4vrcE9WZC4sRHhg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@rdfjs/types": "^2.0.0"
+			},
+			"funding": {
+				"type": "individual",
+				"url": "https://github.com/sponsors/rubensworks/"
 			}
 		},
 		"node_modules/jsonld-streaming-parser/node_modules/undici-types": {
@@ -13499,9 +13351,9 @@
 			}
 		},
 		"node_modules/jsonld-streaming-serializer/node_modules/@types/node": {
-			"version": "18.19.71",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.71.tgz",
-			"integrity": "sha512-evXpcgtZm8FY4jqBSN8+DmOTcVkkvTmAayeo4Wf3m1xAruyVGzGuDh/Fb/WWX2yLItUiho42ozyJjB0dw//Tkw==",
+			"version": "18.19.74",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.74.tgz",
+			"integrity": "sha512-HMwEkkifei3L605gFdV+/UwtpxP6JSzM+xFk2Ia6DNFSwSVBRh9qp5Tgf4lNFOMfPVuU0WnkcWpXZpgn5ufO4A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -13577,6 +13429,257 @@
 			},
 			"engines": {
 				"node": ">= 0.8.0"
+			}
+		},
+		"node_modules/lightningcss": {
+			"version": "1.29.1",
+			"resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.29.1.tgz",
+			"integrity": "sha512-FmGoeD4S05ewj+AkhTY+D+myDvXI6eL27FjHIjoyUkO/uw7WZD1fBVs0QxeYWa7E17CUHJaYX/RUGISCtcrG4Q==",
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"detect-libc": "^1.0.3"
+			},
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			},
+			"optionalDependencies": {
+				"lightningcss-darwin-arm64": "1.29.1",
+				"lightningcss-darwin-x64": "1.29.1",
+				"lightningcss-freebsd-x64": "1.29.1",
+				"lightningcss-linux-arm-gnueabihf": "1.29.1",
+				"lightningcss-linux-arm64-gnu": "1.29.1",
+				"lightningcss-linux-arm64-musl": "1.29.1",
+				"lightningcss-linux-x64-gnu": "1.29.1",
+				"lightningcss-linux-x64-musl": "1.29.1",
+				"lightningcss-win32-arm64-msvc": "1.29.1",
+				"lightningcss-win32-x64-msvc": "1.29.1"
+			}
+		},
+		"node_modules/lightningcss-darwin-arm64": {
+			"version": "1.29.1",
+			"resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.29.1.tgz",
+			"integrity": "sha512-HtR5XJ5A0lvCqYAoSv2QdZZyoHNttBpa5EP9aNuzBQeKGfbyH5+UipLWvVzpP4Uml5ej4BYs5I9Lco9u1fECqw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-darwin-x64": {
+			"version": "1.29.1",
+			"resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.29.1.tgz",
+			"integrity": "sha512-k33G9IzKUpHy/J/3+9MCO4e+PzaFblsgBjSGlpAaFikeBFm8B/CkO3cKU9oI4g+fjS2KlkLM/Bza9K/aw8wsNA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-freebsd-x64": {
+			"version": "1.29.1",
+			"resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.29.1.tgz",
+			"integrity": "sha512-0SUW22fv/8kln2LnIdOCmSuXnxgxVC276W5KLTwoehiO0hxkacBxjHOL5EtHD8BAXg2BvuhsJPmVMasvby3LiQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-linux-arm-gnueabihf": {
+			"version": "1.29.1",
+			"resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.29.1.tgz",
+			"integrity": "sha512-sD32pFvlR0kDlqsOZmYqH/68SqUMPNj+0pucGxToXZi4XZgZmqeX/NkxNKCPsswAXU3UeYgDSpGhu05eAufjDg==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-linux-arm64-gnu": {
+			"version": "1.29.1",
+			"resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.29.1.tgz",
+			"integrity": "sha512-0+vClRIZ6mmJl/dxGuRsE197o1HDEeeRk6nzycSy2GofC2JsY4ifCRnvUWf/CUBQmlrvMzt6SMQNMSEu22csWQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-linux-arm64-musl": {
+			"version": "1.29.1",
+			"resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.29.1.tgz",
+			"integrity": "sha512-UKMFrG4rL/uHNgelBsDwJcBqVpzNJbzsKkbI3Ja5fg00sgQnHw/VrzUTEc4jhZ+AN2BvQYz/tkHu4vt1kLuJyw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-linux-x64-gnu": {
+			"version": "1.29.1",
+			"resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.29.1.tgz",
+			"integrity": "sha512-u1S+xdODy/eEtjADqirA774y3jLcm8RPtYztwReEXoZKdzgsHYPl0s5V52Tst+GKzqjebkULT86XMSxejzfISw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-linux-x64-musl": {
+			"version": "1.29.1",
+			"resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.29.1.tgz",
+			"integrity": "sha512-L0Tx0DtaNUTzXv0lbGCLB/c/qEADanHbu4QdcNOXLIe1i8i22rZRpbT3gpWYsCh9aSL9zFujY/WmEXIatWvXbw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-win32-arm64-msvc": {
+			"version": "1.29.1",
+			"resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.29.1.tgz",
+			"integrity": "sha512-QoOVnkIEFfbW4xPi+dpdft/zAKmgLgsRHfJalEPYuJDOWf7cLQzYg0DEh8/sn737FaeMJxHZRc1oBreiwZCjog==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-win32-x64-msvc": {
+			"version": "1.29.1",
+			"resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.29.1.tgz",
+			"integrity": "sha512-NygcbThNBe4JElP+olyTI/doBNGJvLs3bFCRPdvuCcxZCcCZ71B858IHpdm7L1btZex0FvCmM17FK98Y9MRy1Q==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
 			}
 		},
 		"node_modules/lilconfig": {
@@ -13669,6 +13772,7 @@
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
 			"integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+			"dev": true,
 			"license": "MIT",
 			"bin": {
 				"lz-string": "bin/bin.js"
@@ -13712,13 +13816,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/mdn-data": {
-			"version": "2.0.30",
-			"resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.30.tgz",
-			"integrity": "sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==",
-			"dev": true,
-			"license": "CC0-1.0"
-		},
 		"node_modules/merge2": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -13743,16 +13840,6 @@
 				"relative-to-absolute-iri": "^1.0.2"
 			}
 		},
-		"node_modules/microdata-rdf-streaming-parser/node_modules/@rdfjs/types": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/@rdfjs/types/-/types-1.1.2.tgz",
-			"integrity": "sha512-wqpOJK1QCbmsGNtyzYnojPU8gRDPid2JO0Q0kMtb4j65xhCK880cnKAfEOwC+dX85VJcCByQx5zOwyyfCjDJsg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@types/node": "*"
-			}
-		},
 		"node_modules/microdata-rdf-streaming-parser/node_modules/htmlparser2": {
 			"version": "8.0.2",
 			"resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.2.tgz",
@@ -13771,16 +13858,6 @@
 				"domhandler": "^5.0.3",
 				"domutils": "^3.0.1",
 				"entities": "^4.4.0"
-			}
-		},
-		"node_modules/microdata-rdf-streaming-parser/node_modules/rdf-data-factory": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/rdf-data-factory/-/rdf-data-factory-1.1.3.tgz",
-			"integrity": "sha512-ny6CI7m2bq4lfQQmDYvcb2l1F9KtGwz9chipX4oWu2aAtVoXjb7k3d8J1EsgAsEbMXnBipB/iuRen5H2fwRWWQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@rdfjs/types": "^1.0.0"
 			}
 		},
 		"node_modules/micromatch": {
@@ -14236,22 +14313,11 @@
 				"node": ">= 14.16"
 			}
 		},
-		"node_modules/periscopic": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/periscopic/-/periscopic-3.1.0.tgz",
-			"integrity": "sha512-vKiQ8RRtkl9P+r/+oefh25C3fhybptkHKCZSPlcXiJux2tJF55GnEj3BVn4A5gKfq9NWWXXrxkHBwVPUfH0opw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@types/estree": "^1.0.0",
-				"estree-walker": "^3.0.0",
-				"is-reference": "^3.0.0"
-			}
-		},
 		"node_modules/picocolors": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
 			"integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+			"dev": true,
 			"license": "ISC"
 		},
 		"node_modules/picomatch": {
@@ -14418,6 +14484,16 @@
 				}
 			}
 		},
+		"node_modules/postcss-load-config/node_modules/yaml": {
+			"version": "1.10.2",
+			"resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
+			"integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": ">= 6"
+			}
+		},
 		"node_modules/postcss-nested": {
 			"version": "6.2.0",
 			"resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-6.2.0.tgz",
@@ -14563,6 +14639,7 @@
 			"version": "27.5.1",
 			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
 			"integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"ansi-regex": "^5.0.1",
@@ -14577,6 +14654,7 @@
 			"version": "5.2.0",
 			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
 			"integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=10"
@@ -14634,17 +14712,23 @@
 			"license": "MIT"
 		},
 		"node_modules/rdf-data-factory": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/rdf-data-factory/-/rdf-data-factory-2.0.2.tgz",
-			"integrity": "sha512-WzPoYHwQYWvIP9k+7IBLY1b4nIDitzAK4mA37WumAF/Cjvu/KOtYJH9IPZnUTWNSd5K2+pq4vrcE9WZC4sRHhg==",
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/rdf-data-factory/-/rdf-data-factory-1.1.3.tgz",
+			"integrity": "sha512-ny6CI7m2bq4lfQQmDYvcb2l1F9KtGwz9chipX4oWu2aAtVoXjb7k3d8J1EsgAsEbMXnBipB/iuRen5H2fwRWWQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@rdfjs/types": "^2.0.0"
-			},
-			"funding": {
-				"type": "individual",
-				"url": "https://github.com/sponsors/rubensworks/"
+				"@rdfjs/types": "^1.0.0"
+			}
+		},
+		"node_modules/rdf-data-factory/node_modules/@rdfjs/types": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@rdfjs/types/-/types-1.1.2.tgz",
+			"integrity": "sha512-wqpOJK1QCbmsGNtyzYnojPU8gRDPid2JO0Q0kMtb4j65xhCK880cnKAfEOwC+dX85VJcCByQx5zOwyyfCjDJsg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/node": "*"
 			}
 		},
 		"node_modules/rdf-isomorphic": {
@@ -14671,26 +14755,6 @@
 				"rdf-data-factory": "^1.1.0"
 			}
 		},
-		"node_modules/rdf-literal/node_modules/@rdfjs/types": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/@rdfjs/types/-/types-1.1.2.tgz",
-			"integrity": "sha512-wqpOJK1QCbmsGNtyzYnojPU8gRDPid2JO0Q0kMtb4j65xhCK880cnKAfEOwC+dX85VJcCByQx5zOwyyfCjDJsg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@types/node": "*"
-			}
-		},
-		"node_modules/rdf-literal/node_modules/rdf-data-factory": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/rdf-data-factory/-/rdf-data-factory-1.1.3.tgz",
-			"integrity": "sha512-ny6CI7m2bq4lfQQmDYvcb2l1F9KtGwz9chipX4oWu2aAtVoXjb7k3d8J1EsgAsEbMXnBipB/iuRen5H2fwRWWQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@rdfjs/types": "^1.0.0"
-			}
-		},
 		"node_modules/rdf-object": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/rdf-object/-/rdf-object-2.0.0.tgz",
@@ -14709,20 +14773,10 @@
 				"url": "https://github.com/sponsors/rubensworks/"
 			}
 		},
-		"node_modules/rdf-object/node_modules/@rdfjs/types": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/@rdfjs/types/-/types-1.1.2.tgz",
-			"integrity": "sha512-wqpOJK1QCbmsGNtyzYnojPU8gRDPid2JO0Q0kMtb4j65xhCK880cnKAfEOwC+dX85VJcCByQx5zOwyyfCjDJsg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@types/node": "*"
-			}
-		},
 		"node_modules/rdf-object/node_modules/@types/node": {
-			"version": "18.19.71",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.71.tgz",
-			"integrity": "sha512-evXpcgtZm8FY4jqBSN8+DmOTcVkkvTmAayeo4Wf3m1xAruyVGzGuDh/Fb/WWX2yLItUiho42ozyJjB0dw//Tkw==",
+			"version": "18.19.74",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.74.tgz",
+			"integrity": "sha512-HMwEkkifei3L605gFdV+/UwtpxP6JSzM+xFk2Ia6DNFSwSVBRh9qp5Tgf4lNFOMfPVuU0WnkcWpXZpgn5ufO4A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -14743,16 +14797,6 @@
 			},
 			"bin": {
 				"jsonld-context-parse": "bin/jsonld-context-parse.js"
-			}
-		},
-		"node_modules/rdf-object/node_modules/rdf-data-factory": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/rdf-data-factory/-/rdf-data-factory-1.1.3.tgz",
-			"integrity": "sha512-ny6CI7m2bq4lfQQmDYvcb2l1F9KtGwz9chipX4oWu2aAtVoXjb7k3d8J1EsgAsEbMXnBipB/iuRen5H2fwRWWQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@rdfjs/types": "^1.0.0"
 			}
 		},
 		"node_modules/rdf-object/node_modules/undici-types": {
@@ -15118,16 +15162,6 @@
 				"sparqlalgebrajs": "^4.2.0"
 			}
 		},
-		"node_modules/rdf-parse/node_modules/@rdfjs/types": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/@rdfjs/types/-/types-1.1.2.tgz",
-			"integrity": "sha512-wqpOJK1QCbmsGNtyzYnojPU8gRDPid2JO0Q0kMtb4j65xhCK880cnKAfEOwC+dX85VJcCByQx5zOwyyfCjDJsg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@types/node": "*"
-			}
-		},
 		"node_modules/rdf-parse/node_modules/@types/readable-stream": {
 			"version": "2.3.15",
 			"resolved": "https://registry.npmjs.org/@types/readable-stream/-/readable-stream-2.3.15.tgz",
@@ -15166,16 +15200,6 @@
 				"jsonld-context-parser": "^2.4.0",
 				"rdf-data-factory": "^1.1.0",
 				"readable-stream": "^4.0.0"
-			}
-		},
-		"node_modules/rdf-parse/node_modules/rdf-data-factory": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/rdf-data-factory/-/rdf-data-factory-1.1.3.tgz",
-			"integrity": "sha512-ny6CI7m2bq4lfQQmDYvcb2l1F9KtGwz9chipX4oWu2aAtVoXjb7k3d8J1EsgAsEbMXnBipB/iuRen5H2fwRWWQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@rdfjs/types": "^1.0.0"
 			}
 		},
 		"node_modules/rdf-parse/node_modules/rdfa-streaming-parser": {
@@ -15224,26 +15248,6 @@
 				"rdf-string": "^1.5.0"
 			}
 		},
-		"node_modules/rdf-quad/node_modules/@rdfjs/types": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/@rdfjs/types/-/types-1.1.2.tgz",
-			"integrity": "sha512-wqpOJK1QCbmsGNtyzYnojPU8gRDPid2JO0Q0kMtb4j65xhCK880cnKAfEOwC+dX85VJcCByQx5zOwyyfCjDJsg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@types/node": "*"
-			}
-		},
-		"node_modules/rdf-quad/node_modules/rdf-data-factory": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/rdf-data-factory/-/rdf-data-factory-1.1.3.tgz",
-			"integrity": "sha512-ny6CI7m2bq4lfQQmDYvcb2l1F9KtGwz9chipX4oWu2aAtVoXjb7k3d8J1EsgAsEbMXnBipB/iuRen5H2fwRWWQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@rdfjs/types": "^1.0.0"
-			}
-		},
 		"node_modules/rdf-store-stream": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/rdf-store-stream/-/rdf-store-stream-2.0.1.tgz",
@@ -15267,26 +15271,6 @@
 				"rdf-data-factory": "^1.1.1",
 				"rdf-string": "^1.6.2",
 				"rdf-terms": "^1.9.1"
-			}
-		},
-		"node_modules/rdf-stores/node_modules/@rdfjs/types": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/@rdfjs/types/-/types-1.1.2.tgz",
-			"integrity": "sha512-wqpOJK1QCbmsGNtyzYnojPU8gRDPid2JO0Q0kMtb4j65xhCK880cnKAfEOwC+dX85VJcCByQx5zOwyyfCjDJsg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@types/node": "*"
-			}
-		},
-		"node_modules/rdf-stores/node_modules/rdf-data-factory": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/rdf-data-factory/-/rdf-data-factory-1.1.3.tgz",
-			"integrity": "sha512-ny6CI7m2bq4lfQQmDYvcb2l1F9KtGwz9chipX4oWu2aAtVoXjb7k3d8J1EsgAsEbMXnBipB/iuRen5H2fwRWWQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@rdfjs/types": "^1.0.0"
 			}
 		},
 		"node_modules/rdf-streaming-store": {
@@ -15327,46 +15311,6 @@
 				"rdf-data-factory": "^1.1.0"
 			}
 		},
-		"node_modules/rdf-string-ttl/node_modules/@rdfjs/types": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/@rdfjs/types/-/types-1.1.2.tgz",
-			"integrity": "sha512-wqpOJK1QCbmsGNtyzYnojPU8gRDPid2JO0Q0kMtb4j65xhCK880cnKAfEOwC+dX85VJcCByQx5zOwyyfCjDJsg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@types/node": "*"
-			}
-		},
-		"node_modules/rdf-string-ttl/node_modules/rdf-data-factory": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/rdf-data-factory/-/rdf-data-factory-1.1.3.tgz",
-			"integrity": "sha512-ny6CI7m2bq4lfQQmDYvcb2l1F9KtGwz9chipX4oWu2aAtVoXjb7k3d8J1EsgAsEbMXnBipB/iuRen5H2fwRWWQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@rdfjs/types": "^1.0.0"
-			}
-		},
-		"node_modules/rdf-string/node_modules/@rdfjs/types": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/@rdfjs/types/-/types-1.1.2.tgz",
-			"integrity": "sha512-wqpOJK1QCbmsGNtyzYnojPU8gRDPid2JO0Q0kMtb4j65xhCK880cnKAfEOwC+dX85VJcCByQx5zOwyyfCjDJsg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@types/node": "*"
-			}
-		},
-		"node_modules/rdf-string/node_modules/rdf-data-factory": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/rdf-data-factory/-/rdf-data-factory-1.1.3.tgz",
-			"integrity": "sha512-ny6CI7m2bq4lfQQmDYvcb2l1F9KtGwz9chipX4oWu2aAtVoXjb7k3d8J1EsgAsEbMXnBipB/iuRen5H2fwRWWQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@rdfjs/types": "^1.0.0"
-			}
-		},
 		"node_modules/rdf-terms": {
 			"version": "1.11.0",
 			"resolved": "https://registry.npmjs.org/rdf-terms/-/rdf-terms-1.11.0.tgz",
@@ -15377,26 +15321,6 @@
 				"@rdfjs/types": "*",
 				"rdf-data-factory": "^1.1.0",
 				"rdf-string": "^1.6.0"
-			}
-		},
-		"node_modules/rdf-terms/node_modules/@rdfjs/types": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/@rdfjs/types/-/types-1.1.2.tgz",
-			"integrity": "sha512-wqpOJK1QCbmsGNtyzYnojPU8gRDPid2JO0Q0kMtb4j65xhCK880cnKAfEOwC+dX85VJcCByQx5zOwyyfCjDJsg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@types/node": "*"
-			}
-		},
-		"node_modules/rdf-terms/node_modules/rdf-data-factory": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/rdf-data-factory/-/rdf-data-factory-1.1.3.tgz",
-			"integrity": "sha512-ny6CI7m2bq4lfQQmDYvcb2l1F9KtGwz9chipX4oWu2aAtVoXjb7k3d8J1EsgAsEbMXnBipB/iuRen5H2fwRWWQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@rdfjs/types": "^1.0.0"
 			}
 		},
 		"node_modules/rdfa-streaming-parser": {
@@ -15410,6 +15334,20 @@
 				"rdf-data-factory": "^2.0.0",
 				"readable-stream": "^4.0.0",
 				"relative-to-absolute-iri": "^1.0.2"
+			},
+			"funding": {
+				"type": "individual",
+				"url": "https://github.com/sponsors/rubensworks/"
+			}
+		},
+		"node_modules/rdfa-streaming-parser/node_modules/rdf-data-factory": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/rdf-data-factory/-/rdf-data-factory-2.0.2.tgz",
+			"integrity": "sha512-WzPoYHwQYWvIP9k+7IBLY1b4nIDitzAK4mA37WumAF/Cjvu/KOtYJH9IPZnUTWNSd5K2+pq4vrcE9WZC4sRHhg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@rdfjs/types": "^2.0.0"
 			},
 			"funding": {
 				"type": "individual",
@@ -15433,16 +15371,6 @@
 				"validate-iri": "^1.0.0"
 			}
 		},
-		"node_modules/rdfxml-streaming-parser/node_modules/@rdfjs/types": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/@rdfjs/types/-/types-1.1.2.tgz",
-			"integrity": "sha512-wqpOJK1QCbmsGNtyzYnojPU8gRDPid2JO0Q0kMtb4j65xhCK880cnKAfEOwC+dX85VJcCByQx5zOwyyfCjDJsg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@types/node": "*"
-			}
-		},
 		"node_modules/rdfxml-streaming-parser/node_modules/@types/readable-stream": {
 			"version": "2.3.15",
 			"resolved": "https://registry.npmjs.org/@types/readable-stream/-/readable-stream-2.3.15.tgz",
@@ -15454,20 +15382,11 @@
 				"safe-buffer": "~5.1.1"
 			}
 		},
-		"node_modules/rdfxml-streaming-parser/node_modules/rdf-data-factory": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/rdf-data-factory/-/rdf-data-factory-1.1.3.tgz",
-			"integrity": "sha512-ny6CI7m2bq4lfQQmDYvcb2l1F9KtGwz9chipX4oWu2aAtVoXjb7k3d8J1EsgAsEbMXnBipB/iuRen5H2fwRWWQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@rdfjs/types": "^1.0.0"
-			}
-		},
 		"node_modules/react-is": {
 			"version": "17.0.2",
 			"resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
 			"integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/read-cache": {
@@ -15547,6 +15466,7 @@
 			"version": "0.14.1",
 			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
 			"integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/relative-to-absolute-iri": {
@@ -15901,26 +15821,6 @@
 				"sparqlalgebrajs": "bin/sparqlalgebrajs.js"
 			}
 		},
-		"node_modules/sparqlalgebrajs/node_modules/@rdfjs/types": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/@rdfjs/types/-/types-1.1.2.tgz",
-			"integrity": "sha512-wqpOJK1QCbmsGNtyzYnojPU8gRDPid2JO0Q0kMtb4j65xhCK880cnKAfEOwC+dX85VJcCByQx5zOwyyfCjDJsg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@types/node": "*"
-			}
-		},
-		"node_modules/sparqlalgebrajs/node_modules/rdf-data-factory": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/rdf-data-factory/-/rdf-data-factory-1.1.3.tgz",
-			"integrity": "sha512-ny6CI7m2bq4lfQQmDYvcb2l1F9KtGwz9chipX4oWu2aAtVoXjb7k3d8J1EsgAsEbMXnBipB/iuRen5H2fwRWWQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@rdfjs/types": "^1.0.0"
-			}
-		},
 		"node_modules/sparqljs": {
 			"version": "3.7.3",
 			"resolved": "https://registry.npmjs.org/sparqljs/-/sparqljs-3.7.3.tgz",
@@ -15937,26 +15837,6 @@
 				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
 			}
 		},
-		"node_modules/sparqljs/node_modules/@rdfjs/types": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/@rdfjs/types/-/types-1.1.2.tgz",
-			"integrity": "sha512-wqpOJK1QCbmsGNtyzYnojPU8gRDPid2JO0Q0kMtb4j65xhCK880cnKAfEOwC+dX85VJcCByQx5zOwyyfCjDJsg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@types/node": "*"
-			}
-		},
-		"node_modules/sparqljs/node_modules/rdf-data-factory": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/rdf-data-factory/-/rdf-data-factory-1.1.3.tgz",
-			"integrity": "sha512-ny6CI7m2bq4lfQQmDYvcb2l1F9KtGwz9chipX4oWu2aAtVoXjb7k3d8J1EsgAsEbMXnBipB/iuRen5H2fwRWWQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@rdfjs/types": "^1.0.0"
-			}
-		},
 		"node_modules/sparqljson-parse": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/sparqljson-parse/-/sparqljson-parse-2.2.0.tgz",
@@ -15971,16 +15851,6 @@
 				"readable-stream": "^4.0.0"
 			}
 		},
-		"node_modules/sparqljson-parse/node_modules/@rdfjs/types": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/@rdfjs/types/-/types-1.1.2.tgz",
-			"integrity": "sha512-wqpOJK1QCbmsGNtyzYnojPU8gRDPid2JO0Q0kMtb4j65xhCK880cnKAfEOwC+dX85VJcCByQx5zOwyyfCjDJsg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@types/node": "*"
-			}
-		},
 		"node_modules/sparqljson-parse/node_modules/@types/readable-stream": {
 			"version": "2.3.15",
 			"resolved": "https://registry.npmjs.org/@types/readable-stream/-/readable-stream-2.3.15.tgz",
@@ -15990,16 +15860,6 @@
 			"dependencies": {
 				"@types/node": "*",
 				"safe-buffer": "~5.1.1"
-			}
-		},
-		"node_modules/sparqljson-parse/node_modules/rdf-data-factory": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/rdf-data-factory/-/rdf-data-factory-1.1.3.tgz",
-			"integrity": "sha512-ny6CI7m2bq4lfQQmDYvcb2l1F9KtGwz9chipX4oWu2aAtVoXjb7k3d8J1EsgAsEbMXnBipB/iuRen5H2fwRWWQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@rdfjs/types": "^1.0.0"
 			}
 		},
 		"node_modules/sparqljson-to-tree": {
@@ -16029,16 +15889,6 @@
 				"readable-stream": "^4.0.0"
 			}
 		},
-		"node_modules/sparqlxml-parse/node_modules/@rdfjs/types": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/@rdfjs/types/-/types-1.1.2.tgz",
-			"integrity": "sha512-wqpOJK1QCbmsGNtyzYnojPU8gRDPid2JO0Q0kMtb4j65xhCK880cnKAfEOwC+dX85VJcCByQx5zOwyyfCjDJsg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@types/node": "*"
-			}
-		},
 		"node_modules/sparqlxml-parse/node_modules/@types/readable-stream": {
 			"version": "2.3.15",
 			"resolved": "https://registry.npmjs.org/@types/readable-stream/-/readable-stream-2.3.15.tgz",
@@ -16048,16 +15898,6 @@
 			"dependencies": {
 				"@types/node": "*",
 				"safe-buffer": "~5.1.1"
-			}
-		},
-		"node_modules/sparqlxml-parse/node_modules/rdf-data-factory": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/rdf-data-factory/-/rdf-data-factory-1.1.3.tgz",
-			"integrity": "sha512-ny6CI7m2bq4lfQQmDYvcb2l1F9KtGwz9chipX4oWu2aAtVoXjb7k3d8J1EsgAsEbMXnBipB/iuRen5H2fwRWWQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@rdfjs/types": "^1.0.0"
 			}
 		},
 		"node_modules/stack-trace": {
@@ -16282,6 +16122,7 @@
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
 			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"has-flag": "^4.0.0"
@@ -16304,29 +16145,29 @@
 			}
 		},
 		"node_modules/svelte": {
-			"version": "4.2.19",
-			"resolved": "https://registry.npmjs.org/svelte/-/svelte-4.2.19.tgz",
-			"integrity": "sha512-IY1rnGr6izd10B0A8LqsBfmlT5OILVuZ7XsI0vdGPEvuonFV7NYEUK4dAkm9Zg2q0Um92kYjTpS1CAP3Nh/KWw==",
+			"version": "5.19.2",
+			"resolved": "https://registry.npmjs.org/svelte/-/svelte-5.19.2.tgz",
+			"integrity": "sha512-Ww1uLgdX5MdQrAO5zfU1dWUh6zqiPR6uIbwqm8a+4eQ+tNEYHRPgypvKKfHh9lmTkmJ30PWZ2O5qX8aS+PblRQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@ampproject/remapping": "^2.2.1",
-				"@jridgewell/sourcemap-codec": "^1.4.15",
-				"@jridgewell/trace-mapping": "^0.3.18",
-				"@types/estree": "^1.0.1",
-				"acorn": "^8.9.0",
-				"aria-query": "^5.3.0",
-				"axobject-query": "^4.0.0",
-				"code-red": "^1.0.3",
-				"css-tree": "^2.3.1",
-				"estree-walker": "^3.0.3",
-				"is-reference": "^3.0.1",
+				"@ampproject/remapping": "^2.3.0",
+				"@jridgewell/sourcemap-codec": "^1.5.0",
+				"@types/estree": "^1.0.5",
+				"acorn": "^8.12.1",
+				"acorn-typescript": "^1.4.13",
+				"aria-query": "^5.3.1",
+				"axobject-query": "^4.1.0",
+				"clsx": "^2.1.1",
+				"esm-env": "^1.2.1",
+				"esrap": "^1.4.3",
+				"is-reference": "^3.0.3",
 				"locate-character": "^3.0.0",
-				"magic-string": "^0.30.4",
-				"periscopic": "^3.1.0"
+				"magic-string": "^0.30.11",
+				"zimmerframe": "^1.1.2"
 			},
 			"engines": {
-				"node": ">=16"
+				"node": ">=18"
 			}
 		},
 		"node_modules/svelte-check": {
@@ -16429,17 +16270,14 @@
 				"url": "https://opencollective.com/eslint"
 			}
 		},
-		"node_modules/svelte-hmr": {
-			"version": "0.16.0",
-			"resolved": "https://registry.npmjs.org/svelte-hmr/-/svelte-hmr-0.16.0.tgz",
-			"integrity": "sha512-Gyc7cOS3VJzLlfj7wKS0ZnzDVdv3Pn2IuVeJPk9m2skfhcu5bq3wtIZyQGggr7/Iim5rH5cncyQft/kRLupcnA==",
+		"node_modules/svelte/node_modules/aria-query": {
+			"version": "5.3.2",
+			"resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz",
+			"integrity": "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==",
 			"dev": true,
-			"license": "ISC",
+			"license": "Apache-2.0",
 			"engines": {
-				"node": "^12.20 || ^14.13.1 || >= 16"
-			},
-			"peerDependencies": {
-				"svelte": "^3.19.0 || ^4.0.0"
+				"node": ">= 0.4"
 			}
 		},
 		"node_modules/symbol-tree": {
@@ -16542,6 +16380,16 @@
 				"node": ">= 6"
 			}
 		},
+		"node_modules/tailwindcss/node_modules/jiti": {
+			"version": "1.21.7",
+			"resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
+			"integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
+			"dev": true,
+			"license": "MIT",
+			"bin": {
+				"jiti": "bin/jiti.js"
+			}
+		},
 		"node_modules/tailwindcss/node_modules/lilconfig": {
 			"version": "3.1.3",
 			"resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
@@ -16615,19 +16463,6 @@
 			},
 			"engines": {
 				"node": ">=8.10.0"
-			}
-		},
-		"node_modules/tailwindcss/node_modules/yaml": {
-			"version": "2.7.0",
-			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.7.0.tgz",
-			"integrity": "sha512-+hSoy/QHluxmC9kCIJyL/uyFmLmc+e5CFR5Wa+bpIhIj85LVb9ZH2nVnqrHoSvKogwODv0ClqZkmiSSaIH5LTA==",
-			"dev": true,
-			"license": "ISC",
-			"bin": {
-				"yaml": "bin.mjs"
-			},
-			"engines": {
-				"node": ">= 14"
 			}
 		},
 		"node_modules/test-exclude": {
@@ -16746,22 +16581,22 @@
 			}
 		},
 		"node_modules/tldts": {
-			"version": "6.1.73",
-			"resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.73.tgz",
-			"integrity": "sha512-/h4bVmuEMm57c2uCiAf1Q9mlQk7cA22m+1Bu0K92vUUtTVT9D4mOFWD9r4WQuTULcG9eeZtNKhLl0Il1LdKGog==",
+			"version": "6.1.74",
+			"resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.74.tgz",
+			"integrity": "sha512-O5vTZ1UmmEmrLl/59U9igitnSMlprALLaLgbv//dEvjobPT9vyURhHXKMCDLEhn3qxZFIkb9PwAfNYV0Ol7RPQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"tldts-core": "^6.1.73"
+				"tldts-core": "^6.1.74"
 			},
 			"bin": {
 				"tldts": "bin/cli.js"
 			}
 		},
 		"node_modules/tldts-core": {
-			"version": "6.1.73",
-			"resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.73.tgz",
-			"integrity": "sha512-k1g5eX87vxu3g//6XMn62y4qjayu4cYby/PF7Ksnh4F4uUK1Z1ze/mJ4a+y5OjdJ+cXRp+YTInZhH+FGdUWy1w==",
+			"version": "6.1.74",
+			"resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.74.tgz",
+			"integrity": "sha512-gTwtY6L2GfuxiL4CWpLknv9JDYYqBvKCk/BT5uAaAvCA0s6pzX7lr2IrkQZSUlnSjRHIjTl8ZwKCVXJ7XNRWYw==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -16984,21 +16819,21 @@
 			"license": "MIT"
 		},
 		"node_modules/vite": {
-			"version": "5.4.12",
-			"resolved": "https://registry.npmjs.org/vite/-/vite-5.4.12.tgz",
-			"integrity": "sha512-KwUaKB27TvWwDJr1GjjWthLMATbGEbeWYZIbGZ5qFIsgPP3vWzLu4cVooqhm5/Z2SPDUMjyPVjTztm5tYKwQxA==",
+			"version": "6.0.11",
+			"resolved": "https://registry.npmjs.org/vite/-/vite-6.0.11.tgz",
+			"integrity": "sha512-4VL9mQPKoHy4+FE0NnRE/kbY51TOfaknxAjt3fJbGJxhIpBZiqVzlZDEesWWsuREXHwNdAoOFZ9MkPEVXczHwg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"esbuild": "^0.21.3",
-				"postcss": "^8.4.43",
-				"rollup": "^4.20.0"
+				"esbuild": "^0.24.2",
+				"postcss": "^8.4.49",
+				"rollup": "^4.23.0"
 			},
 			"bin": {
 				"vite": "bin/vite.js"
 			},
 			"engines": {
-				"node": "^18.0.0 || >=20.0.0"
+				"node": "^18.0.0 || ^20.0.0 || >=22.0.0"
 			},
 			"funding": {
 				"url": "https://github.com/vitejs/vite?sponsor=1"
@@ -17007,17 +16842,23 @@
 				"fsevents": "~2.3.3"
 			},
 			"peerDependencies": {
-				"@types/node": "^18.0.0 || >=20.0.0",
+				"@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+				"jiti": ">=1.21.0",
 				"less": "*",
 				"lightningcss": "^1.21.0",
 				"sass": "*",
 				"sass-embedded": "*",
 				"stylus": "*",
 				"sugarss": "*",
-				"terser": "^5.4.0"
+				"terser": "^5.16.0",
+				"tsx": "^4.8.1",
+				"yaml": "^2.4.2"
 			},
 			"peerDependenciesMeta": {
 				"@types/node": {
+					"optional": true
+				},
+				"jiti": {
 					"optional": true
 				},
 				"less": {
@@ -17039,6 +16880,12 @@
 					"optional": true
 				},
 				"terser": {
+					"optional": true
+				},
+				"tsx": {
+					"optional": true
+				},
+				"yaml": {
 					"optional": true
 				}
 			}
@@ -17082,13 +16929,17 @@
 			}
 		},
 		"node_modules/vitefu": {
-			"version": "0.2.5",
-			"resolved": "https://registry.npmjs.org/vitefu/-/vitefu-0.2.5.tgz",
-			"integrity": "sha512-SgHtMLoqaeeGnd2evZ849ZbACbnwQCIwRH57t18FxcXoZop0uQu0uzlIhJBlF/eWVzuce0sHeqPcDo+evVcg8Q==",
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/vitefu/-/vitefu-1.0.5.tgz",
+			"integrity": "sha512-h4Vflt9gxODPFNGPwp4zAMZRpZR7eslzwH2c5hn5kNZ5rhnKyRJ50U+yGCdc2IRaBs8O4haIgLNGrV5CrpMsCA==",
 			"dev": true,
 			"license": "MIT",
+			"workspaces": [
+				"tests/deps/*",
+				"tests/projects/*"
+			],
 			"peerDependencies": {
-				"vite": "^3.0.0 || ^4.0.0 || ^5.0.0"
+				"vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0"
 			},
 			"peerDependenciesMeta": {
 				"vite": {
@@ -17475,13 +17326,16 @@
 			}
 		},
 		"node_modules/yaml": {
-			"version": "1.10.2",
-			"resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
-			"integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.7.0.tgz",
+			"integrity": "sha512-+hSoy/QHluxmC9kCIJyL/uyFmLmc+e5CFR5Wa+bpIhIj85LVb9ZH2nVnqrHoSvKogwODv0ClqZkmiSSaIH5LTA==",
 			"dev": true,
 			"license": "ISC",
+			"bin": {
+				"yaml": "bin.mjs"
+			},
 			"engines": {
-				"node": ">= 6"
+				"node": ">= 14"
 			}
 		},
 		"node_modules/yargs": {
@@ -17560,6 +17414,13 @@
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
+		},
+		"node_modules/zimmerframe": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/zimmerframe/-/zimmerframe-1.1.2.tgz",
+			"integrity": "sha512-rAbqEGa8ovJy4pyBxZM70hg4pE6gDgaQ0Sl9M3enG3I0d6H4XSAM3GeNGLKnsBpuijUow064sf7ww1nutC5/3w==",
+			"dev": true,
+			"license": "MIT"
 		}
 	}
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
 			"version": "0.1.1",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@testing-library/user-event": "^14.6.0"
+				"@testing-library/user-event": "^14.6.1"
 			},
 			"devDependencies": {
 				"@axe-core/playwright": "^4.10.1",
@@ -18,15 +18,15 @@
 				"@comunica/types": "^4.0.2",
 				"@playwright/test": "^1.49.1",
 				"@sveltejs/adapter-static": "^3.0.8",
-				"@sveltejs/kit": "^2.16.0",
+				"@sveltejs/kit": "^2.16.1",
 				"@sveltejs/vite-plugin-svelte": "^3.1.2",
 				"@testing-library/jest-dom": "^6.6.3",
 				"@testing-library/svelte": "^5.2.6",
 				"@types/cytoscape": "^3.21.8",
 				"@types/eslint": "^9.6.1",
 				"@ukic/fonts": "^2.6.5",
-				"@ukic/web-components": "^2.33.0",
-				"@vitest/coverage-v8": "^3.0.2",
+				"@ukic/web-components": "^2.34.0",
+				"@vitest/coverage-v8": "^3.0.3",
 				"asynciterator": "^3.9.0",
 				"autoprefixer": "^10.4.20",
 				"clsx": "^2.1.1",
@@ -49,10 +49,10 @@
 				"tailwindcss": "^3.4.17",
 				"tslib": "^2.8.1",
 				"typescript": "^5.7.3",
-				"typescript-eslint": "^8.20.0",
+				"typescript-eslint": "^8.21.0",
 				"uuid": "^11.0.5",
 				"vite": "^5.4.11",
-				"vitest": "^3.0.2"
+				"vitest": "^3.0.3"
 			}
 		},
 		"node_modules/@adobe/css-tools": {
@@ -10302,9 +10302,9 @@
 			}
 		},
 		"node_modules/@sveltejs/kit": {
-			"version": "2.16.0",
-			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.16.0.tgz",
-			"integrity": "sha512-S9i1ZWKqluzoaJ6riYnEdbe+xJluMTMkhABouBa66GaWcAyCjW/jAc0NdJQJ/DXyK1CnP5quBW25e99MNyvLxA==",
+			"version": "2.16.1",
+			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.16.1.tgz",
+			"integrity": "sha512-2pF5sgGJx9brYZ/9nNDYnh5KX0JguPF14dnvvtf/MqrvlWrDj/e7Rk3LBJPecFLLK1GRs6ZniD24gFPqZm/NFw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -10461,9 +10461,9 @@
 			}
 		},
 		"node_modules/@testing-library/user-event": {
-			"version": "14.6.0",
-			"resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.0.tgz",
-			"integrity": "sha512-+jsfK7kVJbqnCYtLTln8Ja/NmVrZRwBJHmHR9IxIVccMWSOZ6Oy0FkDJNeyVu4QSpMNmRfy10Xb76ObRDlWWBQ==",
+			"version": "14.6.1",
+			"resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+			"integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=12",
@@ -10647,17 +10647,17 @@
 			"license": "MIT"
 		},
 		"node_modules/@typescript-eslint/eslint-plugin": {
-			"version": "8.20.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.20.0.tgz",
-			"integrity": "sha512-naduuphVw5StFfqp4Gq4WhIBE2gN1GEmMUExpJYknZJdRnc+2gDzB8Z3+5+/Kv33hPQRDGzQO/0opHE72lZZ6A==",
+			"version": "8.21.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.21.0.tgz",
+			"integrity": "sha512-eTH+UOR4I7WbdQnG4Z48ebIA6Bgi7WO8HvFEneeYBxG8qCOYgTOFPSg6ek9ITIDvGjDQzWHcoWHCDO2biByNzA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@eslint-community/regexpp": "^4.10.0",
-				"@typescript-eslint/scope-manager": "8.20.0",
-				"@typescript-eslint/type-utils": "8.20.0",
-				"@typescript-eslint/utils": "8.20.0",
-				"@typescript-eslint/visitor-keys": "8.20.0",
+				"@typescript-eslint/scope-manager": "8.21.0",
+				"@typescript-eslint/type-utils": "8.21.0",
+				"@typescript-eslint/utils": "8.21.0",
+				"@typescript-eslint/visitor-keys": "8.21.0",
 				"graphemer": "^1.4.0",
 				"ignore": "^5.3.1",
 				"natural-compare": "^1.4.0",
@@ -10677,16 +10677,16 @@
 			}
 		},
 		"node_modules/@typescript-eslint/parser": {
-			"version": "8.20.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.20.0.tgz",
-			"integrity": "sha512-gKXG7A5HMyjDIedBi6bUrDcun8GIjnI8qOwVLiY3rx6T/sHP/19XLJOnIq/FgQvWLHja5JN/LSE7eklNBr612g==",
+			"version": "8.21.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.21.0.tgz",
+			"integrity": "sha512-Wy+/sdEH9kI3w9civgACwabHbKl+qIOu0uFZ9IMKzX3Jpv9og0ZBJrZExGrPpFAY7rWsXuxs5e7CPPP17A4eYA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/scope-manager": "8.20.0",
-				"@typescript-eslint/types": "8.20.0",
-				"@typescript-eslint/typescript-estree": "8.20.0",
-				"@typescript-eslint/visitor-keys": "8.20.0",
+				"@typescript-eslint/scope-manager": "8.21.0",
+				"@typescript-eslint/types": "8.21.0",
+				"@typescript-eslint/typescript-estree": "8.21.0",
+				"@typescript-eslint/visitor-keys": "8.21.0",
 				"debug": "^4.3.4"
 			},
 			"engines": {
@@ -10702,14 +10702,14 @@
 			}
 		},
 		"node_modules/@typescript-eslint/scope-manager": {
-			"version": "8.20.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.20.0.tgz",
-			"integrity": "sha512-J7+VkpeGzhOt3FeG1+SzhiMj9NzGD/M6KoGn9f4dbz3YzK9hvbhVTmLj/HiTp9DazIzJ8B4XcM80LrR9Dm1rJw==",
+			"version": "8.21.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.21.0.tgz",
+			"integrity": "sha512-G3IBKz0/0IPfdeGRMbp+4rbjfSSdnGkXsM/pFZA8zM9t9klXDnB/YnKOBQ0GoPmoROa4bCq2NeHgJa5ydsQ4mA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "8.20.0",
-				"@typescript-eslint/visitor-keys": "8.20.0"
+				"@typescript-eslint/types": "8.21.0",
+				"@typescript-eslint/visitor-keys": "8.21.0"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -10720,14 +10720,14 @@
 			}
 		},
 		"node_modules/@typescript-eslint/type-utils": {
-			"version": "8.20.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.20.0.tgz",
-			"integrity": "sha512-bPC+j71GGvA7rVNAHAtOjbVXbLN5PkwqMvy1cwGeaxUoRQXVuKCebRoLzm+IPW/NtFFpstn1ummSIasD5t60GA==",
+			"version": "8.21.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.21.0.tgz",
+			"integrity": "sha512-95OsL6J2BtzoBxHicoXHxgk3z+9P3BEcQTpBKriqiYzLKnM2DeSqs+sndMKdamU8FosiadQFT3D+BSL9EKnAJQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/typescript-estree": "8.20.0",
-				"@typescript-eslint/utils": "8.20.0",
+				"@typescript-eslint/typescript-estree": "8.21.0",
+				"@typescript-eslint/utils": "8.21.0",
 				"debug": "^4.3.4",
 				"ts-api-utils": "^2.0.0"
 			},
@@ -10744,9 +10744,9 @@
 			}
 		},
 		"node_modules/@typescript-eslint/types": {
-			"version": "8.20.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.20.0.tgz",
-			"integrity": "sha512-cqaMiY72CkP+2xZRrFt3ExRBu0WmVitN/rYPZErA80mHjHx/Svgp8yfbzkJmDoQ/whcytOPO9/IZXnOc+wigRA==",
+			"version": "8.21.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.21.0.tgz",
+			"integrity": "sha512-PAL6LUuQwotLW2a8VsySDBwYMm129vFm4tMVlylzdoTybTHaAi0oBp7Ac6LhSrHHOdLM3efH+nAR6hAWoMF89A==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -10758,14 +10758,14 @@
 			}
 		},
 		"node_modules/@typescript-eslint/typescript-estree": {
-			"version": "8.20.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.20.0.tgz",
-			"integrity": "sha512-Y7ncuy78bJqHI35NwzWol8E0X7XkRVS4K4P4TCyzWkOJih5NDvtoRDW4Ba9YJJoB2igm9yXDdYI/+fkiiAxPzA==",
+			"version": "8.21.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.21.0.tgz",
+			"integrity": "sha512-x+aeKh/AjAArSauz0GiQZsjT8ciadNMHdkUSwBB9Z6PrKc/4knM4g3UfHml6oDJmKC88a6//cdxnO/+P2LkMcg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "8.20.0",
-				"@typescript-eslint/visitor-keys": "8.20.0",
+				"@typescript-eslint/types": "8.21.0",
+				"@typescript-eslint/visitor-keys": "8.21.0",
 				"debug": "^4.3.4",
 				"fast-glob": "^3.3.2",
 				"is-glob": "^4.0.3",
@@ -10811,16 +10811,16 @@
 			}
 		},
 		"node_modules/@typescript-eslint/utils": {
-			"version": "8.20.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.20.0.tgz",
-			"integrity": "sha512-dq70RUw6UK9ei7vxc4KQtBRk7qkHZv447OUZ6RPQMQl71I3NZxQJX/f32Smr+iqWrB02pHKn2yAdHBb0KNrRMA==",
+			"version": "8.21.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.21.0.tgz",
+			"integrity": "sha512-xcXBfcq0Kaxgj7dwejMbFyq7IOHgpNMtVuDveK7w3ZGwG9owKzhALVwKpTF2yrZmEwl9SWdetf3fxNzJQaVuxw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.4.0",
-				"@typescript-eslint/scope-manager": "8.20.0",
-				"@typescript-eslint/types": "8.20.0",
-				"@typescript-eslint/typescript-estree": "8.20.0"
+				"@typescript-eslint/scope-manager": "8.21.0",
+				"@typescript-eslint/types": "8.21.0",
+				"@typescript-eslint/typescript-estree": "8.21.0"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -10835,13 +10835,13 @@
 			}
 		},
 		"node_modules/@typescript-eslint/visitor-keys": {
-			"version": "8.20.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.20.0.tgz",
-			"integrity": "sha512-v/BpkeeYAsPkKCkR8BDwcno0llhzWVqPOamQrAEMdpZav2Y9OVjd9dwJyBLJWwf335B5DmlifECIkZRJCaGaHA==",
+			"version": "8.21.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.21.0.tgz",
+			"integrity": "sha512-BkLMNpdV6prozk8LlyK/SOoWLmUFi+ZD+pcqti9ILCbVvHGk1ui1g4jJOc2WDLaeExz2qWwojxlPce5PljcT3w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "8.20.0",
+				"@typescript-eslint/types": "8.21.0",
 				"eslint-visitor-keys": "^4.2.0"
 			},
 			"engines": {
@@ -10860,9 +10860,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@ukic/web-components": {
-			"version": "2.33.0",
-			"resolved": "https://registry.npmjs.org/@ukic/web-components/-/web-components-2.33.0.tgz",
-			"integrity": "sha512-rncx34KxpwPS9YV+UkME6AhrYXwGEZIqRMC5Kx3bU1YUanoQ5ITZ0u8OwF8kKRFkrh8Dh+FemTNXFWW6yfPJMw==",
+			"version": "2.34.0",
+			"resolved": "https://registry.npmjs.org/@ukic/web-components/-/web-components-2.34.0.tgz",
+			"integrity": "sha512-1PZgxf+o1ed1bJaj+P7+BwcgL/tJ6Lyv1ThfTHpmEDP3mLEN9UkRc5uiIwT3UzkklSqSm8q6L009XizxbwakEA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -10874,9 +10874,9 @@
 			}
 		},
 		"node_modules/@vitest/coverage-v8": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-3.0.2.tgz",
-			"integrity": "sha512-U+hZYb0FtgNDb6B3E9piAHzXXIuxuBw2cd6Lvepc9sYYY4KjgiwCBmo3Sird9ZRu3ggLpLBTfw1ZRr77ipiSfw==",
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-3.0.3.tgz",
+			"integrity": "sha512-uVbJ/xhImdNtzPnLyxCZJMTeTIYdgcC2nWtBBBpR1H6z0w8m7D+9/zrDIx2nNxgMg9r+X8+RY2qVpUDeW2b3nw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -10897,8 +10897,8 @@
 				"url": "https://opencollective.com/vitest"
 			},
 			"peerDependencies": {
-				"@vitest/browser": "3.0.2",
-				"vitest": "3.0.2"
+				"@vitest/browser": "3.0.3",
+				"vitest": "3.0.3"
 			},
 			"peerDependenciesMeta": {
 				"@vitest/browser": {
@@ -10907,14 +10907,14 @@
 			}
 		},
 		"node_modules/@vitest/expect": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.0.2.tgz",
-			"integrity": "sha512-dKSHLBcoZI+3pmP5hiZ7I5grNru2HRtEW8Z5Zp4IXog8QYcxhlox7JUPyIIFWfN53+3HW3KPLIl6nSzUGgKSuQ==",
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.0.3.tgz",
+			"integrity": "sha512-SbRCHU4qr91xguu+dH3RUdI5dC86zm8aZWydbp961aIR7G8OYNN6ZiayFuf9WAngRbFOfdrLHCGgXTj3GtoMRQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vitest/spy": "3.0.2",
-				"@vitest/utils": "3.0.2",
+				"@vitest/spy": "3.0.3",
+				"@vitest/utils": "3.0.3",
 				"chai": "^5.1.2",
 				"tinyrainbow": "^2.0.0"
 			},
@@ -10923,13 +10923,13 @@
 			}
 		},
 		"node_modules/@vitest/mocker": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.0.2.tgz",
-			"integrity": "sha512-Hr09FoBf0jlwwSyzIF4Xw31OntpO3XtZjkccpcBf8FeVW3tpiyKlkeUzxS/txzHqpUCNIX157NaTySxedyZLvA==",
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.0.3.tgz",
+			"integrity": "sha512-XT2XBc4AN9UdaxJAeIlcSZ0ILi/GzmG5G8XSly4gaiqIvPV3HMTSIDZWJVX6QRJ0PX1m+W8Cy0K9ByXNb/bPIA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vitest/spy": "3.0.2",
+				"@vitest/spy": "3.0.3",
 				"estree-walker": "^3.0.3",
 				"magic-string": "^0.30.17"
 			},
@@ -10950,9 +10950,9 @@
 			}
 		},
 		"node_modules/@vitest/pretty-format": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.0.2.tgz",
-			"integrity": "sha512-yBohcBw/T/p0/JRgYD+IYcjCmuHzjC3WLAKsVE4/LwiubzZkE8N49/xIQ/KGQwDRA8PaviF8IRO8JMWMngdVVQ==",
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.0.3.tgz",
+			"integrity": "sha512-gCrM9F7STYdsDoNjGgYXKPq4SkSxwwIU5nkaQvdUxiQ0EcNlez+PdKOVIsUJvh9P9IeIFmjn4IIREWblOBpP2Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -10963,13 +10963,13 @@
 			}
 		},
 		"node_modules/@vitest/runner": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.0.2.tgz",
-			"integrity": "sha512-GHEsWoncrGxWuW8s405fVoDfSLk6RF2LCXp6XhevbtDjdDme1WV/eNmUueDfpY1IX3MJaCRelVCEXsT9cArfEg==",
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.0.3.tgz",
+			"integrity": "sha512-Rgi2kOAk5ZxWZlwPguRJFOBmWs6uvvyAAR9k3MvjRvYrG7xYvKChZcmnnpJCS98311CBDMqsW9MzzRFsj2gX3g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vitest/utils": "3.0.2",
+				"@vitest/utils": "3.0.3",
 				"pathe": "^2.0.1"
 			},
 			"funding": {
@@ -10977,13 +10977,13 @@
 			}
 		},
 		"node_modules/@vitest/snapshot": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.0.2.tgz",
-			"integrity": "sha512-h9s67yD4+g+JoYG0zPCo/cLTabpDqzqNdzMawmNPzDStTiwxwkyYM1v5lWE8gmGv3SVJ2DcxA2NpQJZJv9ym3g==",
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.0.3.tgz",
+			"integrity": "sha512-kNRcHlI4txBGztuJfPEJ68VezlPAXLRT1u5UCx219TU3kOG2DplNxhWLwDf2h6emwmTPogzLnGVwP6epDaJN6Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vitest/pretty-format": "3.0.2",
+				"@vitest/pretty-format": "3.0.3",
 				"magic-string": "^0.30.17",
 				"pathe": "^2.0.1"
 			},
@@ -10992,9 +10992,9 @@
 			}
 		},
 		"node_modules/@vitest/spy": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.0.2.tgz",
-			"integrity": "sha512-8mI2iUn+PJFMT44e3ISA1R+K6ALVs47W6eriDTfXe6lFqlflID05MB4+rIFhmDSLBj8iBsZkzBYlgSkinxLzSQ==",
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.0.3.tgz",
+			"integrity": "sha512-7/dgux8ZBbF7lEIKNnEqQlyRaER9nkAL9eTmdKJkDO3hS8p59ATGwKOCUDHcBLKr7h/oi/6hP+7djQk8049T2A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -11005,13 +11005,13 @@
 			}
 		},
 		"node_modules/@vitest/utils": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.0.2.tgz",
-			"integrity": "sha512-Qu01ZYZlgHvDP02JnMBRpX43nRaZtNpIzw3C1clDXmn8eakgX6iQVGzTQ/NjkIr64WD8ioqOjkaYRVvHQI5qiw==",
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.0.3.tgz",
+			"integrity": "sha512-f+s8CvyzPtMFY1eZKkIHGhPsQgYo5qCm6O8KZoim9qm1/jT64qBgGpO5tHscNH6BzRHM+edLNOP+3vO8+8pE/A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vitest/pretty-format": "3.0.2",
+				"@vitest/pretty-format": "3.0.3",
 				"loupe": "^3.1.2",
 				"tinyrainbow": "^2.0.0"
 			},
@@ -16879,15 +16879,15 @@
 			}
 		},
 		"node_modules/typescript-eslint": {
-			"version": "8.20.0",
-			"resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.20.0.tgz",
-			"integrity": "sha512-Kxz2QRFsgbWj6Xcftlw3Dd154b3cEPFqQC+qMZrMypSijPd4UanKKvoKDrJ4o8AIfZFKAF+7sMaEIR8mTElozA==",
+			"version": "8.21.0",
+			"resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.21.0.tgz",
+			"integrity": "sha512-txEKYY4XMKwPXxNkN8+AxAdX6iIJAPiJbHE/FpQccs/sxw8Lf26kqwC3cn0xkHlW8kEbLhkhCsjWuMveaY9Rxw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/eslint-plugin": "8.20.0",
-				"@typescript-eslint/parser": "8.20.0",
-				"@typescript-eslint/utils": "8.20.0"
+				"@typescript-eslint/eslint-plugin": "8.21.0",
+				"@typescript-eslint/parser": "8.21.0",
+				"@typescript-eslint/utils": "8.21.0"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -17044,9 +17044,9 @@
 			}
 		},
 		"node_modules/vite-node": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.0.2.tgz",
-			"integrity": "sha512-hsEQerBAHvVAbv40m3TFQe/lTEbOp7yDpyqMJqr2Tnd+W58+DEYOt+fluQgekOePcsNBmR77lpVAnIU2Xu4SvQ==",
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.0.3.tgz",
+			"integrity": "sha512-0sQcwhwAEw/UJGojbhOrnq3HtiZ3tC7BzpAa0lx3QaTX0S3YX70iGcik25UBdB96pmdwjyY2uyKNYruxCDmiEg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -17097,19 +17097,19 @@
 			}
 		},
 		"node_modules/vitest": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/vitest/-/vitest-3.0.2.tgz",
-			"integrity": "sha512-5bzaHakQ0hmVVKLhfh/jXf6oETDBtgPo8tQCHYB+wftNgFJ+Hah67IsWc8ivx4vFL025Ow8UiuTf4W57z4izvQ==",
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/vitest/-/vitest-3.0.3.tgz",
+			"integrity": "sha512-dWdwTFUW9rcnL0LyF2F+IfvNQWB0w9DERySCk8VMG75F8k25C7LsZoh6XfCjPvcR8Nb+Lqi9JKr6vnzH7HSrpQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vitest/expect": "3.0.2",
-				"@vitest/mocker": "3.0.2",
-				"@vitest/pretty-format": "^3.0.2",
-				"@vitest/runner": "3.0.2",
-				"@vitest/snapshot": "3.0.2",
-				"@vitest/spy": "3.0.2",
-				"@vitest/utils": "3.0.2",
+				"@vitest/expect": "3.0.3",
+				"@vitest/mocker": "3.0.3",
+				"@vitest/pretty-format": "^3.0.3",
+				"@vitest/runner": "3.0.3",
+				"@vitest/snapshot": "3.0.3",
+				"@vitest/spy": "3.0.3",
+				"@vitest/utils": "3.0.3",
 				"chai": "^5.1.2",
 				"debug": "^4.4.0",
 				"expect-type": "^1.1.0",
@@ -17121,7 +17121,7 @@
 				"tinypool": "^1.0.2",
 				"tinyrainbow": "^2.0.0",
 				"vite": "^5.0.0 || ^6.0.0",
-				"vite-node": "3.0.2",
+				"vite-node": "3.0.3",
 				"why-is-node-running": "^2.3.0"
 			},
 			"bin": {
@@ -17136,8 +17136,8 @@
 			"peerDependencies": {
 				"@edge-runtime/vm": "*",
 				"@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
-				"@vitest/browser": "3.0.2",
-				"@vitest/ui": "3.0.2",
+				"@vitest/browser": "3.0.3",
+				"@vitest/ui": "3.0.3",
 				"happy-dom": "*",
 				"jsdom": "*"
 			},

--- a/package.json
+++ b/package.json
@@ -28,15 +28,15 @@
 		"@comunica/types": "^4.0.2",
 		"@playwright/test": "^1.49.1",
 		"@sveltejs/adapter-static": "^3.0.8",
-		"@sveltejs/kit": "^2.16.0",
+		"@sveltejs/kit": "^2.16.1",
 		"@sveltejs/vite-plugin-svelte": "^3.1.2",
 		"@testing-library/jest-dom": "^6.6.3",
 		"@testing-library/svelte": "^5.2.6",
 		"@types/cytoscape": "^3.21.8",
 		"@types/eslint": "^9.6.1",
 		"@ukic/fonts": "^2.6.5",
-		"@ukic/web-components": "^2.33.0",
-		"@vitest/coverage-v8": "^3.0.2",
+		"@ukic/web-components": "^2.34.0",
+		"@vitest/coverage-v8": "^3.0.3",
 		"asynciterator": "^3.9.0",
 		"autoprefixer": "^10.4.20",
 		"clsx": "^2.1.1",
@@ -59,13 +59,13 @@
 		"tailwindcss": "^3.4.17",
 		"tslib": "^2.8.1",
 		"typescript": "^5.7.3",
-		"typescript-eslint": "^8.20.0",
+		"typescript-eslint": "^8.21.0",
 		"uuid": "^11.0.5",
 		"vite": "^5.4.11",
-		"vitest": "^3.0.2"
+		"vitest": "^3.0.3"
 	},
 	"type": "module",
 	"dependencies": {
-		"@testing-library/user-event": "^14.6.0"
+		"@testing-library/user-event": "^14.6.1"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -29,8 +29,9 @@
 		"@playwright/test": "^1.49.1",
 		"@sveltejs/adapter-static": "^3.0.8",
 		"@sveltejs/kit": "^2.16.1",
-		"@sveltejs/vite-plugin-svelte": "^3.1.2",
+		"@sveltejs/vite-plugin-svelte": "^5.0.3",
 		"@testing-library/jest-dom": "^6.6.3",
+		"@testing-library/user-event": "^14.6.1",
 		"@testing-library/svelte": "^5.2.6",
 		"@types/cytoscape": "^3.21.8",
 		"@types/eslint": "^9.6.1",
@@ -54,18 +55,15 @@
 		"prettier-plugin-svelte": "^3.3.3",
 		"rdfa-streaming-parser": "^3.0.1",
 		"shadow-dom-testing-library": "^1.11.3",
-		"svelte": "^4.2.19",
+		"svelte": "^5.19.2",
 		"svelte-check": "^4.1.4",
 		"tailwindcss": "^3.4.17",
 		"tslib": "^2.8.1",
 		"typescript": "^5.7.3",
 		"typescript-eslint": "^8.21.0",
 		"uuid": "^11.0.5",
-		"vite": "^5.4.11",
+		"vite": "^6.0.11",
 		"vitest": "^3.0.3"
 	},
-	"type": "module",
-	"dependencies": {
-		"@testing-library/user-event": "^14.6.1"
-	}
+	"type": "module"
 }

--- a/src/lib/components/layout/nav/SideNav.svelte
+++ b/src/lib/components/layout/nav/SideNav.svelte
@@ -6,7 +6,7 @@
 	 * the behavior of the secondary nav items on small screen sizes (see references
 	 * to 'isSmall'). This is included due to an issue in the ICDS component library
 	 * which is renders the app unusable at high zoom levels. Given that we are required
-	 * to meet WCAG AA (must support zoom at 400%). Workaround included until
+	 * to meet WCAG AA (must support zoom at 400%), this workaround included until
 	 * a more permenant solution appears in the ICDS library.
 	 *
 	 * ICDS already aware of issue, details here: https://github.com/mi6/ic-ui-kit/issues/1922
@@ -25,18 +25,18 @@
 	import { type SideNavId, primarySideNavItems, secondarySideNavItems } from '$lib/navigation';
 	import { errorLogs, warningLogs } from '$stores/logger.store';
 	import { Badge } from '$lib/components';
-	import type { ComponentType } from 'svelte';
+	import type { Component } from 'svelte';
 	import type { IcBadgeVariants } from '@ukic/web-components';
 	import { ViewportHelper } from '$lib/components/helpers';
 	import { base } from '$app/paths';
-	import { page } from '$app/stores';
+	import { page } from '$app/state';
 	import { shouldHighlightSideNav } from '$lib/util/nav.utils';
 	import { sources } from '$stores/sources/sources.store';
 	import { version } from '$lib/constants';
 
 	type SideNavItemDetail = {
 		[key in SideNavId]: {
-			icon: ComponentType;
+			icon: Component;
 			badgeDetails?: {
 				label: string;
 				variant: IcBadgeVariants;
@@ -107,7 +107,7 @@
 			label={title}
 			href={`${base}${href}`}
 			slot="primary-navigation"
-			selected={shouldHighlightSideNav(base, href, $page.url.pathname)}
+			selected={shouldHighlightSideNav(base, href, page.url.pathname)}
 		>
 			{#if !!navItemDetail[id].badgeDetails}
 				<div slot="badge">
@@ -133,7 +133,7 @@
 				label={title}
 				href={`${base}${href}`}
 				slot="secondary-navigation"
-				selected={shouldHighlightSideNav(base, href, $page.url.pathname)}
+				selected={shouldHighlightSideNav(base, href, page.url.pathname)}
 			>
 				<div slot="icon">
 					<Icon><svelte:component this={navItemDetail[id].icon} /></Icon>
@@ -144,7 +144,7 @@
 				label={title}
 				href={`${base}${href}`}
 				slot="primary-navigation"
-				selected={shouldHighlightSideNav(base, href, $page.url.pathname)}
+				selected={shouldHighlightSideNav(base, href, page.url.pathname)}
 			>
 				<div slot="icon">
 					<Icon><svelte:component this={navItemDetail[id].icon} /></Icon>

--- a/src/lib/components/ui/Alert.svelte
+++ b/src/lib/components/ui/Alert.svelte
@@ -10,5 +10,5 @@
 </script>
 
 <div>
-	<ic-alert class="my-4" {variant} {heading} {dismissible} {message} />
+	<ic-alert class="my-4" {variant} {heading} {dismissible} {message}></ic-alert>
 </div>

--- a/src/lib/components/ui/Badge.svelte
+++ b/src/lib/components/ui/Badge.svelte
@@ -25,4 +25,5 @@
 	{size}
 	text-label={textLabel}
 	accessible-label={ariaLabel}
-/>
+>
+</ic-badge>

--- a/src/lib/components/ui/Button.spec.ts
+++ b/src/lib/components/ui/Button.spec.ts
@@ -25,9 +25,6 @@ describe('Button component', () => {
 
 		it('dispatches a click event when clicked', async () => {
 			const user = userEvent.setup();
-
-			//component.$on('click', clicked);
-
 			const theButton = await screen.findByShadowRole('button');
 			await user.click(theButton);
 

--- a/src/lib/components/ui/Button.spec.ts
+++ b/src/lib/components/ui/Button.spec.ts
@@ -8,10 +8,11 @@ import userEvent from '@testing-library/user-event';
 
 describe('Button component', () => {
 	describe('default behavior', () => {
-		let component: Button;
+		let clicked: typeof vi.fn;
 
 		beforeEach(async () => {
-			component = (await render(Button, { label: 'Test' })).component as Button;
+			clicked = vi.fn();
+			await render(Button, { label: 'Test', onclick: clicked });
 		});
 
 		it('renders the button with the appropriate label and role', async () => {
@@ -24,8 +25,8 @@ describe('Button component', () => {
 
 		it('dispatches a click event when clicked', async () => {
 			const user = userEvent.setup();
-			const clicked = vi.fn();
-			component.$on('click', clicked);
+
+			//component.$on('click', clicked);
 
 			const theButton = await screen.findByShadowRole('button');
 			await user.click(theButton);

--- a/src/lib/components/ui/Button.svelte
+++ b/src/lib/components/ui/Button.svelte
@@ -3,21 +3,38 @@
 <script lang="ts">
 	import { type IcButtonTypes, type IcButtonVariants, type IcSizes } from '@ukic/web-components';
 	import clsx from 'clsx';
+	import type { EventHandler } from 'svelte/elements';
 
-	export let className: string = '';
-	export let label: string;
-	export let variant: IcButtonVariants = 'primary';
-	export let size: IcSizes = 'default';
-	export let type: IcButtonTypes = 'submit';
-	export let disabled = false;
-	export let ariaLabel: string | undefined = undefined;
+	interface Props {
+		className?: string;
+		label: string;
+		variant?: IcButtonVariants;
+		size?: IcSizes;
+		type?: IcButtonTypes;
+		disabled?: boolean;
+		ariaLabel?: string | undefined;
+		onclick?: EventHandler;
+		onkeydown?: EventHandler;
+	}
+
+	let {
+		onclick,
+		onkeydown,
+		className,
+		label,
+		variant = 'primary',
+		size = 'default',
+		type = 'submit',
+		disabled,
+		ariaLabel
+	}: Props = $props();
 </script>
 
 <!-- These seem to be suprious linting errors due to Svelte not recognizing custom elements -->
-<!-- svelte-ignore a11y-no-static-element-interactions -->
+<!-- svelte-ignore a11y_no_static_element_interactions -->
 <ic-button
-	on:click
-	on:keydown
+	{onclick}
+	{onkeydown}
 	{disabled}
 	{type}
 	{size}

--- a/src/lib/components/ui/Button.svelte
+++ b/src/lib/components/ui/Button.svelte
@@ -5,7 +5,7 @@
 	import clsx from 'clsx';
 	import type { EventHandler } from 'svelte/elements';
 
-	interface Props {
+	interface ButtonProps {
 		className?: string;
 		label: string;
 		variant?: IcButtonVariants;
@@ -27,7 +27,7 @@
 		type = 'submit',
 		disabled,
 		ariaLabel
-	}: Props = $props();
+	}: ButtonProps = $props();
 </script>
 
 <!-- These seem to be suprious linting errors due to Svelte not recognizing custom elements -->

--- a/src/lib/components/ui/Button.svelte
+++ b/src/lib/components/ui/Button.svelte
@@ -3,9 +3,10 @@
 <script lang="ts">
 	import { type IcButtonTypes, type IcButtonVariants, type IcSizes } from '@ukic/web-components';
 	import clsx from 'clsx';
+	import type { Snippet } from 'svelte';
 	import type { EventHandler } from 'svelte/elements';
 
-	interface ButtonProps {
+	interface Props {
 		className?: string;
 		label: string;
 		variant?: IcButtonVariants;
@@ -15,11 +16,13 @@
 		ariaLabel?: string | undefined;
 		onclick?: EventHandler;
 		onkeydown?: EventHandler;
+		icon?: Snippet;
 	}
 
 	let {
 		onclick,
 		onkeydown,
+		icon,
 		className,
 		label,
 		variant = 'primary',
@@ -27,7 +30,7 @@
 		type = 'submit',
 		disabled,
 		ariaLabel
-	}: ButtonProps = $props();
+	}: Props = $props();
 </script>
 
 <!-- These seem to be suprious linting errors due to Svelte not recognizing custom elements -->
@@ -43,5 +46,8 @@
 	aria-label={ariaLabel}
 >
 	{label}
-	<slot name="icon" />
+
+	{#if icon}
+		<i slot="icon">{@render icon()}</i>
+	{/if}
 </ic-button>

--- a/src/lib/components/ui/HighlightedText.spec.ts
+++ b/src/lib/components/ui/HighlightedText.spec.ts
@@ -13,7 +13,9 @@ describe('HighlightedText component', () => {
 
 		beforeEach(async () => {
 			render(HighlightedText, { text: exampleText, highlight: 'quick' });
-			highlightedText = screen.getByText('The', { exact: false });
+			highlightedText = screen.getByText('The', {
+				exact: false
+			});
 		});
 
 		it('Creates a text element', () => {
@@ -21,7 +23,9 @@ describe('HighlightedText component', () => {
 		});
 
 		it('Applies mark tags to case insensitive highlight text', () => {
-			expect(highlightedText.innerHTML).toContain(
+			// See https://svelte.dev/docs/svelte/v5-migration-guide#Other-breaking-changes-Hydration-works-differently
+			// Svelte 5 uses comments to make hydration work. Removing these in the interest of making the test more readable.
+			expect(highlightedText.innerHTML.replaceAll('<!---->', '')).toContain(
 				'The <mark>Quick</mark> Brown Fox Jumps <mark>Quick</mark>ly Over The Lazy Dog'
 			);
 		});

--- a/src/lib/components/ui/PageHeader.svelte
+++ b/src/lib/components/ui/PageHeader.svelte
@@ -30,6 +30,6 @@
 			label={tab.title}
 			href={`${base}${tab.href}`}
 			selected={window.location.toString().endsWith(tab.href)}
-		/>
+		></ic-navigation-item>
 	{/each}
 </ic-page-header>

--- a/src/lib/components/ui/Pagination.svelte
+++ b/src/lib/components/ui/Pagination.svelte
@@ -48,5 +48,5 @@
 		disabled={totalPages < 1}
 		current-page={pageNumber + 1}
 		on:icPageChange={handlePageChange}
-	/>
+	></ic-pagination>
 </div>

--- a/src/lib/components/ui/Switch.spec.ts
+++ b/src/lib/components/ui/Switch.spec.ts
@@ -25,11 +25,8 @@ describe('Switch component', () => {
 
 	it('dispatches a change event when clicked', async () => {
 		const user = userEvent.setup();
-
-		const component = (await render(Switch, exampleProps)).component as Switch;
 		const changed = vi.fn();
-		component.$on('change', changed);
-
+		await render(Switch, { ...exampleProps, onchange: changed });
 		const theSwitch = await screen.findByShadowLabelText(exampleProps.label);
 		await user.click(theSwitch);
 

--- a/src/lib/components/ui/Switch.spec.ts
+++ b/src/lib/components/ui/Switch.spec.ts
@@ -28,8 +28,13 @@ describe('Switch component', () => {
 		const changed = vi.fn();
 		await render(Switch, { ...exampleProps, onchange: changed });
 		const theSwitch = await screen.findByShadowLabelText(exampleProps.label);
-		await user.click(theSwitch);
 
-		expect(changed).toHaveBeenCalledOnce();
+		// Toggle the switch a few times, make sure it's turning off and on
+		await user.click(theSwitch);
+		expect(changed).toHaveBeenCalledWith({ checked: true });
+		await user.click(theSwitch);
+		expect(changed).toHaveBeenCalledWith({ checked: false });
+		await user.click(theSwitch);
+		expect(changed).toHaveBeenCalledWith({ checked: true });
 	});
 });

--- a/src/lib/components/ui/Switch.svelte
+++ b/src/lib/components/ui/Switch.svelte
@@ -2,18 +2,19 @@
 
 <script lang="ts">
 	import type { IcSwitchChangeEventDetail } from '@ukic/web-components';
-	import { createEventDispatcher } from 'svelte';
 
-	export let label: string;
-	export let helperText: string;
-	export let checked: boolean;
+	interface Props {
+		onchange: ({ checked }: { checked: boolean }) => void;
+		label: string;
+		helperText: string;
+		checked: boolean;
+	}
 
-	// Events
-	const dispatch = createEventDispatcher();
+	let { label, helperText, checked = $bindable(), onchange }: Props = $props();
 
 	function handleInput(e: CustomEvent<IcSwitchChangeEventDetail>) {
 		checked = e.detail.checked;
-		dispatch('change', { checked });
+		onchange({ checked });
 	}
 </script>
 

--- a/src/lib/components/ui/Switch.svelte
+++ b/src/lib/components/ui/Switch.svelte
@@ -23,5 +23,5 @@
 	{label}
 	helper-text={helperText}
 	{checked}
-	on:icChange={handleInput}
-/>
+	onicChange={handleInput}
+></ic-switch>

--- a/src/lib/components/ui/TextField.svelte
+++ b/src/lib/components/ui/TextField.svelte
@@ -54,4 +54,4 @@
 	helper-text={helperText}
 	validation-status={validationError ? 'error' : ''}
 	validation-text={validationErrorMessage}
-/>
+></ic-text-field>

--- a/src/lib/components/ui/tabs/Tab.spec.ts
+++ b/src/lib/components/ui/tabs/Tab.spec.ts
@@ -8,11 +8,12 @@ import userEvent from '@testing-library/user-event';
 
 describe('Tab component', () => {
 	describe('default behavior', () => {
-		let component: Tab;
 		let tab: HTMLElement;
+		let clicked: typeof vi.fn;
 
 		beforeEach(async () => {
-			component = (await render(Tab, { title: 'Foo' })).component as Tab;
+			clicked = vi.fn();
+			await render(Tab, { title: 'Foo', onclick: clicked });
 			tab = await screen.findByRole('tab', { name: 'Foo' });
 		});
 
@@ -22,11 +23,7 @@ describe('Tab component', () => {
 
 		it('dispatches a click event when clicked', async () => {
 			const user = userEvent.setup();
-
-			const clicked = vi.fn();
-			component.$on('click', clicked);
 			await user.click(tab);
-
 			expect(clicked).toHaveBeenCalledOnce();
 		});
 	});

--- a/src/lib/components/ui/tabs/Tab.svelte
+++ b/src/lib/components/ui/tabs/Tab.svelte
@@ -2,20 +2,30 @@
 
 <script lang="ts">
 	import clsx from 'clsx';
-	export let title: string;
-	export let disabled = false;
-	export let selected = false;
+	import type { EventHandler } from 'svelte/elements';
+
+	interface Props {
+		title: string;
+		disabled?: boolean;
+		selected?: boolean;
+		onclick?: EventHandler;
+		onkeyup?: EventHandler;
+	}
+
+	let { title, onclick, onkeyup, disabled = false, selected = false }: Props = $props();
 </script>
 
 <!-- These seem to be suprious linting errors due to Svelte not recognizing custom elements -->
-<!-- svelte-ignore a11y-no-static-element-interactions -->
+<!-- svelte-ignore a11y_no_static_element_interactions -->
 <ic-tab
-	on:click
-	on:keyup
+	{onclick}
+	{onkeyup}
 	{disabled}
 	{selected}
 	class={clsx(
 		'border-b-4 border-b-transparent aria-selected:border-b-icds-action visible',
 		disabled && 'pointer-events-none text-gray-300'
-	)}>{title}</ic-tab
+	)}
 >
+	{title}
+</ic-tab>

--- a/src/lib/components/views/PrefixBrowserView.svelte
+++ b/src/lib/components/views/PrefixBrowserView.svelte
@@ -54,7 +54,7 @@
 							ariaLabel={`Add ${prefix.label}`}
 							variant="tertiary"
 							disabled={document.toLowerCase().includes(formatPrefix(prefix).toLowerCase())}
-							on:click={() => handleAddPrefix(prefix)}
+							onclick={() => handleAddPrefix(prefix)}
 						/>
 					</div>
 				</TableData>

--- a/src/lib/components/views/forms/LocalSourceForm.svelte
+++ b/src/lib/components/views/forms/LocalSourceForm.svelte
@@ -72,13 +72,7 @@
 		<Button label="Submit" type="submit" />
 
 		{#if source.id.length}
-			<Button
-				label="Remove Source"
-				variant="destructive"
-				type="reset"
-				on:keyup
-				on:click={handleRemove}
-			/>
+			<Button label="Remove Source" variant="destructive" type="reset" onclick={handleRemove} />
 		{/if}
 		<Link htmlClass="block mt-2" href="/sources">Back to Sources</Link>
 	</div>

--- a/src/lib/components/views/forms/RemoteSourceForm.svelte
+++ b/src/lib/components/views/forms/RemoteSourceForm.svelte
@@ -90,7 +90,7 @@
 		<Button label="Submit" type="submit" />
 
 		{#if source.id.length}
-			<Button label="Remove Source" variant="destructive" type="reset" on:click={handleRemove} />
+			<Button label="Remove Source" variant="destructive" type="reset" onclick={handleRemove} />
 		{/if}
 		<Link htmlClass="block mt-2" href="/sources">Back to Sources</Link>
 	</div>

--- a/src/lib/components/views/quadsView/QuadsGraph.svelte
+++ b/src/lib/components/views/quadsView/QuadsGraph.svelte
@@ -58,15 +58,15 @@
 </script>
 
 <div class="border p-2 my-4">
-	<Button label="Zoom In" size="small" variant="tertiary" on:click={() => handleZoom(0.1)}>
+	<Button label="Zoom In" size="small" variant="tertiary" onclick={() => handleZoom(0.1)}>
 		<i slot="icon"><MagnifyPlus /></i>
 	</Button>
 
-	<Button label="Zoom Out" size="small" variant="tertiary" on:click={() => handleZoom(-0.1)}>
+	<Button label="Zoom Out" size="small" variant="tertiary" onclick={() => handleZoom(-0.1)}>
 		<i slot="icon"><MagnifyMinus /></i>
 	</Button>
 
-	<Button label="Zoom to fit" size="small" variant="tertiary" on:click={resetZoom}>
+	<Button label="Zoom to fit" size="small" variant="tertiary" onclick={resetZoom}>
 		<i slot="icon"><MagnifyFit /></i>
 	</Button>
 	<div class="h-screen block" bind:this={container} />

--- a/src/lib/components/views/quadsView/QuadsGraph.svelte
+++ b/src/lib/components/views/quadsView/QuadsGraph.svelte
@@ -69,5 +69,5 @@
 	<Button label="Zoom to fit" size="small" variant="tertiary" onclick={resetZoom}>
 		<i slot="icon"><MagnifyFit /></i>
 	</Button>
-	<div class="h-screen block" bind:this={container} />
+	<div class="h-screen block" bind:this={container}></div>
 </div>

--- a/src/lib/components/views/quadsView/QuadsGraph.svelte
+++ b/src/lib/components/views/quadsView/QuadsGraph.svelte
@@ -59,15 +59,15 @@
 
 <div class="border p-2 my-4">
 	<Button label="Zoom In" size="small" variant="tertiary" onclick={() => handleZoom(0.1)}>
-		<i slot="icon"><MagnifyPlus /></i>
+		{#snippet icon()}<MagnifyPlus />{/snippet}
 	</Button>
 
 	<Button label="Zoom Out" size="small" variant="tertiary" onclick={() => handleZoom(-0.1)}>
-		<i slot="icon"><MagnifyMinus /></i>
+		{#snippet icon()}<MagnifyMinus />{/snippet}
 	</Button>
 
 	<Button label="Zoom to fit" size="small" variant="tertiary" onclick={resetZoom}>
-		<i slot="icon"><MagnifyFit /></i>
+		{#snippet icon()}<MagnifyFit />{/snippet}
 	</Button>
 	<div class="h-screen block" bind:this={container}></div>
 </div>

--- a/src/lib/components/views/quadsView/QuadsTurtle.svelte
+++ b/src/lib/components/views/quadsView/QuadsTurtle.svelte
@@ -23,4 +23,4 @@
 	label="RDF Document"
 	rows={30}
 	helper-text="RDF document in Turtle (ttl) format."
-/>
+></ic-text-field>

--- a/src/lib/components/views/quadsView/QuadsView.svelte
+++ b/src/lib/components/views/quadsView/QuadsView.svelte
@@ -41,7 +41,7 @@
 			label="Table View"
 			disabled={viewType == 'table'}
 			variant="secondary"
-			on:click={() => (viewType = 'table')}
+			onclick={() => (viewType = 'table')}
 		>
 			<i slot="icon"><Table /></i>
 		</Button>
@@ -50,7 +50,7 @@
 			label="Graph View"
 			variant="secondary"
 			disabled={viewType == 'graph' || inFlight}
-			on:click={() => (viewType = 'graph')}
+			onclick={() => (viewType = 'graph')}
 		>
 			<i slot="icon"><Graph /></i>
 		</Button>
@@ -59,7 +59,7 @@
 			label="TTL View"
 			variant="secondary"
 			disabled={viewType == 'ttl'}
-			on:click={() => (viewType = 'ttl')}
+			onclick={() => (viewType = 'ttl')}
 		>
 			<i slot="icon"><Turtle /></i>
 		</Button>

--- a/src/lib/components/views/quadsView/QuadsView.svelte
+++ b/src/lib/components/views/quadsView/QuadsView.svelte
@@ -43,7 +43,7 @@
 			variant="secondary"
 			onclick={() => (viewType = 'table')}
 		>
-			<i slot="icon"><Table /></i>
+			{#snippet icon()}<Table />{/snippet}
 		</Button>
 
 		<Button
@@ -52,7 +52,7 @@
 			disabled={viewType == 'graph' || inFlight}
 			onclick={() => (viewType = 'graph')}
 		>
-			<i slot="icon"><Graph /></i>
+			{#snippet icon()}<Graph />{/snippet}
 		</Button>
 
 		<Button
@@ -61,7 +61,7 @@
 			disabled={viewType == 'ttl'}
 			onclick={() => (viewType = 'ttl')}
 		>
-			<i slot="icon"><Turtle /></i>
+			{#snippet icon()}<Turtle />{/snippet}
 		</Button>
 	</div>
 

--- a/src/lib/components/views/sources/CatalogList.svelte
+++ b/src/lib/components/views/sources/CatalogList.svelte
@@ -66,7 +66,7 @@
 							variant="primary"
 							disabled={sourceUrls.includes(url)}
 							ariaLabel={`Add ${name} to active data sources`}
-							on:click={() => handleClick({ url, name, description })}
+							onclick={() => handleClick({ url, name, description })}
 						/>
 					</div>
 				</TableData>

--- a/src/lib/components/views/sources/LocalSourceCard.svelte
+++ b/src/lib/components/views/sources/LocalSourceCard.svelte
@@ -47,7 +47,7 @@
 			label={enabled ? 'Disable' : 'Enable'}
 			ariaLabel={`${enabled ? 'Disable' : 'Enable'} source ${source.name}`}
 			variant="secondary"
-			on:click={() => localSources.toggleEnabled(id)}
+			onclick={() => localSources.toggleEnabled(id)}
 		/>
 	</div>
 </SourceCard>

--- a/src/lib/components/views/sources/RemoteSourceCard.svelte
+++ b/src/lib/components/views/sources/RemoteSourceCard.svelte
@@ -44,7 +44,7 @@
 			label={enabled ? 'Disable' : 'Enable'}
 			ariaLabel={`${enabled ? 'Disable' : 'Enable'} source ${source.name}`}
 			variant="secondary"
-			on:click={() => remoteSources.toggleEnabled(id)}
+			onclick={() => remoteSources.toggleEnabled(id)}
 		/>
 	</div>
 </SourceCard>

--- a/src/lib/components/views/sources/SourceCard.svelte
+++ b/src/lib/components/views/sources/SourceCard.svelte
@@ -21,7 +21,7 @@
 		small
 		label={enabled ? 'Enabled' : 'Disabled'}
 		status={enabled ? 'success' : 'warning'}
-	/>
+	></ic-status-tag>
 	<slot name="message" slot="message" />
 	<slot name="interaction-controls" slot="interaction-controls" />
 	<slot />

--- a/src/lib/components/views/sparql/SparqlPersistQuadResults.svelte
+++ b/src/lib/components/views/sparql/SparqlPersistQuadResults.svelte
@@ -45,7 +45,7 @@
 				placeholder="Select a local data source"
 				value={selectedSourceId}
 				on:icChange={handleSourceChange}
-			/>
+			></ic-select>
 
 			<div class="align-bottom inline">
 				<Button label="Persist" {disabled} onclick={handlePersist} />

--- a/src/lib/components/views/sparql/SparqlPersistQuadResults.svelte
+++ b/src/lib/components/views/sparql/SparqlPersistQuadResults.svelte
@@ -48,7 +48,7 @@
 			/>
 
 			<div class="align-bottom inline">
-				<Button label="Persist" {disabled} on:click={handlePersist} />
+				<Button label="Persist" {disabled} onclick={handlePersist} />
 			</div>
 
 			{#if persisted}

--- a/src/lib/components/views/sparql/SparqlQueryStatus.svelte
+++ b/src/lib/components/views/sparql/SparqlQueryStatus.svelte
@@ -28,7 +28,7 @@
 			size="small"
 			disabled={status != QueryStatus.Fetching}
 		>
-			<i slot="icon"><Stop /></i>
+			{#snippet icon()}<Stop />{/snippet}
 		</Button>
 	</dd>
 </dl>

--- a/src/lib/components/views/sparql/SparqlQueryStatus.svelte
+++ b/src/lib/components/views/sparql/SparqlQueryStatus.svelte
@@ -12,14 +12,14 @@
 	<dt class="inline-block font-bold mr-2 after:content-[':']">Query Status</dt>
 	<dd class="inline-block">
 		{#if status == QueryStatus.Fetching}
-			<ic-status-tag label="Fetching" small="true" status="warning" />
+			<ic-status-tag label="Fetching" small="true" status="warning"></ic-status-tag>
 			<LoadingSpinner />
 		{:else if status == QueryStatus.Done}
-			<ic-status-tag label="Complete" small="true" status="success" />
+			<ic-status-tag label="Complete" small="true" status="success"></ic-status-tag>
 		{:else if status == QueryStatus.Error}
-			<ic-status-tag label="Error" small="true" status="danger" />
+			<ic-status-tag label="Error" small="true" status="danger"></ic-status-tag>
 		{:else}
-			<ic-status-tag label={status} small="true" status="neutral" />
+			<ic-status-tag label={status} small="true" status="neutral"></ic-status-tag>
 		{/if}
 		<Button
 			label="Halt Query"

--- a/src/lib/components/views/sparql/SparqlQueryStatus.svelte
+++ b/src/lib/components/views/sparql/SparqlQueryStatus.svelte
@@ -23,7 +23,7 @@
 		{/if}
 		<Button
 			label="Halt Query"
-			on:click={onStop}
+			onclick={onStop}
 			variant="tertiary"
 			size="small"
 			disabled={status != QueryStatus.Fetching}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -13,14 +13,14 @@
 {#await defineCustomElements() then}
 	<div class="tracking-wide leading-relaxed">
 		<SkipToContent landmarkHref="#content" />
-		<ic-theme color="#0c857b" />
+		<ic-theme color="#0c857b"></ic-theme>
 		<main class="sm:flex h-full">
 			<SideNav />
 			<div id="content" tabIndex="-1" class="flex-row flex-grow">
 				<div class="min-h-screen">
 					<slot />
 				</div>
-				<ic-back-to-top target="main" variant={isSmall ? 'icon' : 'default'} />
+				<ic-back-to-top target="main" variant={isSmall ? 'icon' : 'default'}></ic-back-to-top>
 				<Footer />
 			</div>
 		</main>

--- a/src/routes/logs/+page.svelte
+++ b/src/routes/logs/+page.svelte
@@ -10,7 +10,7 @@
 <PageView heading="Logs" subheading="Most recent system logs">
 	<Button
 		label="Clear Logs"
-		on:click={logger.clear}
+		onclick={logger.clear}
 		disabled={!$recentLogs.length}
 		variant="destructive"
 	/>

--- a/src/routes/logs/+page.svelte
+++ b/src/routes/logs/+page.svelte
@@ -30,7 +30,7 @@
 						</p>
 						{#if log.metadata}
 							<SummaryDetail summaryText="Details">
-								<code class="block border mt-2 bg-white p-2 w-full"
+								<code data-testid="log-details" class="block border mt-2 bg-white p-2 w-full"
 									>{JSON.stringify(log.metadata).trim()}</code
 								>
 							</SummaryDetail>

--- a/src/routes/settings/+page.svelte
+++ b/src/routes/settings/+page.svelte
@@ -36,7 +36,7 @@
 			label="Show Quads"
 			helperText="Display full quads rather than triples when browsing data."
 			bind:checked={dirtySettings.general__showQuads}
-			on:change={() => (dirty = true)}
+			onchange={() => (dirty = true)}
 		/>
 
 		<div class="mt-4">

--- a/src/routes/settings/prefixes/+page.svelte
+++ b/src/routes/settings/prefixes/+page.svelte
@@ -88,7 +88,7 @@
 		{...restoreDefaultButtonLabel}
 		className="my-4"
 		variant="destructive"
-		on:click={prefixes.restore}
+		onclick={prefixes.restore}
 	/>
 
 	<Table>
@@ -109,7 +109,7 @@
 								label="Remove"
 								ariaLabel={`Remove ${prefix.label}`}
 								variant="destructive"
-								on:click={() => removePrefix(prefix)}
+								onclick={() => removePrefix(prefix)}
 								size="small"
 							/>
 						</div>
@@ -123,6 +123,6 @@
 		{...restoreDefaultButtonLabel}
 		className="my-4"
 		variant="destructive"
-		on:click={prefixes.restore}
+		onclick={prefixes.restore}
 	/>
 </PageView>

--- a/src/routes/settings/terms/+page.svelte
+++ b/src/routes/settings/terms/+page.svelte
@@ -76,21 +76,21 @@
 			label="Show Node Type"
 			helperText="Whether to display the node-type (e.g. NamedNode, Literal) alongside terms."
 			bind:checked={dirtySettings.term__showNodeType}
-			on:change={() => (dirty = true)}
+			onchange={() => (dirty = true)}
 		/>
 
 		<Switch
 			label="Abbreviate Common Prefixes"
 			helperText="Whether to abbreviate commonly used prefixes such as OWL, RDF and FOAF."
 			bind:checked={dirtySettings.term__abbreviateCommonPrefixes}
-			on:change={() => (dirty = true)}
+			onchange={() => (dirty = true)}
 		/>
 
 		<Switch
 			label="Show Language Tag"
 			helperText="Whether to show the language tag on literals."
 			bind:checked={dirtySettings.term__showLanguageTag}
-			on:change={() => (dirty = true)}
+			onchange={() => (dirty = true)}
 		/>
 		<div class="mt-4">
 			<Button label="Apply" type="submit" disabled={!dirty} />

--- a/src/routes/sources/+page.svelte
+++ b/src/routes/sources/+page.svelte
@@ -30,21 +30,20 @@
 			label="Enable all sources"
 			variant="secondary"
 			disabled={!sourcesExist}
-			on:click={() => toggleAll(true)}
+			onclick={() => toggleAll(true)}
 		/>
 
 		<Button
 			label="Disable all sources"
 			disabled={!sourcesExist}
-			on:click={() => toggleAll(false)}
+			onclick={() => toggleAll(false)}
 			variant="secondary"
 		/>
 
 		<Button
 			label="Remove all sources"
 			disabled={!sourcesExist}
-			on:keyup
-			on:click={removeAll}
+			onclick={removeAll}
 			variant="destructive"
 		/>
 	</div>

--- a/src/routes/sources/[id]/+page.svelte
+++ b/src/routes/sources/[id]/+page.svelte
@@ -47,23 +47,23 @@
 		<svelte:fragment slot="panels">
 			<TabPanel>
 				<ic-data-entity heading="Source Detail">
-					<ic-data-row label="ID" value={source.id} />
-					<ic-data-row label="Name" value={source.name} />
+					<ic-data-row label="ID" value={source.id}></ic-data-row>
+					<ic-data-row label="Name" value={source.name}></ic-data-row>
 					<ic-data-row
 						label="Description"
 						value={source.description.length ? source.description : 'N/A'}
-					/>
+					></ic-data-row>
 					<ic-data-row label="Enabled">
 						<ic-status-tag
 							slot="value"
 							small
 							label={source.enabled ? 'Enabled' : 'Disabled'}
 							status={source.enabled ? 'success' : 'warning'}
-						/>
+						></ic-status-tag>
 					</ic-data-row>
 
 					{#if source.type == 'REMOTE'}
-						<ic-data-row label="URL" value={source.url} />
+						<ic-data-row label="URL" value={source.url}></ic-data-row>
 					{/if}
 				</ic-data-entity>
 

--- a/src/routes/sources/local/[id]/import/+page.svelte
+++ b/src/routes/sources/local/[id]/import/+page.svelte
@@ -28,10 +28,10 @@
 		};
 	};
 
-	enum LocalDataSourceImportTab {
-		Document = 0,
-		PrefixBrowser = 1
-	}
+	const LocalDataSourceImportTab = {
+		Document: 0,
+		PrefixBrowser: 1
+	};
 
 	// State
 	let document = '';

--- a/src/routes/sources/local/[id]/import/+page.svelte
+++ b/src/routes/sources/local/[id]/import/+page.svelte
@@ -93,7 +93,7 @@
 		on:icChange={handleImportTypeChanged}
 		label="Import format"
 		options={Object.entries(imports).map(([value, { label }]) => ({ label, value }))}
-	/>
+	></ic-select>
 
 	<TabNavigation bind:selectedTabIndex>
 		<Tab title="Document" />

--- a/src/routes/sparql-ui/+page.svelte
+++ b/src/routes/sparql-ui/+page.svelte
@@ -10,11 +10,11 @@
 	import { validateSparql } from '$lib/querying/sparqlUtils';
 
 	// We need to change tabs programatically, therefore they need to be given explicit IDs.
-	enum SparqlUiTab {
-		QueryBuilder = 0,
-		Results = 1,
-		PrefixBrowser = 2
-	}
+	const SparqlUiTab = {
+		QueryBuilder: 0,
+		Results: 1,
+		PrefixBrowser: 2
+	};
 
 	// State
 	let sparqlQuery = '';

--- a/src/routes/sparql-ui/+page.svelte
+++ b/src/routes/sparql-ui/+page.svelte
@@ -71,7 +71,7 @@
 					label="Select pre-build query"
 					full-width
 					options={exampleQueries.map((ex) => ({ label: ex.queryName, value: ex.query }))}
-				/>
+				></ic-select>
 
 				<form on:submit|preventDefault={handleSubmit}>
 					{#if sparqlParseError}

--- a/src/routes/sparql-ui/+page.svelte
+++ b/src/routes/sparql-ui/+page.svelte
@@ -90,7 +90,7 @@
 					/>
 
 					<Button label="Submit" type="submit" disabled={sparqlQuery.length == 0} />
-					<Button label="Reset" type="reset" on:click={handleFormReset} variant="destructive" />
+					<Button label="Reset" type="reset" onclick={handleFormReset} variant="destructive" />
 				</form>
 			</TabPanel>
 			<TabPanel>

--- a/test/helpers/render.ts
+++ b/test/helpers/render.ts
@@ -1,7 +1,7 @@
 /* (c) Crown Copyright GCHQ */
 
 import { render as originalRender, waitFor } from '@testing-library/svelte';
-import type { SvelteComponent } from 'svelte';
+import type { Component } from 'svelte';
 import { expect } from 'vitest';
 
 /**
@@ -29,7 +29,8 @@ import { expect } from 'vitest';
  */
 
 const waitForHydration = (fn: typeof originalRender) => {
-	return async (...args: Parameters<typeof originalRender<SvelteComponent>>) => {
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	return async (...args: Parameters<typeof originalRender<Component<any, any, string>>>) => {
 		let appReadyCount = false;
 
 		window.addEventListener('appload', () => {

--- a/test/helpers/render.ts
+++ b/test/helpers/render.ts
@@ -1,6 +1,7 @@
 /* (c) Crown Copyright GCHQ */
 
 import { render as originalRender, waitFor } from '@testing-library/svelte';
+import type { SvelteComponent } from 'svelte';
 import { expect } from 'vitest';
 
 /**
@@ -27,20 +28,15 @@ import { expect } from 'vitest';
  * @returns {async fn} an asynchronous version of the passed in function that waits for hydration.
  */
 
-const waitForHydration = <
-	T extends Parameters<typeof originalRender>,
-	U extends ReturnType<typeof originalRender>
->(
-	fn: (...args: T) => U
-) => {
-	return async (...args: T): Promise<U> => {
+const waitForHydration = (fn: typeof originalRender) => {
+	return async (...args: Parameters<typeof originalRender<SvelteComponent>>) => {
 		let appReadyCount = false;
 
 		window.addEventListener('appload', () => {
 			appReadyCount = true;
 		});
 
-		const view = fn(...(args as T));
+		const view = fn(...args);
 		await waitFor(() => expect(document.body.innerHTML.length).toBeGreaterThan(0));
 		await waitFor(() => expect(appReadyCount).toBeTruthy(), {
 			timeout: 100000,
@@ -58,7 +54,4 @@ export const render = originalRender;
 // try to use this on tests where there is no ICDS component being used, your test will time out (because
 // the `appload` event will never be emitted)
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const hydratedRender = waitForHydration((component, options?: any, renderOptions?) =>
-	originalRender(component, options, renderOptions)
-);
+export const hydratedRender = waitForHydration(originalRender);

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,13 +2,14 @@ import { configDefaults, defineConfig } from 'vitest/config';
 import { fileURLToPath } from 'url';
 import { readFileSync } from 'fs';
 import { sveltekit } from '@sveltejs/kit/vite';
+import { svelteTesting } from '@testing-library/svelte/vite';
 
 const file = fileURLToPath(new URL('package.json', import.meta.url));
 const json = readFileSync(file, 'utf8');
 const pkg = JSON.parse(json);
 
 export default defineConfig({
-	plugins: [sveltekit()],
+	plugins: [sveltekit(), svelteTesting()],
 	define: {
 		PUBLIC_VERSION: JSON.stringify(pkg.version)
 	},


### PR DESCRIPTION
Upgrades both Svelte and Vite to latest major versions.

Svelte is partially backwards compatible (for now) - this PR only addresses those issues that were mandatory to upgrade or that were causing warnings. There are still lots of improvements that could be made in order to fully realise the benefits of the upgrade.