### PR TITLE
73 navigation no longer working on describe page

### DIFF
--- a/e2e/tests/journeys/navigating-between-individuals.spec.ts
+++ b/e2e/tests/journeys/navigating-between-individuals.spec.ts
@@ -2,14 +2,12 @@
 
 import { expect, test } from '$e2e/test';
 
-// TODO: This probably should be a a feature test rather than a journey.
-test('Navigating records', async ({
+test('Navigating between individuals', async ({
 	page,
 	addLocalDataSourcePage,
 	importToLocalDataSourcePage,
 	sherlockExampleDataTTL,
-	exploreClassesPage,
-	exploreIndividualsPage
+	exploreClassesPage
 }) => {
 	const sourceName = 'ExampleData';
 

--- a/e2e/tests/journeys/navigating-records.spec.ts
+++ b/e2e/tests/journeys/navigating-records.spec.ts
@@ -1,0 +1,42 @@
+/* (c) Crown Copyright GCHQ */
+
+import { expect, test } from '$e2e/test';
+
+// TODO: This probably should be a a feature test rather than a journey.
+test('Navigating records', async ({
+	page,
+	addLocalDataSourcePage,
+	importToLocalDataSourcePage,
+	sherlockExampleDataTTL,
+	exploreClassesPage,
+	exploreIndividualsPage
+}) => {
+	const sourceName = 'ExampleData';
+
+	await addLocalDataSourcePage.goto();
+	await addLocalDataSourcePage.createLocalDataSource(sourceName);
+
+	await importToLocalDataSourcePage.navigateTo(sourceName);
+	await importToLocalDataSourcePage.importRdfData(sherlockExampleDataTTL);
+
+	// Go to the classes page and make sure the single class "Person" is there.
+	await exploreClassesPage.navigateTo();
+	await expect(page.getByText('Found 1 item')).toBeVisible();
+	await page.getByRole('link', { name: 'Person' }).click();
+
+	// Now on the describe page for the Person class - click individuals and check
+	// we have two (Holmes and Moriarty)
+	await page.getByRole('link', { name: 'Individuals' }).click();
+	await expect(page.getByText('Found 2 items')).toBeVisible();
+	await page.getByRole('link', { name: 'sherlock_holmes' }).click();
+
+	// Now on describe page for Sherlock. Make sure the correct details are there and
+	// click on moriarty.
+	await expect(page.getByText('Found 3 items')).toBeVisible();
+	await expect(page.getByText('Sherlock Holmes')).toBeVisible();
+
+	// Make sure correct details for moriarty are there
+	await page.getByRole('link', { name: 'james_moriarty' }).click();
+	await expect(page.getByText('Found 3 items')).toBeVisible();
+	await expect(page.getByText('James Moriarty')).toBeVisible();
+});

--- a/src/routes/explore/iris/detail/+page.svelte
+++ b/src/routes/explore/iris/detail/+page.svelte
@@ -15,11 +15,12 @@
 	}
 
 	let { data }: Props = $props();
-	let iri = data.iri;
+
+	let iri = $derived(data.iri);
 
 	// Query
 	const { createQuery } = describeResource;
-	let description = createQueryStore(createQuery(iri), $sourceList);
+	let description = $derived(createQueryStore(createQuery(iri), $sourceList));
 </script>
 
 <TabbedPageView {...createTabDetail(iri)} selectedTabIndex={TabIndices.DESCRIBE}>


### PR DESCRIPTION
Fixes #73 

Issue was that you need to be more explicit with your reactivity in Svelte 5 and we didn't have an e2e test that would check individual-to-individual navigation. 

This PR fixes the problem and introduces a test to ensure it doesn't happen again.