### PR TITLE
Code-split comunica query-sparql

### DIFF
--- a/src/lib/querying/engine.test.ts
+++ b/src/lib/querying/engine.test.ts
@@ -1,10 +1,10 @@
 /* (c) Crown Copyright GCHQ */
 
 import { QueryEngine } from '@comunica/query-sparql/lib/index-browser';
-import { engine } from './engine';
+import { createEngine } from './engine';
 
 describe('Comunica engine', () => {
-	it('exports a comunica query engine', () => {
-		expect(engine).toBeInstanceOf(QueryEngine);
+	it('exports a comunica query engine', async () => {
+		expect(await createEngine()).toBeInstanceOf(QueryEngine);
 	});
 });

--- a/src/lib/querying/engine.ts
+++ b/src/lib/querying/engine.ts
@@ -1,5 +1,15 @@
 /* (c) Crown Copyright GCHQ */
 
-import { QueryEngine } from '@comunica/query-sparql';
+import type { QueryEngine } from '@comunica/query-sparql';
 
-export const engine = new QueryEngine();
+let engine: QueryEngine | null;
+
+export async function createEngine(): Promise<QueryEngine> {
+	if (!engine) {
+		// Note the use of a lazy-loaded singleton here is to facilitate
+		// dynamic import/code splitting of query-sparql, a very large package.
+		const { QueryEngine } = await import('@comunica/query-sparql');
+		engine = new QueryEngine();
+	}
+	return engine;
+}

--- a/src/lib/stores/labelLookup.svelte.ts
+++ b/src/lib/stores/labelLookup.svelte.ts
@@ -1,7 +1,7 @@
 /* (c) Crown Copyright GCHQ */
 
 import { get } from 'svelte/store';
-import { engine } from '$lib/querying/engine';
+import { createEngine } from '$lib/querying/engine';
 import { sourceList } from '$stores/sources/sources.store';
 import defaultLabels from '$lib/data/labels.json';
 
@@ -21,7 +21,7 @@ let labelLookup = $state<LabelLookup>(defaultLabels);
 function createSparqlQueryForLabels(terms: string[], lang = 'en') {
 	return `
     PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
-    
+
     SELECT DISTINCT ?entity ?label
     WHERE {
 	 		VALUES ?entity { ${terms.map((term) => `<${term}> `).join(' ')} }
@@ -82,6 +82,7 @@ async function processLabelsQueue() {
 
 	const sparql = createSparqlQueryForLabels(labelsToFetch);
 
+	const engine = await createEngine();
 	const results = await engine.queryBindings(sparql, {
 		sources: get(sourceList),
 		readonly: true,

--- a/src/lib/stores/streamedQuery.store.ts
+++ b/src/lib/stores/streamedQuery.store.ts
@@ -26,7 +26,7 @@ import type { Quad } from '@rdfjs/types';
 import { QueryStatus } from '$lib/types';
 import type { QuerySources } from './sources/sources.store';
 import type { ResultStream } from '@rdfjs/types';
-import { engine } from '$lib/querying/engine';
+import { createEngine } from '$lib/querying/engine';
 
 type QuadsStream = AsyncIterator<Quad> & ResultStream<Quad>;
 type QueryStream = BindingsStream | QuadsStream;
@@ -71,6 +71,7 @@ export function createQueryStore(sparqlQuery: string, sources: QuerySources): St
 			return;
 		}
 
+		const engine = await createEngine();
 		const result = await engine.query(sparqlQuery, {
 			sources,
 			readonly: true,


### PR DESCRIPTION
Comunica is a very large library which we're just taking the default configuration for - it is possible to customize the setup, but we're not doing this:

https://comunica.dev/docs/modify/getting_started/custom_config_app/

as a result, the chunk containing comunica is getting very large (we've been having warnings about it for years). The latest update to Comunica appears to have pushed us over teh default memory limit for node - before we increase this, there are some other things we can try - in particular, this PR introduces code-splitting via a dynamic import to ensure comuica/query-sparql always ends up in its own chunk.