### PR TITLE
Fix display issue on `DESCRIBE` page

### DIFF
--- a/src/lib/components/ui/rdfjs/BindingsValue.svelte
+++ b/src/lib/components/ui/rdfjs/BindingsValue.svelte
@@ -3,7 +3,7 @@
 <script lang="ts">
 	import type { Bindings } from '@comunica/types';
 	import { Term } from '$lib/components';
-	import type { Variable } from 'n3';
+	import type { Variable } from '@rdfjs/types';
 
 	interface Props {
 		variable: string | Variable;

--- a/src/lib/components/views/ClassHeirachyView.svelte
+++ b/src/lib/components/views/ClassHeirachyView.svelte
@@ -2,7 +2,7 @@
 
 <script lang="ts">
 	import Self from '$lib/components/views/ClassHeirachyView.svelte';
-	import type { Quad, Quad_Subject } from 'n3';
+	import type { Quad, Quad_Subject } from '@rdfjs/types';
 	import { Term, Tree, TreeItem } from '$lib/components';
 
 	interface Props {

--- a/src/lib/components/views/IRIView.svelte
+++ b/src/lib/components/views/IRIView.svelte
@@ -11,9 +11,11 @@
 		TableHead,
 		TableHeading,
 		TableRow,
-		Term
+		Term as TermComponent
 	} from '$lib/components';
-	import { type Term as N3Term, NamedNode, type Quad } from 'n3';
+
+	import type { Term, Quad } from '@rdfjs/types';
+	import { NamedNode } from 'n3';
 	import type { Readable } from 'svelte/store';
 	import type { StreamedQuery } from '$stores/streamedQuery.store';
 
@@ -38,7 +40,7 @@
 	// duplicate data in duplicate graphs and the user may want to see this. It's confusing to see duplicates right now
 	// because we are hiding the "graph" part of the quad but if we ever bring that in, this function will
 	// hide the fact that the same value appeared in multiple graphs.
-	function uniqueTerms(terms: N3Term[]): N3Term[] {
+	function uniqueTerms(terms: Term[]): Term[] {
 		return [...new Map(terms.map((term) => [term.value, term])).values()];
 	}
 </script>
@@ -61,14 +63,14 @@
 		<TableBody>
 			{#each Array.from(uniquePredicateIRIs) as iri, idx (idx)}
 				<TableRow>
-					<TableData><Term term={new NamedNode(iri)} applyVerticalMargins /></TableData>
+					<TableData><TermComponent term={new NamedNode(iri)} applyVerticalMargins /></TableData>
 					<TableData>
 						<List listType="no-symbol">
 							{#each uniqueTerms(quads
 									.filter((q) => q.predicate.value == iri)
-									.map((q) => q.object)) as object (object.id)}
+									.map((q) => q.object)) as object (object.value)}
 								<ListItem>
-									<Term term={object} />
+									<TermComponent term={object} />
 								</ListItem>
 							{/each}
 						</List>

--- a/src/lib/components/views/quadsView/QuadsGraph.svelte
+++ b/src/lib/components/views/quadsView/QuadsGraph.svelte
@@ -5,7 +5,7 @@
 	import cytoscape, { type Core as CytoscapeCore } from 'cytoscape';
 	import { cytoscapeSettings, getCytoscapeElementsForQuads } from '$lib/util/cytoscape/cytoscape';
 	import { Button } from '$lib/components';
-	import type { Quad } from 'n3';
+	import type { Quad } from '@rdfjs/types';
 	import layout from '$lib/util/cytoscape/layout';
 	import { onMount } from 'svelte';
 	import { prefixes } from '$lib/stores/prefixes.store';

--- a/src/lib/components/views/quadsView/QuadsTable.svelte
+++ b/src/lib/components/views/quadsView/QuadsTable.svelte
@@ -12,7 +12,7 @@
 		Term
 	} from '$lib/components';
 	import { getItemsForPage, getTotalPages } from '$lib/util/pagination.utils';
-	import type { Quad } from 'n3';
+	import type { Quad } from '@rdfjs/types';
 	import { filterQuads } from '$lib/util/filter.utils';
 	import { settings } from '$lib/stores/settings.store';
 

--- a/src/lib/components/views/quadsView/QuadsTurtle.svelte
+++ b/src/lib/components/views/quadsView/QuadsTurtle.svelte
@@ -1,7 +1,8 @@
 <!-- (c) Crown Copyright GCHQ -->
 
 <script lang="ts">
