### PR TITLE
Update code to use new Svelte5 syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Copyright 2024 [Crown Copyright](https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/)
 
-LD-Explorer is a prototype user interface built upon the [Comunica graph querying framework](https://comunica.dev/) that can be used for exploring linked data resources directly in the browser. We have found that this tool helps to better demonstrate the value and purpose of linked data to newcomers, and increases the speed at which experiments/ideas can be created and tested. We are open sourcing this software to fill what we believe is a software gap in the linked data linked data space and to hopefully encourage its growth into a valuable community tool.
+LD-Explorer is a prototype user interface built upon the [Comunica graph querying framework](https://comunica.dev/) that can be used for exploring linked data resources directly in the browser. We have found that this tool helps to better demonstrate the value and purpose of linked data to newcomers, and increases the speed at which experiments/ideas can be created and tested. We are open sourcing this software to fill what we believe is a software gap in the linked data ecosystem and to hopefully encourage its growth into a valuable community tool.
 
 LD Explorer runs entirely in the browser and is hosted at https://gchq.github.io/LD-Explorer/
 

--- a/src/lib/components/helpers/ViewportHelper.svelte
+++ b/src/lib/components/helpers/ViewportHelper.svelte
@@ -14,16 +14,20 @@
 	// it means to be small)
 	//
 
+	interface Props {
+		isSmall?: boolean | undefined;
+		isExtraSmall?: boolean | undefined;
+	}
+
 	// viewport sizes based on breakpoints (see handleResize below)
-	export let isSmall: boolean | undefined = undefined;
-	export let isExtraSmall: boolean | undefined = undefined;
+	let { isSmall = $bindable(), isExtraSmall = $bindable() }: Props = $props();
 
 	// Breakpoints
 	const mdBreakpoint = 768;
 	const smBreakpoint = 576;
 
 	// State
-	let innerWidth: number;
+	let innerWidth: number = $state(0);
 
 	// Handlers
 	const handleResize = () => {

--- a/src/lib/components/layout/HtmlHead.svelte
+++ b/src/lib/components/layout/HtmlHead.svelte
@@ -1,7 +1,11 @@
 <!-- (c) Crown Copyright GCHQ -->
 
 <script lang="ts">
-	export let title: string;
+	interface Props {
+		title: string;
+	}
+
+	let { title }: Props = $props();
 </script>
 
 <svelte:head>

--- a/src/lib/components/layout/homepage/ProductFeature.svelte
+++ b/src/lib/components/layout/homepage/ProductFeature.svelte
@@ -6,7 +6,7 @@
 	import type { Snippet } from 'svelte';
 
 	interface Props {
-		children: Snippet;
+		children?: Snippet;
 		title: string;
 		screenshot: string;
 		screenshotAlt: string;
@@ -23,7 +23,7 @@
 >
 	<div class="lg:p-4 lg:w-1/2">
 		<ic-typography variant="h4" class="mb-4"><h3>{title}</h3></ic-typography>
-		{@render children()}
+		{@render children?.()}
 	</div>
 	<div class="lg:p-4 lg:w-1/2">
 		<img

--- a/src/lib/components/layout/homepage/ProductFeature.svelte
+++ b/src/lib/components/layout/homepage/ProductFeature.svelte
@@ -3,12 +3,18 @@
 <script lang="ts">
 	import { base } from '$app/paths';
 	import { clsx } from 'clsx';
+	import type { Snippet } from 'svelte';
+
+	interface Props {
+		children: Snippet;
+		title: string;
+		screenshot: string;
+		screenshotAlt: string;
+		align?: 'left' | 'right';
+	}
 
 	// Props
-	export let title: string;
-	export let screenshot: string;
-	export let screenshotAlt: string;
-	export let align: 'left' | 'right' = 'left';
+	let { children, title, screenshot, screenshotAlt, align = 'left' }: Props = $props();
 </script>
 
 <ic-section-container
@@ -17,7 +23,7 @@
 >
 	<div class="lg:p-4 lg:w-1/2">
 		<ic-typography variant="h4" class="mb-4"><h3>{title}</h3></ic-typography>
-		<slot />
+		{@render children()}
 	</div>
 	<div class="lg:p-4 lg:w-1/2">
 		<img

--- a/src/lib/components/layout/nav/SideNav.svelte
+++ b/src/lib/components/layout/nav/SideNav.svelte
@@ -89,7 +89,6 @@
 
 <!-- Include this as ic-side-navigation does not include an H1 (oversight?) -->
 <ViewportHelper bind:isSmall />
-
 <ic-side-navigation
 	app-title="LD-Explorer"
 	version={`v${version}`}

--- a/src/lib/components/layout/nav/SubNavItem.svelte
+++ b/src/lib/components/layout/nav/SubNavItem.svelte
@@ -5,9 +5,13 @@
 	import clsx from 'clsx';
 
 	// Props
-	export let title: string;
-	export let href: string;
-	export let selected = false;
+	interface Props {
+		title: string;
+		href: string;
+		selected?: boolean;
+	}
+
+	let { title, href, selected = false }: Props = $props();
 </script>
 
 <li class="hover:bg-gray-100">

--- a/src/lib/components/layout/nav/SubNavLayout.svelte
+++ b/src/lib/components/layout/nav/SubNavLayout.svelte
@@ -4,12 +4,18 @@
 	import { SubNav, SubNavItem } from '.';
 	import { page } from '$app/stores';
 	import { shouldHighlightSubNav } from '$lib/util/nav.utils';
+	import type { Snippet } from 'svelte';
 
-	export let navItems: {
-		title: string;
-		href: string;
-		match?: RegExp;
-	}[];
+	interface Props {
+		children?: Snippet;
+		navItems: {
+			title: string;
+			href: string;
+			match?: RegExp;
+		}[];
+	}
+
+	let { children, navItems }: Props = $props();
 </script>
 
 <div class="grid grid-cols-12">
@@ -25,6 +31,6 @@
 		</SubNav>
 	</div>
 	<div class="col-span-12 md:col-span-9 lg:col-span-10 pb-16">
-		<slot />
+		{@render children?.()}
 	</div>
 </div>

--- a/src/lib/components/ui/Alert.svelte
+++ b/src/lib/components/ui/Alert.svelte
@@ -3,10 +3,14 @@
 <script lang="ts">
 	import type { IcStatusVariants } from '@ukic/web-components';
 
-	export let heading: string;
-	export let message: string;
-	export let variant: IcStatusVariants = 'neutral';
-	export let dismissible = false;
+	interface Props {
+		heading: string;
+		message: string;
+		variant?: IcStatusVariants;
+		dismissible?: boolean;
+	}
+
+	let { heading, message, variant = 'neutral', dismissible = false }: Props = $props();
 </script>
 
 <div>

--- a/src/lib/components/ui/Badge.svelte
+++ b/src/lib/components/ui/Badge.svelte
@@ -8,13 +8,25 @@
 		IcSizes
 	} from '@ukic/web-components';
 
-	export let type: IcBadgeTypes;
-	export let visible = true;
-	export let position: IcBadgePositions = 'far';
-	export let variant: IcBadgeVariants = 'neutral';
-	export let size: IcSizes = 'default';
-	export let textLabel: string | undefined = undefined;
-	export let ariaLabel: string | undefined = undefined;
+	interface Props {
+		type: IcBadgeTypes;
+		visible?: boolean;
+		position: IcBadgePositions;
+		variant: IcBadgeVariants;
+		size: IcSizes;
+		textLabel?: string;
+		ariaLabel?: string;
+	}
+
+	let {
+		type,
+		visible = true,
+		position = 'far',
+		variant = 'neutral',
+		size = 'default',
+		textLabel,
+		ariaLabel
+	}: Props = $props();
 </script>
 
 <ic-badge

--- a/src/lib/components/ui/Badge.svelte
+++ b/src/lib/components/ui/Badge.svelte
@@ -11,7 +11,7 @@
 	interface Props {
 		type: IcBadgeTypes;
 		visible?: boolean;
-		position: IcBadgePositions;
+		position?: IcBadgePositions;
 		variant: IcBadgeVariants;
 		size: IcSizes;
 		textLabel?: string;

--- a/src/lib/components/ui/ButtonLink.svelte
+++ b/src/lib/components/ui/ButtonLink.svelte
@@ -3,12 +3,27 @@
 <script lang="ts">
 	import type { IcButtonVariants, IcSizes } from '@ukic/web-components';
 	import { base } from '$app/paths';
-	export let label: string;
-	export let href: string;
-	export let external = false;
-	export let variant: IcButtonVariants = 'primary';
-	export let size: IcSizes = 'default';
-	export let ariaLabel: string | undefined = undefined;
+	import type { Snippet } from 'svelte';
+
+	interface Props {
+		icon?: Snippet;
+		label: string;
+		href: string;
+		external?: boolean;
+		variant?: IcButtonVariants;
+		size?: IcSizes;
+		ariaLabel?: string;
+	}
+
+	let {
+		icon,
+		label,
+		href,
+		external = false,
+		variant = 'primary',
+		size = 'default',
+		ariaLabel
+	}: Props = $props();
 
 	let relativeHref = href.startsWith('/') ? href.substring(1) : href;
 </script>
@@ -23,5 +38,8 @@
 	aria-label={ariaLabel}
 >
 	{label}
-	<slot name="icon" />
+
+	{#if icon}
+		<i slot="icon">{@render icon()}</i>
+	{/if}
 </ic-button>

--- a/src/lib/components/ui/CodeBlock.svelte
+++ b/src/lib/components/ui/CodeBlock.svelte
@@ -1,7 +1,10 @@
 <!-- (c) Crown Copyright GCHQ -->
 
 <script lang="ts">
-	export let code: string;
+	interface Props {
+		code: string;
+	}
+	let { code }: Props = $props();
 </script>
 
 <pre role="code" class="whitespace-pre bg-gray-100 p-4 my-2 overflow-x-scroll">{code}</pre>

--- a/src/lib/components/ui/FilterField.svelte
+++ b/src/lib/components/ui/FilterField.svelte
@@ -20,7 +20,7 @@
 	interface Props {
 		label: string;
 		value: string | number;
-		onInput: EventHandler;
+		onInput?: EventHandler;
 	}
 
 	let { onInput, label, value = $bindable() }: Props = $props();

--- a/src/lib/components/ui/FilterField.svelte
+++ b/src/lib/components/ui/FilterField.svelte
@@ -4,7 +4,7 @@
 	/**
 	 *
 	 * This is a hopefully temporary component created as a workaround for the lack of a viable
-	 * component in the ICDS component libary. The issues with using the provided comonent were
+	 * component in the ICDS component libary. The issues with using the provided component were
 	 * as follows:
 	 *
 	 * - I want an icon - the textfield icon currently has bugs.
@@ -15,12 +15,16 @@
 	 */
 	import { Filter } from '$lib/components/ui/icons';
 	import clsx from 'clsx';
+	import type { EventHandler } from 'svelte/elements';
 
-	// Required Props
-	export let label: string;
-	export let value: string | number;
+	interface Props {
+		label: string;
+		value: string | number;
+		onInput: EventHandler;
+	}
 
-	let hasFocus = false;
+	let { onInput, label, value = $bindable() }: Props = $props();
+	let hasFocus = $state(false);
 </script>
 
 <div
@@ -39,8 +43,8 @@
 		placeholder="Filter results"
 		class="px-2 outline-hidden flex-grow sm:w-72"
 		bind:value
-		on:input
-		on:focus={() => (hasFocus = true)}
-		on:focusout={() => (hasFocus = false)}
+		oninput={onInput}
+		onfocus={() => (hasFocus = true)}
+		onfocusout={() => (hasFocus = false)}
 	/>
 </div>

--- a/src/lib/components/ui/Heading.svelte
+++ b/src/lib/components/ui/Heading.svelte
@@ -1,14 +1,31 @@
 <!-- (c) Crown Copyright GCHQ -->
 
 <script lang="ts">
+	import type { Snippet } from 'svelte';
+
 	// Note that h1 is not a valid tag to pass in. This is because in ICDS' opinion
 	// there should only be one of these on the page, this helps to ensure that
 	// opinion is preserved.
-	export let id: string | undefined = undefined;
-	export let tag: 'h2' | 'h3' | 'h4' | 'h5' = 'h2';
-	export let variant: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' = tag;
-	export let text: string;
-	export let applyVerticalMargins = true;
+
+	interface Props {
+		beforeText?: Snippet;
+		afterText?: Snippet;
+		id?: string;
+		tag?: 'h2' | 'h3' | 'h4' | 'h5';
+		variant?: 'h1' | 'h2' | 'h3' | 'h4' | 'h5';
+		text: string;
+		applyVerticalMargins?: boolean;
+	}
+
+	let {
+		beforeText,
+		afterText,
+		id,
+		text,
+		tag = 'h2',
+		variant = tag,
+		applyVerticalMargins = true
+	}: Props = $props();
 </script>
 
 <ic-typography
@@ -18,8 +35,8 @@
 	apply-vertical-margins={applyVerticalMargins}
 >
 	<svelte:element this={tag}>
-		<slot name="before-text" />
+		{@render beforeText?.()}
 		{text}
-		<slot name="after-text" />
+		{@render afterText?.()}
 	</svelte:element>
 </ic-typography>

--- a/src/lib/components/ui/HighlightedText.svelte
+++ b/src/lib/components/ui/HighlightedText.svelte
@@ -1,18 +1,18 @@
 <!-- (c) Crown Copyright GCHQ -->
 
 <script lang="ts">
-	export let text: string;
-	export let highlight: string;
-
-	$: parts = text.split(new RegExp(`(${highlight || '?!'})`, 'i')).filter(Boolean);
-
-	function isTextToHighlight(compare: string) {
-		return compare.toLowerCase() === highlight.toLowerCase();
+	interface Props {
+		text: string;
+		highlight: string;
 	}
+
+	let { text, highlight }: Props = $props();
+
+	let parts = $derived(text.split(new RegExp(`(${highlight || '?!'})`, 'i')).filter(Boolean));
 </script>
 
 {#each parts as part}
-	{#if isTextToHighlight(part)}
+	{#if part.toLowerCase() === highlight.toLowerCase()}
 		<mark>{part}</mark>
 	{:else}
 		{part}

--- a/src/lib/components/ui/Link.svelte
+++ b/src/lib/components/ui/Link.svelte
@@ -3,10 +3,24 @@
 <script lang="ts">
 	import { base } from '$app/paths';
 	import clsx from 'clsx';
-	export let href: string;
-	export let htmlClass = '';
-	export let external = false;
-	export let inPage = false;
+	import type { Snippet } from 'svelte';
+
+	interface Props {
+		children: Snippet;
+		href: string;
+		htmlClass?: string;
+		external?: boolean;
+		inPage?: boolean;
+	}
+
+	let {
+		children,
+		href,
+		htmlClass = '',
+		external = false,
+		inPage = false,
+		...restOfProps
+	}: Props = $props();
 
 	// BasePath will contain a forward slash, so remove it if the user
 	// has passed one in.
@@ -23,10 +37,12 @@
 		target="_blank"
 		rel="noreferrer"
 		referrerpolicy="no-referrer"
-		{...$$restProps}><slot /></ic-link
+		{...restOfProps}
 	>
+		{@render children?.()}
+	</ic-link>
 {:else}
-	<ic-link class={classes} href={inPage ? href : `${base}/${relativeHref}`} show-icon={false}
-		><slot /></ic-link
-	>
+	<ic-link class={classes} href={inPage ? href : `${base}/${relativeHref}`} show-icon={false}>
+		{@render children?.()}
+	</ic-link>
 {/if}

--- a/src/lib/components/ui/PageHeader.svelte
+++ b/src/lib/components/ui/PageHeader.svelte
@@ -7,12 +7,15 @@
 
 	import clsx from 'clsx';
 
-	export let heading: string;
-	export let subheading: string;
-	export let tabs: RoutedTab<number>[] = [];
-	export let breakWords = false;
+	interface Props {
+		heading: string;
+		subheading: string;
+		tabs?: RoutedTab<number>[];
+		breakWords?: boolean;
+	}
 
-	let isSmall: boolean;
+	let { heading, subheading, tabs = [], breakWords = false }: Props = $props();
+	let isSmall: boolean = $state(false);
 </script>
 
 <ViewportHelper bind:isSmall />

--- a/src/lib/components/ui/Pagination.svelte
+++ b/src/lib/components/ui/Pagination.svelte
@@ -6,12 +6,23 @@
 	import { browser } from '$app/environment';
 	import clsx from 'clsx';
 
-	export let pageNumber: number;
-	export let totalPages: number;
-	export let bottom = false;
-	export let itemCount: number;
-	export let filterText = '';
-	export let includeFilter = false;
+	interface Props {
+		pageNumber: number;
+		totalPages: number;
+		bottom?: boolean;
+		itemCount: number;
+		filterText?: string;
+		includeFilter?: boolean;
+	}
+
+	let {
+		pageNumber,
+		totalPages,
+		itemCount,
+		bottom = false,
+		filterText = '',
+		includeFilter = false
+	}: Props = $props();
 
 	function handleFilterChange() {
 		pageNumber = 0;
@@ -31,7 +42,7 @@
 			<FilterField
 				label="Filter results by text"
 				bind:value={filterText}
-				on:input={handleFilterChange}
+				onInput={handleFilterChange}
 			/>
 		</div>
 
@@ -47,6 +58,6 @@
 		pages={totalPages}
 		disabled={totalPages < 1}
 		current-page={pageNumber + 1}
-		on:icPageChange={handlePageChange}
+		onicPageChange={handlePageChange}
 	></ic-pagination>
 </div>

--- a/src/lib/components/ui/Pagination.svelte
+++ b/src/lib/components/ui/Pagination.svelte
@@ -16,11 +16,11 @@
 	}
 
 	let {
-		pageNumber,
+		pageNumber = $bindable(),
 		totalPages,
 		itemCount,
 		bottom = false,
-		filterText = '',
+		filterText = $bindable(''),
 		includeFilter = false
 	}: Props = $props();
 

--- a/src/lib/components/ui/Paragraph.svelte
+++ b/src/lib/components/ui/Paragraph.svelte
@@ -2,13 +2,19 @@
 
 <script lang="ts">
 	import type { IcTypographyVariants } from '@ukic/web-components';
+	import type { Snippet } from 'svelte';
 
-	export let applyVerticalMargins = true;
-	export let variant: IcTypographyVariants = 'body';
+	interface Props {
+		children?: Snippet;
+		applyVerticalMargins?: boolean;
+		variant?: IcTypographyVariants;
+	}
+
+	let { applyVerticalMargins = true, variant = 'body', children }: Props = $props();
 </script>
 
 <ic-typography apply-vertical-margins={applyVerticalMargins} {variant}>
 	<p class="m-auto py-2">
-		<slot />
+		{@render children?.()}
 	</p>
 </ic-typography>

--- a/src/lib/components/ui/Section.svelte
+++ b/src/lib/components/ui/Section.svelte
@@ -2,10 +2,16 @@
 
 <script lang="ts">
 	import { clsx } from 'clsx';
-	export let aligned: 'center' | 'full-width' | 'left' = 'center';
-	export let applyBottomPadding = false;
+	import type { Snippet } from 'svelte';
+
+	interface Props {
+		aligned?: 'center' | 'full-width' | 'left';
+		applyBottomPadding?: boolean;
+		children?: Snippet;
+	}
+	let { aligned = 'center', applyBottomPadding = false, children }: Props = $props();
 </script>
 
-<ic-section-container {aligned} class={clsx('m-auto p-4 xl:px-6', applyBottomPadding && 'pb-20')}
-	><slot /></ic-section-container
->
+<ic-section-container {aligned} class={clsx('m-auto p-4 xl:px-6', applyBottomPadding && 'pb-20')}>
+	{@render children?.()}
+</ic-section-container>

--- a/src/lib/components/ui/SkipToContent.svelte
+++ b/src/lib/components/ui/SkipToContent.svelte
@@ -1,7 +1,10 @@
 <!-- (c) Crown Copyright GCHQ -->
 
 <script lang="ts">
-	export let landmarkHref: string;
+	interface Props {
+		landmarkHref: string;
+	}
+	let { landmarkHref }: Props = $props();
 </script>
 
 <a

--- a/src/lib/components/ui/SummaryDetail.svelte
+++ b/src/lib/components/ui/SummaryDetail.svelte
@@ -2,8 +2,13 @@
 
 <script lang="ts">
 	import clsx from 'clsx';
-	export let summaryText: string;
-	export let pad = true;
+	import type { Snippet } from 'svelte';
+	interface Props {
+		children?: Snippet;
+		summaryText: string;
+		pad?: boolean;
+	}
+	let { children, summaryText, pad = true }: Props = $props();
 </script>
 
 <details class={clsx('my-2')}>
@@ -13,6 +18,6 @@
 		)}>{summaryText}</summary
 	>
 	<div class={clsx(pad && 'py-2 px-4 break-words overflow-hidden')}>
-		<slot />
+		{@render children?.()}
 	</div>
 </details>

--- a/src/lib/components/ui/TextField.svelte
+++ b/src/lib/components/ui/TextField.svelte
@@ -4,44 +4,61 @@
 	import type { IcTextFieldTypes, IcValueEventDetail } from '@ukic/web-components';
 	import { ViewportHelper } from '$lib/components/helpers';
 	import { clsx } from 'clsx';
-	import { createEventDispatcher } from 'svelte';
 
-	// Required Props
-	export let label: string;
-	export let value: string | number;
+	// Props
 
-	// Events
-	const dispatch = createEventDispatcher();
+	interface Props {
+		// mandatory
+		label: string;
+		value: string | number;
 
-	// Optional Props
-	export let helperText = '';
-	export let inline = false;
-	export let placeholder: string | undefined = undefined;
-	export let readonly = false;
-	export let codeEditor = false;
-	export let type: IcTextFieldTypes = 'text';
-	export let required = false;
-	export let validationEnabled = false;
-	export let isValid = true;
-	export let validationErrorMessage = '';
-	export let rows: number | undefined = undefined;
+		// optional
+		oninput?: (e: CustomEvent<IcValueEventDetail>) => void;
+		helperText?: string;
+		inline?: boolean;
+		placeholder?: string;
+		readonly?: boolean;
+		codeEditor?: boolean;
+		type?: IcTextFieldTypes;
+		required?: boolean;
+		validationEnabled?: boolean;
+		isValid?: boolean;
+		validationErrorMessage?: string;
+		rows?: number;
+	}
+
+	let {
+		oninput,
+		label,
+		value = $bindable(),
+		helperText = '',
+		inline = false,
+		placeholder,
+		readonly = false,
+		codeEditor = false,
+		type = 'text',
+		required = false,
+		validationEnabled = false,
+		isValid = true,
+		validationErrorMessage = '',
+		rows
+	}: Props = $props();
 
 	// State
-	$: validationError = validationEnabled && !isValid;
+	let validationError = $derived(validationEnabled && !isValid);
+	let isSmall: boolean = $state(false);
 
 	// Events
 	function handleInput(e: CustomEvent<IcValueEventDetail>) {
 		value = e.detail.value;
-		dispatch('input', { e });
+		oninput?.(e);
 	}
-
-	let isSmall: boolean;
 </script>
 
 <ViewportHelper bind:isSmall />
 
 <ic-text-field
-	on:icInput={handleInput}
+	onicInput={handleInput}
 	{readonly}
 	{value}
 	{rows}

--- a/src/lib/components/ui/accordian/Accordian.svelte
+++ b/src/lib/components/ui/accordian/Accordian.svelte
@@ -1,11 +1,17 @@
 <!-- (c) Crown Copyright GCHQ -->
 
 <script lang="ts">
-	export let heading: string;
+	import type { Snippet } from 'svelte';
+
+	interface Props {
+		children: Snippet;
+		heading: string;
+	}
+	let { children, heading }: Props = $props();
 </script>
 
 <ic-accordion {heading} class="border-gray-400 first:border-t border-b">
 	<ic-typography variant="body">
-		<slot />
+		{@render children?.()}
 	</ic-typography>
 </ic-accordion>

--- a/src/lib/components/ui/accordian/AccordianGroup.svelte
+++ b/src/lib/components/ui/accordian/AccordianGroup.svelte
@@ -1,9 +1,15 @@
 <!-- (c) Crown Copyright GCHQ -->
 
 <script lang="ts">
-	export let groupTitle: string;
+	import type { Snippet } from 'svelte';
+
+	interface Props {
+		groupTitle: string;
+		children?: Snippet;
+	}
+	let { groupTitle, children }: Props = $props();
 </script>
 
-<ic-accordion-group size="large" class="block mb-10" single-expansion group-title={groupTitle}
-	><slot /></ic-accordion-group
->
+<ic-accordion-group size="large" class="block mb-10" single-expansion group-title={groupTitle}>
+	{@render children?.()}
+</ic-accordion-group>

--- a/src/lib/components/ui/lists/List.svelte
+++ b/src/lib/components/ui/lists/List.svelte
@@ -5,7 +5,7 @@
 	import type { Snippet } from 'svelte';
 
 	interface Props {
-		children: Snippet;
+		children?: Snippet;
 		listType: 'ul' | 'ol' | 'no-symbol';
 		applyVerticalMargins?: boolean;
 	}
@@ -23,5 +23,5 @@
 		applyVerticalMargins && 'my-8'
 	)}
 >
-	{@render children()}
+	{@render children?.()}
 </svelte:element>

--- a/src/lib/components/ui/lists/List.svelte
+++ b/src/lib/components/ui/lists/List.svelte
@@ -2,8 +2,15 @@
 
 <script lang="ts">
 	import clsx from 'clsx';
-	export let listType: 'ul' | 'ol' | 'no-symbol';
-	export let applyVerticalMargins = false;
+	import type { Snippet } from 'svelte';
+
+	interface Props {
+		children: Snippet;
+		listType: 'ul' | 'ol' | 'no-symbol';
+		applyVerticalMargins?: boolean;
+	}
+
+	let { listType, children, applyVerticalMargins = false }: Props = $props();
 </script>
 
 <svelte:element
@@ -16,5 +23,5 @@
 		applyVerticalMargins && 'my-8'
 	)}
 >
-	<slot />
+	{@render children()}
 </svelte:element>

--- a/src/lib/components/ui/rdfjs/BindingsValue.svelte
+++ b/src/lib/components/ui/rdfjs/BindingsValue.svelte
@@ -5,9 +5,13 @@
 	import { Term } from '$lib/components';
 	import type { Variable } from 'n3';
 
-	export let variable: string | Variable;
-	export let bindings: Bindings;
-	export let highlightText: string | undefined;
+	interface Props {
+		variable: string | Variable;
+		bindings: Bindings;
+		highlightText: string | undefined;
+	}
+
+	let { variable, bindings, highlightText }: Props = $props();
 
 	/**
 	 * Expressing "no value exists" in RDF can be problematic.

--- a/src/lib/components/ui/rdfjs/QuotedTriple.svelte
+++ b/src/lib/components/ui/rdfjs/QuotedTriple.svelte
@@ -5,8 +5,12 @@
 	import { Term } from '$lib/components';
 	import { settings } from '$lib/stores/settings.store';
 
-	export let term: ITerm;
-	export let showGraph = !!$settings.general__showQuads;
+	interface Props {
+		term: ITerm;
+		showGraph?: boolean;
+	}
+
+	let { term, showGraph = !!$settings.general__showQuads }: Props = $props();
 </script>
 
 <span>

--- a/src/lib/components/ui/rdfjs/Term.svelte
+++ b/src/lib/components/ui/rdfjs/Term.svelte
@@ -16,10 +16,19 @@
 	import { prefixes } from '$lib/stores/prefixes.store';
 
 	// Props
-	export let applyVerticalMargins = false;
-	export let term: Term;
-	export let settings: TermSettings = $savedSettings; // settings exposed as prop to allow for preview functionality
-	export let highlightText: string | undefined = undefined;
+	interface Props {
+		applyVerticalMargins?: boolean;
+		term: Term;
+		settings?: TermSettings; // settings exposed as prop to allow for preview functionality
+		highlightText?: string;
+	}
+
+	let {
+		applyVerticalMargins = false,
+		settings = $savedSettings, // settings exposed as prop to allow for preview functionality
+		term,
+		highlightText
+	}: Props = $props();
 
 	// State
 	const termTypeDetails = {
@@ -31,10 +40,11 @@
 		Quad: { colour: 'bg-lime-400', text: 'Quoted Triple' }
 	};
 
-	$: termValue =
+	let termValue = $derived(
 		term.value && settings.term__abbreviateCommonPrefixes
 			? abbreviateTermPrefix(term.value || '', $prefixes)
-			: term.value;
+			: term.value
+	);
 </script>
 
 {#if term}

--- a/src/lib/components/ui/rdfjs/TermValue.svelte
+++ b/src/lib/components/ui/rdfjs/TermValue.svelte
@@ -3,8 +3,11 @@
 <script lang="ts">
 	import { HighlightedText } from '$lib/components';
 
-	export let termValue: string;
-	export let highlightText: string | undefined = undefined;
+	interface Props {
+		termValue: string;
+		highlightText?: string;
+	}
+	let { termValue, highlightText }: Props = $props();
 </script>
 
 {#if highlightText}

--- a/src/lib/components/ui/tables/TableHeading.svelte
+++ b/src/lib/components/ui/tables/TableHeading.svelte
@@ -2,9 +2,13 @@
 
 <script lang="ts">
 	import { clsx } from 'clsx';
-	export let value: string;
-	export let alignment: 'left' | 'right' | 'center' = 'left';
-	export let className = '';
+
+	interface Props {
+		value: string;
+		alignment: 'left' | 'right' | 'center';
+		className?: string;
+	}
+	let { value, className, alignment = 'left' }: Props = $props();
 </script>
 
 <th

--- a/src/lib/components/ui/tables/TableHeading.svelte
+++ b/src/lib/components/ui/tables/TableHeading.svelte
@@ -5,7 +5,7 @@
 
 	interface Props {
 		value: string;
-		alignment: 'left' | 'right' | 'center';
+		alignment?: 'left' | 'right' | 'center';
 		className?: string;
 	}
 	let { value, className, alignment = 'left' }: Props = $props();

--- a/src/lib/components/ui/tables/TableRow.svelte
+++ b/src/lib/components/ui/tables/TableRow.svelte
@@ -2,10 +2,15 @@
 
 <script lang="ts">
 	import { clsx } from 'clsx';
+	import type { Snippet } from 'svelte';
 
-	export let includeBottomBorder = true;
+	interface Props {
+		includeBottomBorder?: boolean;
+		children: Snippet;
+	}
+	let { includeBottomBorder = true, children }: Props = $props();
 </script>
 
 <tr class={clsx('hover:bg-gray-50', includeBottomBorder && 'border-b border-gray-300')}>
-	<slot />
+	{@render children()}
 </tr>

--- a/src/lib/components/ui/tables/TableRow.svelte
+++ b/src/lib/components/ui/tables/TableRow.svelte
@@ -6,11 +6,11 @@
 
 	interface Props {
 		includeBottomBorder?: boolean;
-		children: Snippet;
+		children?: Snippet;
 	}
 	let { includeBottomBorder = true, children }: Props = $props();
 </script>
 
 <tr class={clsx('hover:bg-gray-50', includeBottomBorder && 'border-b border-gray-300')}>
-	{@render children()}
+	{@render children?.()}
 </tr>

--- a/src/lib/components/ui/tabs/TabNavigation.svelte
+++ b/src/lib/components/ui/tabs/TabNavigation.svelte
@@ -2,21 +2,27 @@
 
 <script lang="ts">
 	import type { IcTabSelectEventDetail } from '@ukic/web-components';
-	import { createEventDispatcher } from 'svelte';
-	const dispatch = createEventDispatcher();
+	import { type Snippet } from 'svelte';
 
-	export let selectedTabIndex: number | undefined = undefined;
+	interface Props {
+		selectedTabIndex?: number;
+		onchange?: (e: CustomEvent<IcTabSelectEventDetail>) => void;
+		panels: Snippet;
+		children: Snippet;
+	}
+
+	let { selectedTabIndex = $bindable(), onchange, children, panels }: Props = $props();
 
 	// Events
 	function handleTabChange(e: CustomEvent<IcTabSelectEventDetail>) {
 		selectedTabIndex = e.detail.tabIndex;
-		dispatch('change', { e });
+		onchange?.(e);
 	}
 </script>
 
-<ic-tab-context selected-tab-index={selectedTabIndex} on:icTabSelect={handleTabChange}>
+<ic-tab-context selected-tab-index={selectedTabIndex} onicTabSelect={handleTabChange}>
 	<ic-tab-group label="Tab group" class="mb-4">
-		<slot></slot>
+		{@render children()}
 	</ic-tab-group>
-	<slot name="panels"></slot>
+	{@render panels()}
 </ic-tab-context>

--- a/src/lib/components/ui/tree/Tree.svelte
+++ b/src/lib/components/ui/tree/Tree.svelte
@@ -5,12 +5,12 @@
 	import type { Snippet } from 'svelte';
 
 	interface Props {
-		drawBranch: boolean;
-		children: Snippet;
+		drawBranch?: boolean;
+		children?: Snippet;
 	}
-	let { drawBranch, children }: Props = $props();
+	let { drawBranch = false, children }: Props = $props();
 </script>
 
 <ul class={clsx(drawBranch && 'ml-4 pl-4 border-l')}>
-	{@render children()}
+	{@render children?.()}
 </ul>

--- a/src/lib/components/ui/tree/Tree.svelte
+++ b/src/lib/components/ui/tree/Tree.svelte
@@ -2,9 +2,15 @@
 
 <script lang="ts">
 	import clsx from 'clsx';
-	export let drawBranch = false;
+	import type { Snippet } from 'svelte';
+
+	interface Props {
+		drawBranch: boolean;
+		children: Snippet;
+	}
+	let { drawBranch, children }: Props = $props();
 </script>
 
 <ul class={clsx(drawBranch && 'ml-4 pl-4 border-l')}>
-	<slot />
+	{@render children()}
 </ul>

--- a/src/lib/components/views/BooleanView.svelte
+++ b/src/lib/components/views/BooleanView.svelte
@@ -6,12 +6,13 @@
 	import type { Readable } from 'svelte/store';
 	import type { StreamedQuery } from '$stores/streamedQuery.store';
 
-	// Props
-	export let results: Readable<StreamedQuery>;
+	interface Props {
+		results: Readable<StreamedQuery>;
+	}
 
-	// State
-	$: result = $results.results[0] as boolean;
-	$: resultText = result ? 'True' : 'False';
+	let { results }: Props = $props();
+	let result = $derived($results.results[0] as boolean);
+	let resultText = $derived(result ? 'True' : 'False');
 </script>
 
 <ic-card heading={resultText} full-width>

--- a/src/lib/components/views/ClassHeirachyView.svelte
+++ b/src/lib/components/views/ClassHeirachyView.svelte
@@ -1,20 +1,23 @@
 <!-- (c) Crown Copyright GCHQ -->
 
 <script lang="ts">
-	import type { NamedNode, Quad } from 'n3';
+	import Self from '$lib/components/views/ClassHeirachyView.svelte';
+	import type { Quad, Quad_Subject } from 'n3';
 	import { Term, Tree, TreeItem } from '$lib/components';
 
-	// Props
-	export let root: NamedNode;
-	export let quads: Quad[];
-	export let drawBranch = false;
+	interface Props {
+		root: Quad_Subject;
+		quads: Quad[];
+		drawBranch?: boolean;
+	}
 
-	$: directDescendents = quads.filter((q) => q.object.equals(root));
+	let { root, quads, drawBranch = false }: Props = $props();
+	let directDescendents = $derived(quads.filter((q) => q.object.equals(root)));
 </script>
 
 <Tree {drawBranch}>
 	<TreeItem><Term term={root} /></TreeItem>
 	{#each directDescendents as quad (quad)}
-		<svelte:self root={quad.subject} {quads} drawBranch={true} />
+		<Self root={quad.subject} {quads} drawBranch={true} />
 	{/each}
 </Tree>

--- a/src/lib/components/views/IRIView.svelte
+++ b/src/lib/components/views/IRIView.svelte
@@ -23,12 +23,15 @@
 	const MAX_DISPLAY = 500;
 
 	// Props
-	export let results: Readable<StreamedQuery>;
+	interface Props {
+		results: Readable<StreamedQuery>;
+	}
+	let { results }: Props = $props();
 
 	// State
-	$: quads = $results.results.slice(0, MAX_DISPLAY) as Quad[];
-	$: overMaximum = $results.results.length > MAX_DISPLAY;
-	$: uniquePredicateIRIs = new Set<string>(quads.map((q) => q.predicate.value));
+	let quads = $derived($results.results.slice(0, MAX_DISPLAY) as Quad[]);
+	let overMaximum = $derived($results.results.length > MAX_DISPLAY);
+	let uniquePredicateIRIs = $derived(new Set<string>(quads.map((q) => q.predicate.value)));
 
 	// TODO: This is probably a useful function for elsewhere too - should not live here. Also, possibly
 	// may one day want to make this an "optional" thing - when federating data, you might find

--- a/src/lib/components/views/PageView.svelte
+++ b/src/lib/components/views/PageView.svelte
@@ -3,12 +3,25 @@
 <script lang="ts">
 	import { HtmlHead, PageHeader, Section } from '$lib/components';
 	import type { RoutedTab } from '$lib/navigation/tabs/types';
+	import type { Snippet } from 'svelte';
 
-	export let heading: string;
-	export let subheading: string;
-	export let pageTitle: string = heading;
-	export let includeSection = true;
-	export let tabs: RoutedTab<number>[] | undefined = undefined;
+	interface Props {
+		children: Snippet;
+		heading: string;
+		subheading: string;
+		pageTitle?: string;
+		includeSection?: boolean;
+		tabs?: RoutedTab<number>[];
+	}
+
+	let {
+		children,
+		heading,
+		subheading,
+		tabs,
+		pageTitle = heading,
+		includeSection = true
+	}: Props = $props();
 </script>
 
 <HtmlHead title={pageTitle} />
@@ -16,8 +29,8 @@
 
 {#if includeSection}
 	<Section>
-		<slot />
+		{@render children()}
 	</Section>
 {:else}
-	<slot />
+	{@render children()}
 {/if}

--- a/src/lib/components/views/PrefixBrowserView.svelte
+++ b/src/lib/components/views/PrefixBrowserView.svelte
@@ -14,10 +14,12 @@
 	import type { Prefix } from '$lib/types';
 	import { prefixes } from '$lib/stores/prefixes.store';
 
-	// Props
-	export let document: string;
-	export let onAddPrefix: (prefix: string) => void;
-	export let description: string;
+	interface Props {
+		document: string;
+		onAddPrefix: (prefix: string) => void;
+		description: string;
+	}
+	let { document, onAddPrefix, description }: Props = $props();
 
 	// Utility Functions
 	const formatPrefix = (prefix: Prefix) => `PREFIX ${prefix.label}: <${prefix.iri}>`;

--- a/src/lib/components/views/QueryResultsView.svelte
+++ b/src/lib/components/views/QueryResultsView.svelte
@@ -9,10 +9,12 @@
 	import { sourceList } from '$stores/sources/sources.store';
 
 	// Props
-	export let query: string;
-	export let codeComment: string | undefined = undefined;
-
-	$: queryStore = createQueryStore(query, $sourceList);
+	interface Props {
+		query: string;
+		codeComment?: string;
+	}
+	let { query, codeComment }: Props = $props();
+	let queryStore = $derived(createQueryStore(query, $sourceList));
 </script>
 
 <SparqlQueryDetail {queryStore} {codeComment} />

--- a/src/lib/components/views/TabbedPageView.svelte
+++ b/src/lib/components/views/TabbedPageView.svelte
@@ -4,8 +4,10 @@
 	import { Heading, Paragraph as P } from '$lib/components';
 	import { PageView } from '$lib/components/views';
 	import type { RoutedTab } from '$lib/navigation/tabs/types';
+	import type { Snippet } from 'svelte';
 
 	interface Props {
+		children?: Snippet;
 		heading: string;
 		subheading: string;
 		selectedTabIndex: number;
@@ -13,7 +15,7 @@
 		tabs: RoutedTab<number>[];
 	}
 
-	let { heading, subheading, selectedTabIndex, navigationLabel, tabs }: Props = $props();
+	let { children, heading, subheading, selectedTabIndex, navigationLabel, tabs }: Props = $props();
 
 	const tab = tabs.find((t) => t.tabIndex === selectedTabIndex);
 	const tabTitle = tab?.title || 'Detail';
@@ -29,5 +31,5 @@
 		{/if}
 	</div>
 
-	<slot />
+	{@render children?.()}
 </PageView>

--- a/src/lib/components/views/TabbedPageView.svelte
+++ b/src/lib/components/views/TabbedPageView.svelte
@@ -5,13 +5,16 @@
 	import { PageView } from '$lib/components/views';
 	import type { RoutedTab } from '$lib/navigation/tabs/types';
 
-	export let heading: string;
-	export let subheading: string;
-	export let selectedTabIndex: number;
-	export let navigationLabel: string;
-	export let tabs: RoutedTab<number>[];
+	interface Props {
+		heading: string;
+		subheading: string;
+		selectedTabIndex: number;
+		navigationLabel: string;
+		tabs: RoutedTab<number>[];
+	}
 
-	// State
+	let { heading, subheading, selectedTabIndex, navigationLabel, tabs }: Props = $props();
+
 	const tab = tabs.find((t) => t.tabIndex === selectedTabIndex);
 	const tabTitle = tab?.title || 'Detail';
 	const tabDescription = tab?.description;

--- a/src/lib/components/views/bindingsView/BindingsView.svelte
+++ b/src/lib/components/views/bindingsView/BindingsView.svelte
@@ -10,19 +10,23 @@
 	import { filterBindings } from '$lib/util/filter.utils';
 
 	// Props
-	export let results: Readable<StreamedQuery>;
+	interface Props {
+		results: Readable<StreamedQuery>;
+	}
+
+	let { results }: Props = $props();
 
 	// State
-	$: bindings = $results.results as Bindings[];
+	let bindings = $derived($results.results as Bindings[]);
 
 	// Pagination + Filtering
-	let pageNumber = 0;
-	$: filterText = '';
+	let pageNumber = $state(0);
+	let filterText = $state('');
 
 	const PER_PAGE = 100;
-	$: filteredBindings = filterBindings(bindings, filterText);
-	$: totalPages = getTotalPages(PER_PAGE, filteredBindings);
-	$: bindingsForPage = getItemsForPage(pageNumber, PER_PAGE, filteredBindings);
+	let filteredBindings = $derived(filterBindings(bindings, filterText));
+	let totalPages = $derived(getTotalPages(PER_PAGE, filteredBindings));
+	let bindingsForPage = $derived(getItemsForPage(pageNumber, PER_PAGE, filteredBindings));
 </script>
 
 {#if bindings.length}

--- a/src/lib/components/views/bindingsView/BindingsViewTable.svelte
+++ b/src/lib/components/views/bindingsView/BindingsViewTable.svelte
@@ -12,12 +12,13 @@
 	} from '$lib/components';
 	import type { Bindings as IBindings } from '@comunica/types';
 
-	// Props
-	export let bindingsCollection: IBindings[];
-	export let highlightText: string;
+	interface Props {
+		bindingsCollection: IBindings[];
+		highlightText: string;
+		variables: string[];
+	}
 
-	// State
-	export let variables: string[];
+	let { bindingsCollection, highlightText, variables }: Props = $props();
 </script>
 
 <Table>

--- a/src/lib/components/views/forms/IRISearchForm.svelte
+++ b/src/lib/components/views/forms/IRISearchForm.svelte
@@ -4,20 +4,22 @@
 	import { Button, TextField } from '$lib/components';
 
 	// Props
-	export let onSubmit: (iri: string) => void;
-
-	// State
-	let validationEnabled = false;
-	let iri = '';
+	interface Props {
+		onSubmit: (iri: string) => void;
+	}
+	let { onSubmit }: Props = $props();
+	let validationEnabled = $state(false);
+	let iri = $state('');
 
 	// Events
-	function handleSubmit() {
+	function handleSubmit(e: Event) {
+		e.preventDefault();
 		validationEnabled = true;
 		onSubmit(iri);
 	}
 </script>
 
-<form on:submit|preventDefault={handleSubmit} action="/sources">
+<form onsubmit={handleSubmit} action="/sources">
 	<TextField
 		required
 		type="url"

--- a/src/lib/components/views/forms/LocalSourceForm.svelte
+++ b/src/lib/components/views/forms/LocalSourceForm.svelte
@@ -7,36 +7,41 @@
 	import { goto } from '$app/navigation';
 
 	// Props
-	export let handleSubmit: (s: LocalSource, document?: string) => void;
-
-	// Form Data (including default values for new sources)
-	export let source: LocalSource = {
-		id: '',
-		name: '',
-		type: 'LOCAL',
-		description: '',
-		enabled: false,
-		n3Store: undefined
-	};
-
-	// Validation
-	export let valid = false;
-	export let validationEnabled = false;
-	$: {
-		valid = source.name.length > 0;
+	interface Props {
+		onSubmit: (s: LocalSource, document?: string) => void;
+		valid?: boolean;
+		validationEnabled?: boolean;
+		source?: LocalSource;
 	}
 
+	let {
+		onSubmit,
+		validationEnabled = false,
+		source = $bindable({
+			id: '',
+			name: '',
+			type: 'LOCAL',
+			description: '',
+			enabled: false,
+			n3Store: undefined
+		})
+	}: Props = $props();
+
+	let valid = $derived(source.name.length > 0);
+
 	// Events
-	function onSubmit() {
+	function handleSubmit(e: Event) {
+		e.preventDefault();
+
 		if (valid) {
-			handleSubmit({ ...source });
+			onSubmit({ ...source });
 		} else {
 			validationEnabled = true;
 		}
 	}
 
 	function handleRemove() {
-		// Probably should have some kind of "are you sure" functionality here haha
+		// TODO: Probably should have some kind of "are you sure" functionality here
 		sources.removeSource(source.id);
 		goto(`${base}/sources`);
 	}
@@ -50,7 +55,7 @@
 	/>
 {/if}
 
-<form on:submit|preventDefault={onSubmit} class="my-4" action="/sources">
+<form onsubmit={handleSubmit} class="my-4" action="/sources">
 	<TextField
 		required
 		label="Source Name"

--- a/src/lib/components/views/quadsView/QuadsGraph.svelte
+++ b/src/lib/components/views/quadsView/QuadsGraph.svelte
@@ -11,10 +11,11 @@
 	import { prefixes } from '$lib/stores/prefixes.store';
 	import { settings } from '$lib/stores/settings.store';
 
-	// Props
-	export let quads: Quad[];
+	interface Props {
+		quads: Quad[];
+	}
+	let { quads }: Props = $props();
 
-	// State
 	let container: HTMLDivElement;
 	let cy: CytoscapeCore;
 	let zoomLevel = 1;
@@ -29,7 +30,7 @@
 		zoomLevel = cy.zoom();
 	});
 
-	$: {
+	$effect(() => {
 		const elements = getCytoscapeElementsForQuads(
 			quads,
 			$settings.term__abbreviateCommonPrefixes,
@@ -41,9 +42,7 @@
 			cy.fit();
 			zoomLevel = cy.zoom();
 		}
-	}
-
-	// Events
+	});
 
 	function handleZoom(zoomChange: 0.1 | -0.1) {
 		zoomLevel = zoomLevel + zoomChange;

--- a/src/lib/components/views/quadsView/QuadsTable.svelte
+++ b/src/lib/components/views/quadsView/QuadsTable.svelte
@@ -16,17 +16,19 @@
 	import { filterQuads } from '$lib/util/filter.utils';
 	import { settings } from '$lib/stores/settings.store';
 
-	// Props
-	export let quads: Quad[];
+	interface Props {
+		quads: Quad[];
+	}
+	let { quads }: Props = $props();
 
 	// Pagination + Filtering
-	let pageNumber = 0;
-	$: filterText = '';
+	let pageNumber = $state(0);
+	let filterText = $state('');
 
 	const PER_PAGE = 100;
-	$: filteredQuads = filterQuads(quads, filterText);
-	$: totalPages = getTotalPages(PER_PAGE, filteredQuads);
-	$: quadsForPage = getItemsForPage(pageNumber, PER_PAGE, filteredQuads);
+	let filteredQuads = $derived(filterQuads(quads, filterText));
+	let totalPages = $derived(getTotalPages(PER_PAGE, filteredQuads));
+	let quadsForPage = $derived(getItemsForPage(pageNumber, PER_PAGE, filteredQuads));
 
 	// Other state
 	let showGraph = !!$settings.general__showQuads;

--- a/src/lib/components/views/quadsView/QuadsTurtle.svelte
+++ b/src/lib/components/views/quadsView/QuadsTurtle.svelte
@@ -3,12 +3,13 @@
 <script lang="ts">
 	import { type Quad, Writer } from 'n3';
 
-	// Props
-	export let quads: Quad[];
+	interface Props {
+		quads: Quad[];
+	}
+	let { quads }: Props = $props();
 
-	// State
 	const writer = new Writer({ format: 'application/ttl' });
-	let ttl: string;
+	let ttl: string = $state('');
 
 	writer.addQuads(quads);
 	writer.end((err, doc) => {

--- a/src/lib/components/views/quadsView/QuadsView.svelte
+++ b/src/lib/components/views/quadsView/QuadsView.svelte
@@ -18,21 +18,23 @@
 	const MAX_DISPLAY_GRAPH = 200;
 	const MAX_DISPLAY_TTL = 2000;
 
-	// Props
-	export let results: Readable<StreamedQuery>;
+	interface Props {
+		results: Readable<StreamedQuery>;
+	}
+	let { results }: Props = $props();
 
-	// State
-	let viewType: 'graph' | 'table' | 'ttl' = 'table';
+	let viewType: 'graph' | 'table' | 'ttl' = $state('table');
 
-	$: quads = $results.results as Quad[];
-	$: overMaximumGraph = $results.results.length > MAX_DISPLAY_GRAPH;
-	$: overMaximumTTL = $results.results.length > MAX_DISPLAY_TTL;
+	let quads = $derived($results.results as Quad[]);
+	let overMaximumGraph = $derived($results.results.length > MAX_DISPLAY_GRAPH);
+	let overMaximumTTL = $derived($results.results.length > MAX_DISPLAY_TTL);
 
 	// We don't want the user entering graph view while the query is in flight and streaming as this
 	// would be very expensive and janky. There are better ways of doing this, but for now I'm just
 	// disabling the button until the query is settled.
-	$: inFlight =
-		$results.status == QueryStatus.Initialized || $results.status == QueryStatus.Fetching;
+	let inFlight = $derived(
+		$results.status == QueryStatus.Initialized || $results.status == QueryStatus.Fetching
+	);
 </script>
 
 {#if quads.length}

--- a/src/lib/components/views/sources/CatalogList.svelte
+++ b/src/lib/components/views/sources/CatalogList.svelte
@@ -20,11 +20,11 @@
 		url: string;
 	}
 
-	// Props
-	export let catalogEntries: CatalogEntry[];
-
-	// State
-	$: sourceUrls = $sources.map((s) => s.url);
+	interface Props {
+		catalogEntries: CatalogEntry[];
+	}
+	let { catalogEntries }: Props = $props();
+	let sourceUrls = $derived($sources.map((s) => s.url));
 
 	// Events
 	function handleClick({ name, description, url }: CatalogEntry) {

--- a/src/lib/components/views/sources/LocalSourceCard.svelte
+++ b/src/lib/components/views/sources/LocalSourceCard.svelte
@@ -39,9 +39,9 @@
 			href={`/sources/local/${id}/import`}
 			ariaLabel={`Import data into source ${source.name}`}
 		>
-			<i slot="icon">
+			{#snippet icon()}
 				<Import />
-			</i>
+			{/snippet}
 		</ButtonLink>
 		<Button
 			label={enabled ? 'Disable' : 'Enable'}

--- a/src/lib/components/views/sources/LocalSourceCard.svelte
+++ b/src/lib/components/views/sources/LocalSourceCard.svelte
@@ -7,47 +7,53 @@
 	import type { Store as N3Store } from 'n3';
 	import SourceCard from './SourceCard.svelte';
 
-	// Props
-	export let source: LocalSource;
-
-	// State
-	$: ({ enabled, description, id } = source);
+	interface Props {
+		source: LocalSource;
+	}
+	let { source }: Props = $props();
+	let { enabled, description, id } = source;
 	let store: N3Store = source.n3Store as N3Store;
 </script>
 
 <SourceCard {source}>
-	<div slot="message">
-		<ic-typography>{description}</ic-typography>
-		<div class="mt-2">
-			<ic-typography class="bg-gray-100 inline px-2 py-1" variant="caption"> Local </ic-typography>
-			<ic-typography class="bg-gray-100 inline px-2 py-1" variant="caption">
-				Triples: {store.size}
-			</ic-typography>
+	{#snippet message()}
+		<div>
+			<ic-typography>{description}</ic-typography>
+			<div class="mt-2">
+				<ic-typography class="bg-gray-100 inline px-2 py-1" variant="caption">
+					Local
+				</ic-typography>
+				<ic-typography class="bg-gray-100 inline px-2 py-1" variant="caption">
+					Triples: {store.size}
+				</ic-typography>
+			</div>
 		</div>
-	</div>
+	{/snippet}
 
-	<div slot="interaction-controls" class="flex flex-wrap gap-1">
-		<ButtonLink label="Show" href={`/sources/${id}`} ariaLabel={`Show source ${source.name}`} />
-		<ButtonLink
-			label="Edit"
-			href={`/sources/local/${id}/edit`}
-			ariaLabel={`Edit source ${source.name}`}
-		/>
+	{#snippet interactionControls()}
+		<div class="flex flex-wrap gap-1">
+			<ButtonLink label="Show" href={`/sources/${id}`} ariaLabel={`Show source ${source.name}`} />
+			<ButtonLink
+				label="Edit"
+				href={`/sources/local/${id}/edit`}
+				ariaLabel={`Edit source ${source.name}`}
+			/>
 
-		<ButtonLink
-			label="Import data"
-			href={`/sources/local/${id}/import`}
-			ariaLabel={`Import data into source ${source.name}`}
-		>
-			{#snippet icon()}
-				<Import />
-			{/snippet}
-		</ButtonLink>
-		<Button
-			label={enabled ? 'Disable' : 'Enable'}
-			ariaLabel={`${enabled ? 'Disable' : 'Enable'} source ${source.name}`}
-			variant="secondary"
-			onclick={() => localSources.toggleEnabled(id)}
-		/>
-	</div>
+			<ButtonLink
+				label="Import data"
+				href={`/sources/local/${id}/import`}
+				ariaLabel={`Import data into source ${source.name}`}
+			>
+				{#snippet icon()}
+					<Import />
+				{/snippet}
+			</ButtonLink>
+			<Button
+				label={enabled ? 'Disable' : 'Enable'}
+				ariaLabel={`${enabled ? 'Disable' : 'Enable'} source ${source.name}`}
+				variant="secondary"
+				onclick={() => localSources.toggleEnabled(id)}
+			/>
+		</div>
+	{/snippet}
 </SourceCard>

--- a/src/lib/components/views/sources/RemoteSourceCard.svelte
+++ b/src/lib/components/views/sources/RemoteSourceCard.svelte
@@ -8,43 +8,51 @@
 	} from '$stores/sources/remote-sources.store';
 	import SourceCard from './SourceCard.svelte';
 
-	// Props
-	export let source: RemoteSource;
+	interface Props {
+		source: RemoteSource;
+	}
+	let { source }: Props = $props();
 
-	$: ({ url, enabled, description, id, fromCatalog } = source);
+	let { url, enabled, description, id, fromCatalog } = $derived(source);
 </script>
 
 <SourceCard {source}>
-	<div slot="message">
-		<ic-typography>{description}</ic-typography>
-		{#if url}
-			<Link href={url.toString()} external>
-				{url}
-			</Link>
-		{/if}
-		<div class="mt-2">
-			<ic-typography class="bg-gray-100 inline px-2 py-1" variant="caption"> Remote </ic-typography>
-			{#if fromCatalog}
-				<ic-typography class="bg-gray-100 inline px-2 py-1" variant="caption">
-					From Catalog
-				</ic-typography>
+	{#snippet message()}
+		<div>
+			<ic-typography>{description}</ic-typography>
+			{#if url}
+				<Link href={url.toString()} external>
+					{url}
+				</Link>
 			{/if}
+			<div class="mt-2">
+				<ic-typography class="bg-gray-100 inline px-2 py-1" variant="caption">
+					Remote
+				</ic-typography>
+				{#if fromCatalog}
+					<ic-typography class="bg-gray-100 inline px-2 py-1" variant="caption">
+						From Catalog
+					</ic-typography>
+				{/if}
+			</div>
 		</div>
-	</div>
+	{/snippet}
 
-	<div slot="interaction-controls" class="flex flex-wrap gap-1">
-		<ButtonLink label="Show" href={`/sources/${id}`} ariaLabel={`Show source ${source.name}`} />
-		<ButtonLink
-			label="Edit"
-			href={`/sources/remote/${id}/edit`}
-			ariaLabel={`Edit source ${source.name}`}
-		/>
+	{#snippet interactionControls()}
+		<div class="flex flex-wrap gap-1">
+			<ButtonLink label="Show" href={`/sources/${id}`} ariaLabel={`Show source ${source.name}`} />
+			<ButtonLink
+				label="Edit"
+				href={`/sources/remote/${id}/edit`}
+				ariaLabel={`Edit source ${source.name}`}
+			/>
 
-		<Button
-			label={enabled ? 'Disable' : 'Enable'}
-			ariaLabel={`${enabled ? 'Disable' : 'Enable'} source ${source.name}`}
-			variant="secondary"
-			onclick={() => remoteSources.toggleEnabled(id)}
-		/>
-	</div>
+			<Button
+				label={enabled ? 'Disable' : 'Enable'}
+				ariaLabel={`${enabled ? 'Disable' : 'Enable'} source ${source.name}`}
+				variant="secondary"
+				onclick={() => remoteSources.toggleEnabled(id)}
+			/>
+		</div>
+	{/snippet}
 </SourceCard>

--- a/src/lib/components/views/sources/SourceCard.svelte
+++ b/src/lib/components/views/sources/SourceCard.svelte
@@ -3,26 +3,34 @@
 <script lang="ts">
 	import type { LocalSource } from '$stores/sources/local-sources.store';
 	import type { RemoteSource } from '$stores/sources/remote-sources.store';
+	import type { Snippet } from 'svelte';
 
-	// Props
-	export let source: LocalSource | RemoteSource;
-
-	// State
-	$: ({ id, name, enabled } = source);
+	interface Props {
+		source: LocalSource | RemoteSource;
+		message: Snippet;
+		interactionControls: Snippet;
+	}
+	let { source, message, interactionControls }: Props = $props();
+	let { id, name, enabled } = $derived(source);
 </script>
 
 <ic-card class="mb-4" full-width heading={name} clickable="false" data-testid="data-source-card">
 	<ic-typography variant="subtitle-small" slot="subheading">
 		{id}<br />
-		<slot name="subheading" />
 	</ic-typography>
+
 	<ic-status-tag
 		slot="adornment"
 		small
 		label={enabled ? 'Enabled' : 'Disabled'}
 		status={enabled ? 'success' : 'warning'}
 	></ic-status-tag>
-	<slot name="message" slot="message" />
-	<slot name="interaction-controls" slot="interaction-controls" />
-	<slot />
+
+	<div slot="message">
+		{@render message()}
+	</div>
+
+	<div slot="interaction-controls">
+		{@render interactionControls()}
+	</div>
 </ic-card>

--- a/src/lib/components/views/sparql/SparqlPersistQuadResults.svelte
+++ b/src/lib/components/views/sparql/SparqlPersistQuadResults.svelte
@@ -10,16 +10,22 @@
 	import { sources } from '$stores/sources/local-sources.store';
 
 	// Props
-	export let queryStore: StreamedQuery;
+
+	interface Props {
+		queryStore: StreamedQuery;
+	}
+	let { queryStore }: Props = $props();
 
 	// State
-	let selectedSourceId = '';
-	$: selectedSource = $sources.find((s) => s.id == selectedSourceId);
-	$: quads = queryStore.results as Quad[];
-	$: disabled =
-		persisted || (queryStore.status != QueryStatus.Done && queryStore.status != QueryStatus.Halted);
-	let options = $sources.map((source) => ({ label: source.name, value: source.id }));
-	let persisted = false;
+	let selectedSourceId = $state('');
+	let persisted = $state(false);
+
+	let selectedSource = $derived($sources.find((s) => s.id == selectedSourceId));
+	let quads = $derived(queryStore.results as Quad[]);
+	let disabled = $derived(
+		persisted || (queryStore.status != QueryStatus.Done && queryStore.status != QueryStatus.Halted)
+	);
+	let options = $derived($sources.map((source) => ({ label: source.name, value: source.id })));
 
 	// Events
 	function handleSourceChange(e: CustomEvent<IcValueEventDetail>) {
@@ -44,7 +50,7 @@
 				{options}
 				placeholder="Select a local data source"
 				value={selectedSourceId}
-				on:icChange={handleSourceChange}
+				onicChange={handleSourceChange}
 			></ic-select>
 
 			<div class="align-bottom inline">

--- a/src/lib/components/views/sparql/SparqlQueryCodeBlock.svelte
+++ b/src/lib/components/views/sparql/SparqlQueryCodeBlock.svelte
@@ -2,8 +2,13 @@
 
 <script lang="ts">
 	import { CodeBlock, Paragraph as P, SummaryDetail } from '$lib/components';
-	export let query: string;
-	export let codeComment: string | undefined = undefined;
+
+	interface Props {
+		query: string;
+		codeComment?: string;
+	}
+
+	let { query, codeComment }: Props = $props();
 </script>
 
 <SummaryDetail summaryText="View SPARQL query">

--- a/src/lib/components/views/sparql/SparqlQueryDetail.svelte
+++ b/src/lib/components/views/sparql/SparqlQueryDetail.svelte
@@ -6,10 +6,15 @@
 	import SparqlQueryCodeBlock from './SparqlQueryCodeBlock.svelte';
 	import SparqlQueryStatus from './SparqlQueryStatus.svelte';
 	import type { StreamedQueryStore } from '$stores/streamedQuery.store';
-	export let allowPersist = true;
-	export let codeComment: string | undefined = undefined;
-	export let queryStore: StreamedQueryStore;
-	$: pluralize = $queryStore.results.length > 1 || $queryStore.results.length == 0;
+
+	interface Props {
+		queryStore: StreamedQueryStore;
+		allowPersist?: boolean;
+		codeComment?: string;
+	}
+
+	let { allowPersist = true, codeComment, queryStore }: Props = $props();
+	let pluralize = $derived($queryStore.results.length > 1 || $queryStore.results.length == 0);
 </script>
 
 <SparqlQueryStatus status={$queryStore.status} onStop={queryStore.stop} />

--- a/src/lib/components/views/sparql/SparqlQueryStatus.svelte
+++ b/src/lib/components/views/sparql/SparqlQueryStatus.svelte
@@ -4,8 +4,12 @@
 	import { Button, LoadingSpinner } from '$lib/components';
 	import { QueryStatus } from '$lib/types';
 	import { Stop } from '$lib/components/ui/icons';
-	export let status: QueryStatus;
-	export let onStop: () => void;
+
+	interface Props {
+		status: QueryStatus;
+		onStop: () => void;
+	}
+	let { status, onStop }: Props = $props();
 </script>
 
 <dl class="">

--- a/src/lib/util/source.util.test.ts
+++ b/src/lib/util/source.util.test.ts
@@ -58,9 +58,9 @@ describe('data import functionality', () => {
 			expect(store.size).toEqual(2);
 		});
 
-		it('errors via promise rejection when the document is not formatted correctly', () => {
+		it('errors via promise rejection when the document is not formatted correctly', async () => {
 			const document = `flobalob`;
-			expect(importRdfDocument(source, document)).rejects.toThrowError();
+			await expect(importRdfDocument(source, document)).rejects.toThrowError();
 		});
 	});
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -16,11 +16,11 @@
 >
 	<div slot="heading" class="mb-4">
 		<Heading tag="h2" variant="h1" text="LD-Explorer" applyVerticalMargins={false}>
-			<span
-				slot="before-text"
-				class="inline-block w-[34px] h-[34px] relative top-px stroke-none fill-current"
-				><Logo /></span
-			>
+			{#snippet beforeText()}
+				<span class="inline-block w-[34px] h-[34px] relative top-px stroke-none fill-current">
+					<Logo />
+				</span>
+			{/snippet}
 		</Heading>
 	</div>
 	<div slot="interaction">

--- a/src/routes/explore/iris/detail/+page.svelte
+++ b/src/routes/explore/iris/detail/+page.svelte
@@ -10,15 +10,16 @@
 	import { describeResource } from '$lib/querying/queries';
 	import { sourceList } from '$stores/sources/sources.store';
 
-	// Props
-	export let data: PageData;
+	interface Props {
+		data: PageData;
+	}
 
-	// State
-	$: iri = data.iri;
+	let { data }: Props = $props();
+	let iri = data.iri;
 
 	// Query
 	const { createQuery } = describeResource;
-	$: description = createQueryStore(createQuery(iri), $sourceList);
+	let description = createQueryStore(createQuery(iri), $sourceList);
 </script>
 
 <TabbedPageView {...createTabDetail(iri)} selectedTabIndex={TabIndices.DESCRIBE}>

--- a/src/routes/explore/iris/detail/appearances/+page.svelte
+++ b/src/routes/explore/iris/detail/appearances/+page.svelte
@@ -11,15 +11,15 @@
 	import { settings } from '$lib/stores/settings.store';
 	import { sourceList } from '$stores/sources/sources.store';
 
-	// Props
-	export let data: PageData;
-
-	// State
-	$: iri = data.iri;
+	interface Props {
+		data: PageData;
+	}
+	let { data }: Props = $props();
+	let iri = data.iri;
 
 	// Query
 	const { createQuery, codeComment } = getAppearances;
-	$: instances = createQueryStore(createQuery(iri, $settings.general__defaultLimit), $sourceList);
+	let instances = createQueryStore(createQuery(iri, $settings.general__defaultLimit), $sourceList);
 </script>
 
 <TabbedPageView {...createTabDetail(iri)} selectedTabIndex={TabIndices.Appearances}>

--- a/src/routes/explore/iris/detail/instances/+page.svelte
+++ b/src/routes/explore/iris/detail/instances/+page.svelte
@@ -11,15 +11,15 @@
 	import { settings } from '$lib/stores/settings.store';
 	import { sourceList } from '$stores/sources/sources.store';
 
-	// Props
-	export let data: PageData;
-
-	// State
-	$: iri = data.iri;
+	interface Props {
+		data: PageData;
+	}
+	let { data }: Props = $props();
+	let iri = data.iri;
 
 	// Query
 	const { createQuery, codeComment } = getClassInstances;
-	$: instances = createQueryStore(createQuery(iri, $settings.general__defaultLimit), $sourceList);
+	let instances = createQueryStore(createQuery(iri, $settings.general__defaultLimit), $sourceList);
 </script>
 
 <TabbedPageView {...createTabDetail(iri)} selectedTabIndex={TabIndices.Instances}>

--- a/src/routes/explore/iris/detail/subclasses/+page.svelte
+++ b/src/routes/explore/iris/detail/subclasses/+page.svelte
@@ -13,16 +13,19 @@
 	import { sourceList } from '$stores/sources/sources.store';
 
 	// Props
-	export let data: PageData;
-
-	// State
-	$: iri = data.iri;
+	interface Props {
+		data: PageData;
+	}
+	let { data }: Props = $props();
+	let iri = data.iri;
+	let iriTerm = new NamedNode(iri);
 
 	// Query
 	const { createQuery, codeComment } = getSubclasses;
-	$: subclasses = createQueryStore(createQuery(iri, $settings.general__defaultLimit), $sourceList);
-	$: quads = $subclasses.results as Quad[];
-	$: iriTerm = new NamedNode(iri);
+	let subclasses = $derived(
+		createQueryStore(createQuery(iri, $settings.general__defaultLimit), $sourceList)
+	);
+	let quads = $derived($subclasses.results as Quad[]);
 </script>
 
 <TabbedPageView {...createTabDetail(iri)} selectedTabIndex={TabIndices.Subclasses}>

--- a/src/routes/explore/iris/detail/superclasses/+page.svelte
+++ b/src/routes/explore/iris/detail/superclasses/+page.svelte
@@ -11,17 +11,16 @@
 	import { settings } from '$lib/stores/settings.store';
 	import { sourceList } from '$stores/sources/sources.store';
 
-	// Props
-	export let data: PageData;
-
-	// State
-	$: iri = data.iri;
+	interface Props {
+		data: PageData;
+	}
+	let { data }: Props = $props();
+	let iri = data.iri;
 
 	// Query
 	const { createQuery, codeComment } = getSuperclasses;
-	$: superClasses = createQueryStore(
-		createQuery(iri, $settings.general__defaultLimit),
-		$sourceList
+	let superClasses = $derived(
+		createQueryStore(createQuery(iri, $settings.general__defaultLimit), $sourceList)
 	);
 </script>
 

--- a/src/routes/settings/+page.svelte
+++ b/src/routes/settings/+page.svelte
@@ -29,7 +29,7 @@
 			type="number"
 			helperText="Default limit to set on any sparql queries in the explore section"
 			bind:value={dirtySettings.general__defaultLimit}
-			on:input={() => (dirty = true)}
+			oninput={() => (dirty = true)}
 		/>
 
 		<Switch

--- a/src/routes/sources/[id]/+page.svelte
+++ b/src/routes/sources/[id]/+page.svelte
@@ -22,10 +22,11 @@
 	import { settings } from '$lib/stores/settings.store';
 
 	// Props
-	export let data: PageData;
+	interface Props {
+		data: PageData;
+	}
+	let { data }: Props = $props();
 	let source = { ...data.source };
-
-	// State
 
 	// Local sources will have an n3 store, remote sources have a URL. This logic will become
 	// more complicated if there are ever any other types of source in play but this'll do for now.
@@ -34,7 +35,7 @@
 
 	const { createQuery, codeComment } = getTriples;
 	const queryStore = createQueryStore(createQuery($settings.general__defaultLimit), [dataSource]);
-	$: editUrl = `/sources/${source.type == 'LOCAL' ? 'local' : 'remote'}/${source.id}/edit`;
+	let editUrl = `/sources/${source.type == 'LOCAL' ? 'local' : 'remote'}/${source.id}/edit`;
 </script>
 
 <PageView

--- a/src/routes/sources/[id]/+page.svelte
+++ b/src/routes/sources/[id]/+page.svelte
@@ -44,7 +44,7 @@
 	<TabNavigation>
 		<Tab title="Detail" />
 		<Tab title="Sample Data" />
-		<svelte:fragment slot="panels">
+		{#snippet panels()}
 			<TabPanel>
 				<ic-data-entity heading="Source Detail">
 					<ic-data-row label="ID" value={source.id}></ic-data-row>
@@ -71,7 +71,9 @@
 					<ButtonLink label="Edit" href={editUrl} />
 					{#if source.type == 'LOCAL'}
 						<ButtonLink label="Import data" href={`/sources/local/${source.id}/import`}>
-							<i slot="icon"><Import /></i>
+							{#snippet icon()}
+								<Import />
+							{/snippet}
 						</ButtonLink>
 					{/if}
 				</div>
@@ -86,6 +88,6 @@
 				<SparqlQueryDetail {queryStore} allowPersist={false} {codeComment} />
 				<QuadsView results={queryStore} />
 			</TabPanel>
-		</svelte:fragment>
+		{/snippet}
 	</TabNavigation>
 </PageView>

--- a/src/routes/sources/catalog/+page.svelte
+++ b/src/routes/sources/catalog/+page.svelte
@@ -14,13 +14,13 @@
 	<TabNavigation>
 		<Tab title="Open Source" disabled={sourcesCatalog.external.length == 0} />
 		<Tab title="Internal/Demo" disabled={sourcesCatalog.internal.length == 0} />
-		<svelte:fragment slot="panels">
+		{#snippet panels()}
 			<TabPanel>
 				<CatalogList catalogEntries={sourcesCatalog.external} />
 			</TabPanel>
 			<TabPanel>
 				<CatalogList catalogEntries={sourcesCatalog.internal} />
 			</TabPanel>
-		</svelte:fragment>
+		{/snippet}
 	</TabNavigation>
 </PageView>

--- a/src/routes/sources/local/[id]/edit/+page.svelte
+++ b/src/routes/sources/local/[id]/edit/+page.svelte
@@ -8,9 +8,11 @@
 	import { base } from '$app/paths';
 	import { goto } from '$app/navigation';
 
-	// Props
-	export let data: PageData;
-	let source = { ...data.source };
+	interface Props {
+		data: PageData;
+	}
+	let { data }: Props = $props();
+	let source = $state({ ...data.source });
 
 	// Events
 	function handleSubmit(source: LocalSource) {
@@ -20,5 +22,5 @@
 </script>
 
 <PageView heading="Edit local source" subheading="Add a new local data source.">
-	<LocalSourceForm {handleSubmit} bind:source />
+	<LocalSourceForm onSubmit={handleSubmit} bind:source />
 </PageView>

--- a/src/routes/sources/local/[id]/import/+page.svelte
+++ b/src/routes/sources/local/[id]/import/+page.svelte
@@ -15,8 +15,10 @@
 	import { base } from '$app/paths';
 	import { goto } from '$app/navigation';
 
-	// Props
-	export let data: PageData;
+	interface Props {
+		data: PageData;
+	}
+	let { data }: Props = $props();
 	let source = { ...data.source };
 
 	type ImportType = 'rdf' | 'rdfa' | 'json-ld';
@@ -34,17 +36,14 @@
 	};
 
 	// State
-	let document = '';
-	let parseError = '';
-	let selectedTabIndex = LocalDataSourceImportTab.Document;
-	let currentImportType: ImportType = 'rdf';
+	let document = $state('');
+	let parseError = $state('');
+	let selectedTabIndex = $state(LocalDataSourceImportTab.Document);
+	let currentImportType: ImportType = $state('rdf');
 
 	// Validation
-	export let valid = false;
-	export let validationEnabled = false;
-	$: {
-		valid = document.trim().length > 0;
-	}
+	let validationEnabled = $state(false);
+	let valid = $derived(document.trim().length > 0);
 
 	const imports: ImportTypes = {
 		rdf: {
@@ -65,7 +64,8 @@
 	} as const;
 
 	// Events
-	async function handleSubmit() {
+	async function handleSubmit(e: Event) {
+		e.preventDefault();
 		validationEnabled = true;
 
 		if (valid)
@@ -90,7 +90,7 @@
 	<ic-select
 		class="mt-4 mb-10 block"
 		value={currentImportType}
-		on:icChange={handleImportTypeChanged}
+		onicChange={handleImportTypeChanged}
 		label="Import format"
 		options={Object.entries(imports).map(([value, { label }]) => ({ label, value }))}
 	></ic-select>
@@ -105,7 +105,7 @@
 
 		{#snippet panels()}
 			<TabPanel>
-				<form on:submit|preventDefault={handleSubmit}>
+				<form onsubmit={handleSubmit}>
 					{#if parseError.length > 0}
 						<Alert variant="error" heading="Document Parse Error" message={parseError} />
 					{/if}

--- a/src/routes/sources/local/[id]/import/+page.svelte
+++ b/src/routes/sources/local/[id]/import/+page.svelte
@@ -103,7 +103,7 @@
 			disabled={currentImportType == 'json-ld'}
 		/>
 
-		<svelte:fragment slot="panels">
+		{#snippet panels()}
 			<TabPanel>
 				<form on:submit|preventDefault={handleSubmit}>
 					{#if parseError.length > 0}
@@ -132,6 +132,6 @@
 					description="Add common prefixes to your imported document."
 				/>
 			</TabPanel>
-		</svelte:fragment>
+		{/snippet}
 	</TabNavigation>
 </PageView>

--- a/src/routes/sources/local/add/+page.svelte
+++ b/src/routes/sources/local/add/+page.svelte
@@ -14,5 +14,5 @@
 </script>
 
 <PageView heading="Add local source" subheading="Add a new local data source.">
-	<LocalSourceForm {handleSubmit} />
+	<LocalSourceForm onSubmit={handleSubmit} />
 </PageView>

--- a/src/routes/sources/remote/[id]/edit/+page.svelte
+++ b/src/routes/sources/remote/[id]/edit/+page.svelte
@@ -8,9 +8,11 @@
 	import { base } from '$app/paths';
 	import { goto } from '$app/navigation';
 
-	// Props
-	export let data: PageData;
-	let source = { ...data.source };
+	interface Props {
+		data: PageData;
+	}
+	let { data }: Props = $props();
+	let source = $state({ ...data.source });
 
 	// Events
 	function handleSubmit(source: RemoteSource) {
@@ -20,5 +22,5 @@
 </script>
 
 <PageView heading="Edit remote source" subheading="Add a new remote data source.">
-	<RemoteSourceForm {handleSubmit} bind:source />
+	<RemoteSourceForm onSubmit={handleSubmit} bind:source />
 </PageView>

--- a/src/routes/sources/remote/add/+page.svelte
+++ b/src/routes/sources/remote/add/+page.svelte
@@ -14,5 +14,5 @@
 </script>
 
 <PageView heading="Add remote source" subheading="Add a new remote data source.">
-	<RemoteSourceForm {handleSubmit} />
+	<RemoteSourceForm onSubmit={handleSubmit} />
 </PageView>

--- a/src/routes/sparql-ui/+page.svelte
+++ b/src/routes/sparql-ui/+page.svelte
@@ -64,7 +64,7 @@
 		/>
 		<Tab title="Prefix Browser" selected={selectedTabIndex == SparqlUiTab.PrefixBrowser} />
 
-		<svelte:fragment slot="panels">
+		{#snippet panels()}
 			<TabPanel>
 				<ic-select
 					on:icChange={handleSparqlQueryChanged}
@@ -82,7 +82,7 @@
 						label="Sparql Query"
 						helperText="SPARQL 1.1 supported query types are SELECT, DESCRIBE, ASK and CONSTRUCT"
 						bind:value={sparqlQuery}
-						on:input={resetParseError}
+						oninput={resetParseError}
 						rows={10}
 						{validationEnabled}
 						isValid={validationStatus != 'error'}
@@ -105,6 +105,6 @@
 					description="Add common prefixes to your SPARQL query."
 				/></TabPanel
 			>
-		</svelte:fragment>
+		{/snippet}
 	</TabNavigation>
 </PageView>


### PR DESCRIPTION
Svelte 5 is already included, but nearly every component is still using legacy syntax which cuts us off from some of the potential improvements that the new syntax might bring (e.g. extracting some of the cross cutting state logic, simplifying some of the stores..).

This PR updates all components to use the new syntax.