### PR TITLE
Add dark mode

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -4,10 +4,17 @@
 @import './theme.css';
 @import 'tailwindcss';
 
-/*
-Hopefully temporary fix to make the application usable
-while ICDS are working out the issues with dark mode.
+/* 
+For toggling dark mode manually through the use of settings.
+https://tailwindcss.com/docs/dark-mode#toggling-dark-mode-manually
 */
-:root {
-	color-scheme: only light;
+@custom-variant dark (&:where(.dark, .dark *));
+
+/* Colour theme */
+html.dark {
+	color-scheme: dark;
+}
+
+html:not(.dark) {
+	color-scheme: light;
 }

--- a/src/lib/components/layout/homepage/ProductFeature.svelte
+++ b/src/lib/components/layout/homepage/ProductFeature.svelte
@@ -33,4 +33,6 @@
 		/>
 	</div>
 </ic-section-container>
-<hr class="py-4 my-14 md:my-4 w-2/3 block m-auto border-t border-t-gray-200" />
+<hr
+	class="py-4 my-14 md:my-4 w-2/3 block m-auto border-t border-t-gray-200 dark:border-t-gray-600"
+/>

--- a/src/lib/components/layout/nav/SubNav.svelte
+++ b/src/lib/components/layout/nav/SubNav.svelte
@@ -3,7 +3,7 @@
 <nav
 	data-testid="sub-nav"
 	aria-labelledby="sub-navigation-landmark"
-	class="bg-gray-50 md:min-h-screen border-b md:border-0 overflow-y-scroll sticky top-0 items-start"
+	class="bg-icds-page-header-background md:min-h-screen md:border-r md:border-icds-page-header-border md:bg-icds-background-primary dark:bg-icds-background-primary overflow-y-scroll sticky top-0 items-start"
 >
 	<span class="sr-only" id="sub-navigation-landmark">Sub navigation</span>
 	<ul class="md:pt-8">

--- a/src/lib/components/layout/nav/SubNavItem.svelte
+++ b/src/lib/components/layout/nav/SubNavItem.svelte
@@ -2,7 +2,6 @@
 
 <script lang="ts">
 	import { base } from '$app/paths';
-	import { Link } from '$lib/components';
 	import clsx from 'clsx';
 
 	// Props

--- a/src/lib/components/layout/nav/SubNavItem.svelte
+++ b/src/lib/components/layout/nav/SubNavItem.svelte
@@ -2,6 +2,7 @@
 
 <script lang="ts">
 	import { base } from '$app/paths';
+	import { Link } from '$lib/components';
 	import clsx from 'clsx';
 
 	// Props
@@ -14,12 +15,13 @@
 	let { title, href, selected = false }: Props = $props();
 </script>
 
-<li class="hover:bg-gray-100">
-	<a
-		class={clsx(
-			'px-4 inline-block w-full p-2 hover:bg-gray-100 border-l-8',
-			selected ? 'font-bold border-icds-action' : 'border-gray-50'
-		)}
-		href={`${base}${href}`}>{title}</a
+<li
+	class={clsx(
+		'relative hover:bg-icds-tree-view-hover',
+		selected && 'before:content-[""] before:absolute before:w-2 before:h-full before:bg-icds-action'
+	)}
+>
+	<a class={clsx('px-4 inline-block w-full p-2')} href={`${base}${href}`}
+		><ic-typography>{title}</ic-typography></a
 	>
 </li>

--- a/src/lib/components/ui/Alert.svelte
+++ b/src/lib/components/ui/Alert.svelte
@@ -14,5 +14,5 @@
 </script>
 
 <div>
-	<ic-alert class="my-4 text-inherit" {variant} {heading} {dismissible} {message}></ic-alert>
+	<ic-alert class="my-4" {variant} {heading} {dismissible} {message}></ic-alert>
 </div>

--- a/src/lib/components/ui/Alert.svelte
+++ b/src/lib/components/ui/Alert.svelte
@@ -14,5 +14,5 @@
 </script>
 
 <div>
-	<ic-alert class="my-4" {variant} {heading} {dismissible} {message}></ic-alert>
+	<ic-alert class="my-4 text-inherit" {variant} {heading} {dismissible} {message}></ic-alert>
 </div>

--- a/src/lib/components/ui/CodeBlock.svelte
+++ b/src/lib/components/ui/CodeBlock.svelte
@@ -7,4 +7,6 @@
 	let { code }: Props = $props();
 </script>
 
-<pre role="code" class="whitespace-pre bg-gray-100 p-4 my-2 overflow-x-scroll">{code}</pre>
+<pre
+	role="code"
+	class="whitespace-pre bg-gray-100 dark:bg-gray-700 p-4 my-2 overflow-x-scroll">{code}</pre>

--- a/src/lib/components/ui/SummaryDetail.svelte
+++ b/src/lib/components/ui/SummaryDetail.svelte
@@ -14,7 +14,7 @@
 <details class={clsx('my-2')}>
 	<summary
 		class={clsx(
-			'font-bold hover:decoration-4 hover:underline-offset-4 underline cursor-pointer text-icds-hyperlink hover:text-icds-hyperlink-hover'
+			'font-bold hover:decoration-4 hover:underline-offset-4 underline cursor-pointer text-icds-hyperlink'
 		)}>{summaryText}</summary
 	>
 	<div class={clsx(pad && 'py-2 px-4 break-words overflow-hidden')}>

--- a/src/lib/components/ui/rdfjs/Term.svelte
+++ b/src/lib/components/ui/rdfjs/Term.svelte
@@ -34,9 +34,12 @@
 	// State
 	const termTypeDetails = {
 		NamedNode: { colour: 'bg-amber-400', text: 'Resource' },
-		BlankNode: { colour: 'text-black border border-black', text: 'Blank Node' },
-		Literal: { colour: 'bg-black text-white', text: 'Literal' },
-		Variable: { colour: 'bg-gray-200', text: 'Variable' },
+		BlankNode: {
+			colour: 'text-black border border-black dark:border-white dark:text-white',
+			text: 'Blank Node'
+		},
+		Literal: { colour: 'bg-black text-white dark:bg-gray-200 dark:text-black', text: 'Literal' },
+		Variable: { colour: 'bg-gray-200 dark:bg-gray-800 dark:text-white', text: 'Variable' },
 		DefaultGraph: { colour: 'bg-pink-600 text-white', text: 'Default Graph' },
 		Quad: { colour: 'bg-lime-400', text: 'Quoted Triple' }
 	};
@@ -70,7 +73,7 @@
 				</Link>
 			{:else}
 				{#if settings.term__showLanguageTag && term.termType == 'Literal' && term.language && term.language.length}
-					<span class="bg-gray-100 px-1">@{term.language}</span>
+					<span class="bg-gray-100 dark:bg-gray-700 px-1">@{term.language}</span>
 				{/if}
 				<TermValue termValue={termDisplayValue} {highlightText} />
 			{/if}

--- a/src/lib/components/ui/tables/TableHead.svelte
+++ b/src/lib/components/ui/tables/TableHead.svelte
@@ -1,7 +1,7 @@
 <!-- (c) Crown Copyright GCHQ -->
 
 <thead class="p-4 text-left break-all">
-	<tr class="border-b-gray-200 border-b-2">
+	<tr class="border-b-gray-200 border-b-2 dark:border-b-gray-500">
 		<slot />
 	</tr>
 </thead>

--- a/src/lib/components/ui/tables/TableRow.svelte
+++ b/src/lib/components/ui/tables/TableRow.svelte
@@ -11,6 +11,11 @@
 	let { includeBottomBorder = true, children }: Props = $props();
 </script>
 
-<tr class={clsx('hover:bg-gray-50', includeBottomBorder && 'border-b border-gray-300')}>
+<tr
+	class={clsx(
+		'hover:bg-gray-50 dark:hover:bg-gray-900',
+		includeBottomBorder && 'border-b border-gray-300 dark:border-gray-600'
+	)}
+>
 	{@render children?.()}
 </tr>

--- a/src/lib/components/views/sources/LocalSourceCard.svelte
+++ b/src/lib/components/views/sources/LocalSourceCard.svelte
@@ -20,10 +20,10 @@
 		<div>
 			<ic-typography>{description}</ic-typography>
 			<div class="mt-2">
-				<ic-typography class="bg-gray-100 inline px-2 py-1" variant="caption">
+				<ic-typography class="bg-gray-100 dark:bg-gray-700 inline px-2 py-1" variant="caption">
 					Local
 				</ic-typography>
-				<ic-typography class="bg-gray-100 inline px-2 py-1" variant="caption">
+				<ic-typography class="bg-gray-100 dark:bg-gray-700 inline px-2 py-1" variant="caption">
 					Triples: {store.size}
 				</ic-typography>
 			</div>

--- a/src/lib/components/views/sources/RemoteSourceCard.svelte
+++ b/src/lib/components/views/sources/RemoteSourceCard.svelte
@@ -26,11 +26,11 @@
 				</Link>
 			{/if}
 			<div class="mt-2">
-				<ic-typography class="bg-gray-100 inline px-2 py-1" variant="caption">
+				<ic-typography class="bg-gray-100 dark:bg-gray-700 inline px-2 py-1" variant="caption">
 					Remote
 				</ic-typography>
 				{#if fromCatalog}
-					<ic-typography class="bg-gray-100 inline px-2 py-1" variant="caption">
+					<ic-typography class="bg-gray-100 dark:bg-gray-700 inline px-2 py-1" variant="caption">
 						From Catalog
 					</ic-typography>
 				{/if}

--- a/src/lib/stores/localStorageJson.store.ts
+++ b/src/lib/stores/localStorageJson.store.ts
@@ -13,7 +13,10 @@ import { writable } from 'svelte/store';
 export function createLocalStorageJSONStore<T>(key: string, defaultValue: T) {
 	const namespacedKey = `${namespace}${key}`;
 
-	const { set, subscribe, update } = writable<T>(retrieveJSONObject(namespacedKey) || defaultValue);
+	const { set, subscribe, update } = writable<T>({
+		...defaultValue,
+		...retrieveJSONObject(namespacedKey)
+	});
 
 	subscribe((store) => {
 		storeJSONObject<T>(namespacedKey, store);

--- a/src/lib/stores/settings.store.ts
+++ b/src/lib/stores/settings.store.ts
@@ -3,6 +3,7 @@
 import { createLocalStorageJSONStore } from './localStorageJson.store';
 
 interface GeneralSettings {
+	general__darkMode: boolean;
 	general__defaultLimit: number;
 	general__showQuads: boolean;
 	general__showRDFSLabels: boolean;
@@ -17,6 +18,9 @@ export interface TermSettings {
 export type Settings = GeneralSettings & TermSettings;
 
 const defaultSettings: Settings = {
+	general__darkMode: !!(
+		window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches
+	),
 	general__defaultLimit: 1000,
 	general__showQuads: false,
 	general__showRDFSLabels: false,
@@ -26,3 +30,9 @@ const defaultSettings: Settings = {
 };
 
 export const settings = createLocalStorageJSONStore('settings', defaultSettings);
+
+// On dark mode toggle, update the document element to add the 'dark' class, allowing the
+// TailwindCSS custom variant to apply :dark styles.
+settings.subscribe(({ general__darkMode }) => {
+	document.documentElement.classList.toggle('dark', general__darkMode);
+});

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -5,15 +5,19 @@
 	import { Footer, SideNav, SkipToContent } from '$lib/components';
 	import { ViewportHelper } from '$lib/components/helpers';
 	import { defineCustomElements } from '@ukic/web-components/loader';
+	import { settings } from '$lib/stores/settings.store';
+
 	let isSmall: boolean;
+
+	$: darkMode = $settings.general__darkMode;
 </script>
 
 <ViewportHelper bind:isSmall />
 
 {#await defineCustomElements() then}
-	<div class="tracking-wide leading-relaxed scheme-only-light text-icds-primary-text">
+	<div class="tracking-wide leading-relaxed">
 		<SkipToContent landmarkHref="#content" />
-		<ic-theme brand-color="#0c857b">
+		<ic-theme brand-color="#0c857b" theme={darkMode ? 'dark' : 'light'}>
 			<main class="sm:flex h-full">
 				<SideNav />
 				<div id="content" tabIndex="-1" class="flex-row flex-grow">

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -42,7 +42,7 @@
 	</div>
 </ic-hero>
 
-<div class="bg-gray-100 text-center md:text-left px-4">
+<div class="bg-gray-100 dark:bg-gray-800 text-center md:text-left px-4">
 	<ic-section-container align="full-width" class="md:grid md:grid-cols-2 m-auto max-w-6xl p-4">
 		<div class="mr-4 py-4">
 			<Heading text="The Problem" tag="h2" variant="h3" />
@@ -66,7 +66,9 @@
 	</ic-section-container>
 </div>
 
-<div class="bg-gray-50 py-8 px-4 md:px-16 border-b border-b-gray-100 mb-4">
+<div
+	class="bg-gray-50 dark:bg-gray-900 py-8 px-4 md:px-16 border-b border-b-gray-100 dark:border-b-gray-600 mb-4"
+>
 	<ic-section-container align="center" class="font-medium m-auto max-w-6xl">
 		<p>
 			LD-Explorer is a browser-based user interface running on top of the open-source <Link

--- a/src/routes/logs/+page.svelte
+++ b/src/routes/logs/+page.svelte
@@ -15,10 +15,15 @@
 		variant="destructive"
 	/>
 	{#if $recentLogs.length > 0}
-		<ul class="border mt-2 py-2 font-mono text-sm">
+		<ul class="border border-black mt-2 font-mono text-sm dark:border-gray-600">
 			{#each $recentLogs as log (log.timestamp)}
-				<li class={clsx(`py-2 px-4`, log.type == 'error' ? 'bg-icds-error-bg' : 'bg-gray-50')}>
-					<div>
+				<li
+					class={clsx(
+						`py-2 px-4`,
+						log.type == 'error' ? 'bg-icds-error-bg' : 'bg-gray-50 dark:bg-gray-800'
+					)}
+				>
+					<div class="text-black dark:text-white">
 						<strong class="text-base">
 							<time datetime={new Date(log.timestamp).toLocaleString()}
 								>{new Date(log.timestamp).toLocaleString()}</time
@@ -30,7 +35,9 @@
 						</p>
 						{#if log.metadata}
 							<SummaryDetail summaryText="Details">
-								<code data-testid="log-details" class="block border mt-2 bg-white p-2 w-full"
+								<code
+									data-testid="log-details"
+									class="block border border-black mt-2 bg-icds-background-primary p-2 w-full dark:border-gray-600"
 									>{JSON.stringify(log.metadata).trim()}</code
 								>
 							</SummaryDetail>

--- a/src/routes/settings/+page.svelte
+++ b/src/routes/settings/+page.svelte
@@ -7,6 +7,7 @@
 
 	// State (the "dirty" settings are the ones which are in-flight and have not yet been applied)
 	const dirtySettings = {
+		general__darkMode: $settings.general__darkMode,
 		general__defaultLimit: $settings.general__defaultLimit,
 		general__showQuads: $settings.general__showQuads,
 		general__showRDFSLabels: $settings.general__showRDFSLabels
@@ -45,6 +46,13 @@
 			label="Display Labels"
 			helperText="Attempt to fetch and display RDFS labels from active data sources when viewing terms."
 			bind:checked={dirtySettings.general__showRDFSLabels}
+			onchange={() => (dirty = true)}
+		/>
+
+		<Switch
+			label="Dark Mode"
+			helperText="Toggle the dark colour theme."
+			bind:checked={dirtySettings.general__darkMode}
 			onchange={() => (dirty = true)}
 		/>
 

--- a/src/theme.css
+++ b/src/theme.css
@@ -3,6 +3,10 @@
 	--font-display: var(--ic-font-body-family);
 
 	/* ICDS tokens */
+	--color-icds-background-primary: var(--ic-color-background-primary);
+	--color-icds-page-header-border: var(--ic-page-header-border);
+	--color-icds-page-header-background: var(--ic-page-header-background);
+	--color-icds-tree-view-hover: var(--ic-tree-view-hover);
 	--color-icds-personality: var(--ic-theme-primary);
 	--color-icds-hyperlink: var(--ic-color-link-default);
 	--color-icds-hyperlink-hover: var(--ic-color-link-hover);

--- a/src/theme.css
+++ b/src/theme.css
@@ -1,8 +1,6 @@
 @theme inline {
 	/* text and fonts */
 	--font-display: var(--ic-font-body-family);
-	/* Note that we're hard-coding light-mode here. This is due to issues with ICDS' darkmode functionality */
-	--color-icds-primary-text: var(--ic-color-text-primary-light);
 
 	/* ICDS tokens */
 	--color-icds-personality: var(--ic-theme-primary);


### PR DESCRIPTION
- Added a dark mode switch to general settings that toggles the dark theme
  - Updates `ic-theme` with either the 'dark' or 'light' theme
  - Updates the document element with the 'dark' class for TailwindCSS selectors 
- Updated `localStorageJson.store` to spread the `defaultValue`, allowing new settings to be appended to (potentially) already existing settings object

I believe I've taken care of the most obvious `:dark` selectors, but there may be some outstanding. 