-	import { type Quad, Writer } from 'n3';
+	import type { Quad } from '@rdfjs/types';
+	import { Writer } from 'n3';
 
 	interface Props {
 		quads: Quad[];

--- a/src/lib/components/views/quadsView/QuadsView.svelte
+++ b/src/lib/components/views/quadsView/QuadsView.svelte
@@ -3,7 +3,7 @@
 <script lang="ts">
 	import { Alert, Button } from '$lib/components';
 	import { Graph, Table, Turtle } from '$lib/components/ui/icons';
-	import type { Quad } from 'n3';
+	import type { Quad } from '@rdfjs/types';
 	import QuadsGraph from './QuadsGraph.svelte';
 	import QuadsTable from './QuadsTable.svelte';
 	import QuadsTurtle from './QuadsTurtle.svelte';

--- a/src/lib/components/views/sparql/SparqlPersistQuadResults.svelte
+++ b/src/lib/components/views/sparql/SparqlPersistQuadResults.svelte
@@ -3,7 +3,7 @@
 <script lang="ts">
 	import { Alert, Button, Section, SummaryDetail } from '$lib/components';
 	import type { IcValueEventDetail } from '@ukic/web-components';
-	import type { Quad } from 'n3';
+	import type { Quad } from '@rdfjs/types';
 	import { QueryStatus } from '$lib/types';
 	import type { StreamedQuery } from '$stores/streamedQuery.store';
 	import { importQuads } from '$lib/util/source.util';

--- a/src/lib/stores/streamedQuery.store.test.ts
+++ b/src/lib/stores/streamedQuery.store.test.ts
@@ -4,7 +4,7 @@ import { type StreamedQuery, createQueryStore } from './streamedQuery.store';
 import { sourceList, sources } from '$lib/stores/sources/local-sources.store';
 import type { Bindings } from '@comunica/types';
 import type { MockInstance } from 'vitest';
-import type { Quad } from 'n3';
+import type { Quad } from '@rdfjs/types';
 import { QueryStatus } from '$lib/types';
 import { get } from 'svelte/store';
 import { importRdfDocument } from '$lib/util/source.util';

--- a/src/lib/stores/streamedQuery.store.ts
+++ b/src/lib/stores/streamedQuery.store.ts
@@ -22,7 +22,7 @@ import type { Bindings, BindingsStream } from '@comunica/types';
 import { type Readable, writable } from 'svelte/store';
 import { comunicaLogger, logger } from '$stores/logger.store';
 import type { AsyncIterator } from 'asynciterator';
-import type { Quad } from 'n3';
+import type { Quad } from '@rdfjs/types';
 import { QueryStatus } from '$lib/types';
 import type { QuerySources } from './sources/sources.store';
 import type { ResultStream } from '@rdfjs/types';

--- a/src/lib/util/cytoscape/cytoscape.ts
+++ b/src/lib/util/cytoscape/cytoscape.ts
@@ -2,7 +2,7 @@
 
 import type { ElementDefinition } from 'cytoscape';
 import type { Prefix } from '$lib/types';
-import type { Quad } from 'n3';
+import type { Quad } from '@rdfjs/types';
 import { abbreviateTermPrefix } from '$lib/util/term.utils';
 import layout from './layout';
 import style from './style';

--- a/src/lib/util/filter.utils.ts
+++ b/src/lib/util/filter.utils.ts
@@ -1,7 +1,7 @@
 /* (c) Crown Copyright GCHQ */
 
 import type { Bindings } from '@comunica/types';
-import type { Quad } from 'n3';
+import type { Quad } from '@rdfjs/types';
 
 /**
  * Takes a collection of bindings and a search term, then filters through the collection to include

--- a/src/lib/util/source.util.ts
+++ b/src/lib/util/source.util.ts
@@ -1,6 +1,7 @@
 /* (c) Crown Copyright GCHQ */
 
-import { Parser as N3Parser, type Store as N3Store, type Quad } from 'n3';
+import type { Quad } from '@rdfjs/types';
+import { Parser as N3Parser, type Store as N3Store } from 'n3';
 import { JsonLdParser } from 'jsonld-streaming-parser';
 import type { LocalSource } from '$lib/stores/sources/local-sources.store';
 import { RdfaParser } from 'rdfa-streaming-parser';

--- a/src/routes/explore/iris/detail/subclasses/+page.svelte
+++ b/src/routes/explore/iris/detail/subclasses/+page.svelte
@@ -2,7 +2,8 @@
 
 <script lang="ts">
 	import { Alert, SparqlQueryDetail } from '$lib/components';
-	import { NamedNode, type Quad } from 'n3';
+	import type { Quad } from '@rdfjs/types';
+	import { NamedNode } from 'n3';
 	import createTabDetail, { TabIndices } from '$lib/navigation/tabs/IRIDetailNavigation';
 	import { ClassHeirachyView } from '$lib/components/views';
 	import type { PageData } from './$types';


### PR DESCRIPTION
Issue caused by us having used the `n3` types for things like `Term` and `Quad`, incorrectly thinking that they were just proxying straight to the `rdfjs` types - this is not the case, in particular `n3` adds an `"id"` key which is not present on the [RDFJS Data Model](https://rdf.js.org/data-model-spec/) - this `id` key would therefore only be present on any triples that had come out of the n3 store, which in our case will mean only on local data sources.

The knock on effect of this was that I had been using that ID key (thinking it would always be there) as a key in an `each` block - this is why we were seeing the issue with the astronauts not displaying correctly in the list (they were a remote source rahter than a local one, hence no ID).

I don't think it's necessary any more to add a unit test to check this, as we now already have a safety net provided by using the correct Typescript types as opposed to the n3 ones.