### PR TITLE
Fix dark mode

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -3,3 +3,11 @@
 
 @import './theme.css';
 @import 'tailwindcss';
+
+/*
+Hopefully temporary fix to make the application usable
+while ICDS are working out the issues with dark mode.
+*/
+:root {
+	color-scheme: only light;
+}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -11,18 +11,19 @@
 <ViewportHelper bind:isSmall />
 
 {#await defineCustomElements() then}
-	<div class="tracking-wide leading-relaxed">
+	<div class="tracking-wide leading-relaxed scheme-only-light text-icds-primary-text">
 		<SkipToContent landmarkHref="#content" />
-		<ic-theme brand-color="#0c857b"></ic-theme>
-		<main class="sm:flex h-full">
-			<SideNav />
-			<div id="content" tabIndex="-1" class="flex-row flex-grow">
-				<div class="min-h-screen">
-					<slot />
+		<ic-theme brand-color="#0c857b">
+			<main class="sm:flex h-full">
+				<SideNav />
+				<div id="content" tabIndex="-1" class="flex-row flex-grow">
+					<div class="min-h-screen">
+						<slot />
+					</div>
+					<ic-back-to-top target="main" variant={isSmall ? 'icon' : 'default'}></ic-back-to-top>
+					<Footer />
 				</div>
-				<ic-back-to-top target="main" variant={isSmall ? 'icon' : 'default'}></ic-back-to-top>
-				<Footer />
-			</div>
-		</main>
+			</main>
+		</ic-theme>
 	</div>
 {/await}

--- a/src/theme.css
+++ b/src/theme.css
@@ -1,5 +1,8 @@
 @theme inline {
+	/* text and fonts */
 	--font-display: var(--ic-font-body-family);
+	/* Note that we're hard-coding light-mode here. This is due to issues with ICDS' darkmode functionality */
+	--color-icds-primary-text: var(--ic-color-text-primary-light);
 
 	/* ICDS tokens */
 	--color-icds-personality: var(--ic-theme-primary);


### PR DESCRIPTION
Dark mode was never supported in the first place and upgrading to the latest version of ICDS resulted in the application becoming unusable if the user happened to have their system set to prefer dark mode (we'd previously assumed that this feature would be opt-in - it isn't, although whether or not that's a bug remains to be explored).

This PR effectively forces LD Explorer to always be light-mode, even when the user's system is set to dark mode. It would be nice to actually support dark mode eventually, but for now let's just make it usable.