### PR TITLE
Swap JSDOM for HappyDOM

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
 			"name": "ld-explorer",
 			"version": "0.1.1",
 			"license": "Apache-2.0",
+			"dependencies": {
+				"happy-dom": "^20.1.0"
+			},
 			"devDependencies": {
 				"@axe-core/playwright": "^4.11.0",
 				"@comunica/query-sparql": "^4.5.0",
@@ -35,7 +38,6 @@
 				"eslint-plugin-prettier": "^5.5.4",
 				"eslint-plugin-svelte": "^3.14.0",
 				"globals": "^16.5.0",
-				"jsdom": "^27.1.0",
 				"jsonld-streaming-parser": "^5.0.0",
 				"n3": "^1.26.0",
 				"postcss": "^8.5.6",
@@ -55,72 +57,10 @@
 				"vitest": "^4.0.16"
 			}
 		},
-		"node_modules/@acemir/cssom": {
-			"version": "0.9.19",
-			"resolved": "https://registry.npmjs.org/@acemir/cssom/-/cssom-0.9.19.tgz",
-			"integrity": "sha512-Pp2gAQXPZ2o7lt4j0IMwNRXqQ3pagxtDj5wctL5U2Lz4oV0ocDNlkgx4DpxfyKav4S/bePuI+SMqcBSUHLy9kg==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/@adobe/css-tools": {
 			"version": "4.4.4",
 			"resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.4.tgz",
 			"integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/@asamuzakjp/css-color": {
-			"version": "4.0.5",
-			"resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-4.0.5.tgz",
-			"integrity": "sha512-lMrXidNhPGsDjytDy11Vwlb6OIGrT3CmLg3VWNFyWkLWtijKl7xjvForlh8vuj0SHGjgl4qZEQzUmYTeQA2JFQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@csstools/css-calc": "^2.1.4",
-				"@csstools/css-color-parser": "^3.1.0",
-				"@csstools/css-parser-algorithms": "^3.0.5",
-				"@csstools/css-tokenizer": "^3.0.4",
-				"lru-cache": "^11.2.1"
-			}
-		},
-		"node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
-			"version": "11.2.2",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.2.tgz",
-			"integrity": "sha512-F9ODfyqML2coTIsQpSkRHnLSZMtkU8Q+mSfcaIyKwy58u+8k5nvAYeiNhsyMARvzNcXJ9QfWVrcPsC9e9rAxtg==",
-			"dev": true,
-			"license": "ISC",
-			"engines": {
-				"node": "20 || >=22"
-			}
-		},
-		"node_modules/@asamuzakjp/dom-selector": {
-			"version": "6.7.4",
-			"resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-6.7.4.tgz",
-			"integrity": "sha512-buQDjkm+wDPXd6c13534URWZqbz0RP5PAhXZ+LIoa5LgwInT9HVJvGIJivg75vi8I13CxDGdTnz+aY5YUJlIAA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@asamuzakjp/nwsapi": "^2.3.9",
-				"bidi-js": "^1.0.3",
-				"css-tree": "^3.1.0",
-				"is-potential-custom-element-name": "^1.0.1",
-				"lru-cache": "^11.2.2"
-			}
-		},
-		"node_modules/@asamuzakjp/dom-selector/node_modules/lru-cache": {
-			"version": "11.2.2",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.2.tgz",
-			"integrity": "sha512-F9ODfyqML2coTIsQpSkRHnLSZMtkU8Q+mSfcaIyKwy58u+8k5nvAYeiNhsyMARvzNcXJ9QfWVrcPsC9e9rAxtg==",
-			"dev": true,
-			"license": "ISC",
-			"engines": {
-				"node": "20 || >=22"
-			}
-		},
-		"node_modules/@asamuzakjp/nwsapi": {
-			"version": "2.3.9",
-			"resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
-			"integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -5650,141 +5590,6 @@
 				"@rdfjs/types": "^1.0.0"
 			}
 		},
-		"node_modules/@csstools/color-helpers": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
-			"integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/csstools"
-				},
-				{
-					"type": "opencollective",
-					"url": "https://opencollective.com/csstools"
-				}
-			],
-			"license": "MIT-0",
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@csstools/css-calc": {
-			"version": "2.1.4",
-			"resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
-			"integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/csstools"
-				},
-				{
-					"type": "opencollective",
-					"url": "https://opencollective.com/csstools"
-				}
-			],
-			"license": "MIT",
-			"engines": {
-				"node": ">=18"
-			},
-			"peerDependencies": {
-				"@csstools/css-parser-algorithms": "^3.0.5",
-				"@csstools/css-tokenizer": "^3.0.4"
-			}
-		},
-		"node_modules/@csstools/css-color-parser": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
-			"integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/csstools"
-				},
-				{
-					"type": "opencollective",
-					"url": "https://opencollective.com/csstools"
-				}
-			],
-			"license": "MIT",
-			"dependencies": {
-				"@csstools/color-helpers": "^5.1.0",
-				"@csstools/css-calc": "^2.1.4"
-			},
-			"engines": {
-				"node": ">=18"
-			},
-			"peerDependencies": {
-				"@csstools/css-parser-algorithms": "^3.0.5",
-				"@csstools/css-tokenizer": "^3.0.4"
-			}
-		},
-		"node_modules/@csstools/css-parser-algorithms": {
-			"version": "3.0.5",
-			"resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
-			"integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/csstools"
-				},
-				{
-					"type": "opencollective",
-					"url": "https://opencollective.com/csstools"
-				}
-			],
-			"license": "MIT",
-			"engines": {
-				"node": ">=18"
-			},
-			"peerDependencies": {
-				"@csstools/css-tokenizer": "^3.0.4"
-			}
-		},
-		"node_modules/@csstools/css-syntax-patches-for-csstree": {
-			"version": "1.0.15",
-			"resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.0.15.tgz",
-			"integrity": "sha512-q0p6zkVq2lJnmzZVPR33doA51G7YOja+FBvRdp5ISIthL0MtFCgYHHhR563z9WFGxcOn0WfjSkPDJ5Qig3H3Sw==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/csstools"
-				},
-				{
-					"type": "opencollective",
-					"url": "https://opencollective.com/csstools"
-				}
-			],
-			"license": "MIT-0",
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@csstools/css-tokenizer": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
-			"integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/csstools"
-				},
-				{
-					"type": "opencollective",
-					"url": "https://opencollective.com/csstools"
-				}
-			],
-			"license": "MIT",
-			"engines": {
-				"node": ">=18"
-			}
-		},
 		"node_modules/@dabh/diagnostics": {
 			"version": "2.0.8",
 			"resolved": "https://registry.npmjs.org/@dabh/diagnostics/-/diagnostics-2.0.8.tgz",
@@ -6323,9 +6128,9 @@
 			}
 		},
 		"node_modules/@eslint/eslintrc": {
-			"version": "3.3.1",
-			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.1.tgz",
-			"integrity": "sha512-gtF186CXhIl1p4pJNGZw8Yc6RlshoePRvE0X91oPGb3vZ8pM3qOS9W9NGPat9LziaBV7XrJWGylNQXkGcnM3IQ==",
+			"version": "3.3.3",
+			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.3.tgz",
+			"integrity": "sha512-Kr+LPIUVKz2qkx1HAMH8q1q6azbqBAsXJUxBl/ODDuVPX45Z9DfwB8tPjTi6nNZ8BuM3nbJxC5zCAg5elnBUTQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -6335,7 +6140,7 @@
 				"globals": "^14.0.0",
 				"ignore": "^5.2.0",
 				"import-fresh": "^3.2.1",
-				"js-yaml": "^4.1.0",
+				"js-yaml": "^4.1.1",
 				"minimatch": "^3.1.2",
 				"strip-json-comments": "^3.1.1"
 			},
@@ -6579,9 +6384,9 @@
 			}
 		},
 		"node_modules/@rollup/rollup-android-arm-eabi": {
-			"version": "4.52.2",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.52.2.tgz",
-			"integrity": "sha512-o3pcKzJgSGt4d74lSZ+OCnHwkKBeAbFDmbEm5gg70eA8VkyCuC/zV9TwBnmw6VjDlRdF4Pshfb+WE9E6XY1PoQ==",
+			"version": "4.55.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.55.1.tgz",
+			"integrity": "sha512-9R0DM/ykwfGIlNu6+2U09ga0WXeZ9MRC2Ter8jnz8415VbuIykVuc6bhdrbORFZANDmTDvq26mJrEVTl8TdnDg==",
 			"cpu": [
 				"arm"
 			],
@@ -6593,9 +6398,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-android-arm64": {
-			"version": "4.52.2",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.52.2.tgz",
-			"integrity": "sha512-cqFSWO5tX2vhC9hJTK8WAiPIm4Q8q/cU8j2HQA0L3E1uXvBYbOZMhE2oFL8n2pKB5sOCHY6bBuHaRwG7TkfJyw==",
+			"version": "4.55.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.55.1.tgz",
+			"integrity": "sha512-eFZCb1YUqhTysgW3sj/55du5cG57S7UTNtdMjCW7LwVcj3dTTcowCsC8p7uBdzKsZYa8J7IDE8lhMI+HX1vQvg==",
 			"cpu": [
 				"arm64"
 			],
@@ -6635,9 +6440,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-freebsd-arm64": {
-			"version": "4.52.2",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.52.2.tgz",
-			"integrity": "sha512-/eg4CI61ZUkLXxMHyVlmlGrSQZ34xqWlZNW43IAU4RmdzWEx0mQJ2mN/Cx4IHLVZFL6UBGAh+/GXhgvGb+nVxw==",
+			"version": "4.55.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.55.1.tgz",
+			"integrity": "sha512-+JiU7Jbp5cdxekIgdte0jfcu5oqw4GCKr6i3PJTlXTCU5H5Fvtkpbs4XJHRmWNXF+hKmn4v7ogI5OQPaupJgOg==",
 			"cpu": [
 				"arm64"
 			],
@@ -6649,9 +6454,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-freebsd-x64": {
-			"version": "4.52.2",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.52.2.tgz",
-			"integrity": "sha512-QOWgFH5X9+p+S1NAfOqc0z8qEpJIoUHf7OWjNUGOeW18Mx22lAUOiA9b6r2/vpzLdfxi/f+VWsYjUOMCcYh0Ng==",
+			"version": "4.55.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.55.1.tgz",
+			"integrity": "sha512-V5xC1tOVWtLLmr3YUk2f6EJK4qksksOYiz/TCsFHu/R+woubcLWdC9nZQmwjOAbmExBIVKsm1/wKmEy4z4u4Bw==",
 			"cpu": [
 				"x64"
 			],
@@ -6663,9 +6468,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-			"version": "4.52.2",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.52.2.tgz",
-			"integrity": "sha512-kDWSPafToDd8LcBYd1t5jw7bD5Ojcu12S3uT372e5HKPzQt532vW+rGFFOaiR0opxePyUkHrwz8iWYEyH1IIQA==",
+			"version": "4.55.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.55.1.tgz",
+			"integrity": "sha512-Rn3n+FUk2J5VWx+ywrG/HGPTD9jXNbicRtTM11e/uorplArnXZYsVifnPPqNNP5BsO3roI4n8332ukpY/zN7rQ==",
 			"cpu": [
 				"arm"
 			],
@@ -6677,9 +6482,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-arm-musleabihf": {
-			"version": "4.52.2",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.52.2.tgz",
-			"integrity": "sha512-gKm7Mk9wCv6/rkzwCiUC4KnevYhlf8ztBrDRT9g/u//1fZLapSRc+eDZj2Eu2wpJ+0RzUKgtNijnVIB4ZxyL+w==",
+			"version": "4.55.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.55.1.tgz",
+			"integrity": "sha512-grPNWydeKtc1aEdrJDWk4opD7nFtQbMmV7769hiAaYyUKCT1faPRm2av8CX1YJsZ4TLAZcg9gTR1KvEzoLjXkg==",
 			"cpu": [
 				"arm"
 			],
@@ -6719,9 +6524,23 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-loong64-gnu": {
-			"version": "4.52.2",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.52.2.tgz",
-			"integrity": "sha512-8wTRM3+gVMDLLDdaT6tKmOE3lJyRy9NpJUS/ZRWmLCmOPIJhVyXwjBo+XbrrwtV33Em1/eCTd5TuGJm4+DmYjw==",
+			"version": "4.55.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.55.1.tgz",
+			"integrity": "sha512-r3Wv40in+lTsULSb6nnoudVbARdOwb2u5fpeoOAZjFLznp6tDU8kd+GTHmJoqZ9lt6/Sys33KdIHUaQihFcu7g==",
+			"cpu": [
+				"loong64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-loong64-musl": {
+			"version": "4.55.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.55.1.tgz",
+			"integrity": "sha512-MR8c0+UxAlB22Fq4R+aQSPBayvYa3+9DrwG/i1TKQXFYEaoW3B5b/rkSRIypcZDdWjWnpcvxbNaAJDcSbJU3Lw==",
 			"cpu": [
 				"loong64"
 			],
@@ -6733,9 +6552,23 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-ppc64-gnu": {
-			"version": "4.52.2",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.52.2.tgz",
-			"integrity": "sha512-6yqEfgJ1anIeuP2P/zhtfBlDpXUb80t8DpbYwXQ3bQd95JMvUaqiX+fKqYqUwZXqdJDd8xdilNtsHM2N0cFm6A==",
+			"version": "4.55.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.55.1.tgz",
+			"integrity": "sha512-3KhoECe1BRlSYpMTeVrD4sh2Pw2xgt4jzNSZIIPLFEsnQn9gAnZagW9+VqDqAHgm1Xc77LzJOo2LdigS5qZ+gw==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-ppc64-musl": {
+			"version": "4.55.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.55.1.tgz",
+			"integrity": "sha512-ziR1OuZx0vdYZZ30vueNZTg73alF59DicYrPViG0NEgDVN8/Jl87zkAPu4u6VjZST2llgEUjaiNl9JM6HH1Vdw==",
 			"cpu": [
 				"ppc64"
 			],
@@ -6747,9 +6580,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-riscv64-gnu": {
-			"version": "4.52.2",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.52.2.tgz",
-			"integrity": "sha512-sshYUiYVSEI2B6dp4jMncwxbrUqRdNApF2c3bhtLAU0qA8Lrri0p0NauOsTWh3yCCCDyBOjESHMExonp7Nzc0w==",
+			"version": "4.55.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.55.1.tgz",
+			"integrity": "sha512-uW0Y12ih2XJRERZ4jAfKamTyIHVMPQnTZcQjme2HMVDAHY4amf5u414OqNYC+x+LzRdRcnIG1YodLrrtA8xsxw==",
 			"cpu": [
 				"riscv64"
 			],
@@ -6761,9 +6594,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-riscv64-musl": {
-			"version": "4.52.2",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.52.2.tgz",
-			"integrity": "sha512-duBLgd+3pqC4MMwBrKkFxaZerUxZcYApQVC5SdbF5/e/589GwVvlRUnyqMFbM8iUSb1BaoX/3fRL7hB9m2Pj8Q==",
+			"version": "4.55.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.55.1.tgz",
+			"integrity": "sha512-u9yZ0jUkOED1BFrqu3BwMQoixvGHGZ+JhJNkNKY/hyoEgOwlqKb62qu+7UjbPSHYjiVy8kKJHvXKv5coH4wDeg==",
 			"cpu": [
 				"riscv64"
 			],
@@ -6775,9 +6608,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-s390x-gnu": {
-			"version": "4.52.2",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.52.2.tgz",
-			"integrity": "sha512-tzhYJJidDUVGMgVyE+PmxENPHlvvqm1KILjjZhB8/xHYqAGeizh3GBGf9u6WdJpZrz1aCpIIHG0LgJgH9rVjHQ==",
+			"version": "4.55.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.55.1.tgz",
+			"integrity": "sha512-/0PenBCmqM4ZUd0190j7J0UsQ/1nsi735iPRakO8iPciE7BQ495Y6msPzaOmvx0/pn+eJVVlZrNrSh4WSYLxNg==",
 			"cpu": [
 				"s390x"
 			],
@@ -6816,10 +6649,24 @@
 				"linux"
 			]
 		},
+		"node_modules/@rollup/rollup-openbsd-x64": {
+			"version": "4.55.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.55.1.tgz",
+			"integrity": "sha512-eLXw0dOiqE4QmvikfQ6yjgkg/xDM+MdU9YJuP4ySTibXU0oAvnEWXt7UDJmD4UkYialMfOGFPJnIHSe/kdzPxg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openbsd"
+			]
+		},
 		"node_modules/@rollup/rollup-openharmony-arm64": {
-			"version": "4.52.2",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.52.2.tgz",
-			"integrity": "sha512-uPj7MQ6/s+/GOpolavm6BPo+6CbhbKYyZHUDvZ/SmJM7pfDBgdGisFX3bY/CBDMg2ZO4utfhlApkSfZ92yXw7Q==",
+			"version": "4.55.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.55.1.tgz",
+			"integrity": "sha512-xzm44KgEP11te3S2HCSyYf5zIzWmx3n8HDCc7EE59+lTcswEWNpvMLfd9uJvVX8LCg9QWG67Xt75AuHn4vgsXw==",
 			"cpu": [
 				"arm64"
 			],
@@ -6845,9 +6692,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-win32-ia32-msvc": {
-			"version": "4.52.2",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.52.2.tgz",
-			"integrity": "sha512-+GnYBmpjldD3XQd+HMejo+0gJGwYIOfFeoBQv32xF/RUIvccUz20/V6Otdv+57NE70D5pa8W/jVGDoGq0oON4A==",
+			"version": "4.55.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.55.1.tgz",
+			"integrity": "sha512-3fZBidchE0eY0oFZBnekYCfg+5wAB0mbpCBuofh5mZuzIU/4jIVkbESmd2dOsFNS78b53CYv3OAtwqkZZmU5nA==",
 			"cpu": [
 				"ia32"
 			],
@@ -6859,9 +6706,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-win32-x64-gnu": {
-			"version": "4.52.2",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.52.2.tgz",
-			"integrity": "sha512-ApXFKluSB6kDQkAqZOKXBjiaqdF1BlKi+/eqnYe9Ee7U2K3pUDKsIyr8EYm/QDHTJIM+4X+lI0gJc3TTRhd+dA==",
+			"version": "4.55.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.55.1.tgz",
+			"integrity": "sha512-xGGY5pXj69IxKb4yv/POoocPy/qmEGhimy/FoTpTSVju3FYXUQQMFCaZZXJVidsmGxRioZAwpThl/4zX41gRKg==",
 			"cpu": [
 				"x64"
 			],
@@ -6899,24 +6746,6 @@
 				"node": ">=v12.22.12"
 			}
 		},
-		"node_modules/@smessie/readable-web-to-node-stream": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/@smessie/readable-web-to-node-stream/-/readable-web-to-node-stream-3.0.3.tgz",
-			"integrity": "sha512-8FFE7psRtRWQT31/duqbmgnSf2++QLR2YH9kj5iwsHhnoqSvHdOY3SAN5e7dhc+60p2cNk7rv3HYOiXOapTEXQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"process": "^0.11.10",
-				"readable-stream": "^4.5.1"
-			},
-			"engines": {
-				"node": ">=8"
-			},
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/Borewit"
-			}
-		},
 		"node_modules/@so-ric/colorspace": {
 			"version": "1.1.6",
 			"resolved": "https://registry.npmjs.org/@so-ric/colorspace/-/colorspace-1.1.6.tgz",
@@ -6929,16 +6758,16 @@
 			}
 		},
 		"node_modules/@standard-schema/spec": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.0.0.tgz",
-			"integrity": "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+			"integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
 			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@stencil/core": {
-			"version": "4.37.1",
-			"resolved": "https://registry.npmjs.org/@stencil/core/-/core-4.37.1.tgz",
-			"integrity": "sha512-s4ZroxdYc2HU0b7V3n59RVtMKdNlTvWWBN8KofaP64eCzvg1qRh6SKMet7MJ069F1lx/FxDvsYfOv7pZRiMWmQ==",
+			"version": "4.41.1",
+			"resolved": "https://registry.npmjs.org/@stencil/core/-/core-4.41.1.tgz",
+			"integrity": "sha512-dX9o15OFnvXkg7eiquu5py2CPePJsduRVHmJvU3wbn3bpzjj08+Fc64lVQzTADqVKEsNvwQpyXjmWSS7iKgaBQ==",
 			"dev": true,
 			"license": "MIT",
 			"bin": {
@@ -6960,9 +6789,9 @@
 			}
 		},
 		"node_modules/@sveltejs/acorn-typescript": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/@sveltejs/acorn-typescript/-/acorn-typescript-1.0.5.tgz",
-			"integrity": "sha512-IwQk4yfwLdibDlrXVE04jTZYlLnwsTT2PIOQQGNLWfjavGifnk1JD1LcZjZaBTRcxZu2FfPfNLOE04DSu9lqtQ==",
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/@sveltejs/acorn-typescript/-/acorn-typescript-1.0.8.tgz",
+			"integrity": "sha512-esgN+54+q0NjB0Y/4BomT9samII7jGwNy/2a3wNZbT2A2RpmXsXwUt24LvLhx6jUq2gVk4cWEvcRO6MFQbOfNA==",
 			"dev": true,
 			"license": "MIT",
 			"peerDependencies": {
@@ -7044,13 +6873,13 @@
 			}
 		},
 		"node_modules/@sveltejs/vite-plugin-svelte-inspector": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte-inspector/-/vite-plugin-svelte-inspector-5.0.1.tgz",
-			"integrity": "sha512-ubWshlMk4bc8mkwWbg6vNvCeT7lGQojE3ijDh3QTR6Zr/R+GXxsGbyH4PExEPpiFmqPhYiVSVmHBjUcVc1JIrA==",
+			"version": "5.0.2",
+			"resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte-inspector/-/vite-plugin-svelte-inspector-5.0.2.tgz",
+			"integrity": "sha512-TZzRTcEtZffICSAoZGkPSl6Etsj2torOVrx6Uw0KpXxrec9Gg6jFWQ60Q3+LmNGfZSxHRCZL7vXVZIWmuV50Ig==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"debug": "^4.4.1"
+				"obug": "^2.1.0"
 			},
 			"engines": {
 				"node": "^20.19 || ^22.12 || >=24"
@@ -7538,19 +7367,18 @@
 			}
 		},
 		"node_modules/@types/node": {
-			"version": "24.5.2",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-24.5.2.tgz",
-			"integrity": "sha512-FYxk1I7wPv3K2XBaoyH2cTnocQEu8AOZ60hPbsyukMPLv5/5qr7V1i8PLHdl6Zf87I+xZXFvPCXYjiTFq+YSDQ==",
-			"dev": true,
+			"version": "25.0.6",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-25.0.6.tgz",
+			"integrity": "sha512-NNu0sjyNxpoiW3YuVFfNz7mxSQ+S4X2G28uqg2s+CzoqoQjLPsWSbsFFyztIAqt2vb8kfEAsJNepMGPTxFDx3Q==",
 			"license": "MIT",
 			"dependencies": {
-				"undici-types": "~7.12.0"
+				"undici-types": "~7.16.0"
 			}
 		},
 		"node_modules/@types/readable-stream": {
-			"version": "4.0.21",
-			"resolved": "https://registry.npmjs.org/@types/readable-stream/-/readable-stream-4.0.21.tgz",
-			"integrity": "sha512-19eKVv9tugr03IgfXlA9UVUVRbW6IuqRO5B92Dl4a6pT7K8uaGrNS0GkxiZD0BOk6PLuXl5FhWl//eX/pzYdTQ==",
+			"version": "4.0.23",
+			"resolved": "https://registry.npmjs.org/@types/readable-stream/-/readable-stream-4.0.23.tgz",
+			"integrity": "sha512-wwXrtQvbMHxCbBgjHaMGEmImFTQxxpfMOR/ZoQnXxB1woqkUbdLGFDgauo00Py9IudiaqSeiBiulSV9i6XIPig==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -7609,6 +7437,21 @@
 			"integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/@types/whatwg-mimetype": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/@types/whatwg-mimetype/-/whatwg-mimetype-3.0.2.tgz",
+			"integrity": "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==",
+			"license": "MIT"
+		},
+		"node_modules/@types/ws": {
+			"version": "8.18.1",
+			"resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+			"integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/node": "*"
+			}
 		},
 		"node_modules/@types/yargs": {
 			"version": "17.0.35",
@@ -8084,16 +7927,6 @@
 				"acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
 			}
 		},
-		"node_modules/agent-base": {
-			"version": "7.1.4",
-			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
-			"integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 14"
-			}
-		},
 		"node_modules/ajv": {
 			"version": "6.12.6",
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -8172,9 +8005,9 @@
 			}
 		},
 		"node_modules/ast-v8-to-istanbul": {
-			"version": "0.3.8",
-			"resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-0.3.8.tgz",
-			"integrity": "sha512-szgSZqUxI5T8mLKvS7WTjF9is+MVbOeLADU73IseOcrqhxr/VAvy6wfoVE39KnKzA7JRhjF5eUagNlHwvZPlKQ==",
+			"version": "0.3.10",
+			"resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-0.3.10.tgz",
+			"integrity": "sha512-p4K7vMz2ZSk3wN8l5o3y2bJAoZXT3VuJI5OLTATY/01CYWumWvwkUw0SqDBnNq6IiTO3qDa1eSQDibAV8g7XOQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -8255,9 +8088,9 @@
 			}
 		},
 		"node_modules/axe-core": {
-			"version": "4.11.0",
-			"resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.0.tgz",
-			"integrity": "sha512-ilYanEU8vxxBexpJd8cWM4ElSQq4QctCLKih0TSfjIfCQTeyH/6zVrmIJfLPrKTKJRbiG+cfnZbQIjAlJmF1jQ==",
+			"version": "4.11.1",
+			"resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.1.tgz",
+			"integrity": "sha512-BASOg+YwO2C+346x3LZOeoovTIoTrRqEsqMa6fmfAV0P+U9mFr9NsyOEpiYvFjbc64NMrSswhV50WdXzdb/Z5A==",
 			"dev": true,
 			"license": "MPL-2.0",
 			"engines": {
@@ -8303,23 +8136,13 @@
 			"license": "MIT"
 		},
 		"node_modules/baseline-browser-mapping": {
-			"version": "2.9.7",
-			"resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.7.tgz",
-			"integrity": "sha512-k9xFKplee6KIio3IDbwj+uaCLpqzOwakOgmqzPezM0sFJlFKcg30vk2wOiAJtkTSfx0SSQDSe8q+mWA/fSH5Zg==",
+			"version": "2.9.14",
+			"resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.14.tgz",
+			"integrity": "sha512-B0xUquLkiGLgHhpPBqvl7GWegWBUNuujQ6kXd/r1U38ElPT6Ok8KZ8e+FpUGEc2ZoRQUzq/aUnaKFc/svWUGSg==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"bin": {
 				"baseline-browser-mapping": "dist/cli.js"
-			}
-		},
-		"node_modules/bidi-js": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
-			"integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"require-from-string": "^2.0.2"
 			}
 		},
 		"node_modules/bignumber.js": {
@@ -8413,9 +8236,9 @@
 			}
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001760",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001760.tgz",
-			"integrity": "sha512-7AAMPcueWELt1p3mi13HR/LHH0TJLT11cnwDJEs3xA4+CK/PLKeO9Kl1oru24htkyUKtkGCvAx4ohB0Ttry8Dw==",
+			"version": "1.0.30001764",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001764.tgz",
+			"integrity": "sha512-9JGuzl2M+vPL+pz70gtMF9sHdMFbY9FJaQBi186cHKH3pSzDvzoUJUPV6fqiKIMyXbud9ZLg4F3Yza1vJ1+93g==",
 			"dev": true,
 			"funding": [
 				{
@@ -8496,59 +8319,6 @@
 			},
 			"engines": {
 				"node": ">=12"
-			}
-		},
-		"node_modules/cliui/node_modules/emoji-regex": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/cliui/node_modules/string-width": {
-			"version": "4.2.3",
-			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"emoji-regex": "^8.0.0",
-				"is-fullwidth-code-point": "^3.0.0",
-				"strip-ansi": "^6.0.1"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/cliui/node_modules/strip-ansi": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"ansi-regex": "^5.0.1"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/cliui/node_modules/wrap-ansi": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-			"integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"ansi-styles": "^4.0.0",
-				"string-width": "^4.1.0",
-				"strip-ansi": "^6.0.0"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
 			}
 		},
 		"node_modules/clsx": {
@@ -8642,9 +8412,9 @@
 			}
 		},
 		"node_modules/componentsjs": {
-			"version": "6.3.0",
-			"resolved": "https://registry.npmjs.org/componentsjs/-/componentsjs-6.3.0.tgz",
-			"integrity": "sha512-psWOXR/jk21yy4RwSi6CnIHqOn17QoECF+D+5LQqF+aGdvH1ZOlSlC/sD5j9xJGPpQ0wG5zE26SO3/t7W5JTrQ==",
+			"version": "6.4.0",
+			"resolved": "https://registry.npmjs.org/componentsjs/-/componentsjs-6.4.0.tgz",
+			"integrity": "sha512-H3AmzWARyQB5V/XJ7brjnFVfqywedjVFX3n528GKjEpQvNY4HXu5CBOAWDADjeSC42cufVc7C+J+cGTsgeKRzg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -8654,27 +8424,17 @@
 				"@types/semver": "^7.3.4",
 				"jsonld-context-parser": "^3.0.0",
 				"minimist": "^1.2.0",
-				"rdf-data-factory": "^1.1.0",
-				"rdf-object": "^2.0.0",
-				"rdf-parse": "^2.0.0",
-				"rdf-quad": "^1.5.0",
-				"rdf-string": "^1.6.0",
-				"rdf-terms": "^1.7.0",
+				"rdf-data-factory": "^2.0.2",
+				"rdf-object": "^3.0.0",
+				"rdf-parse": "^4.0.0",
+				"rdf-quad": "^2.0.0",
+				"rdf-string": "^2.0.1",
+				"rdf-terms": "^2.0.0",
 				"semver": "^7.3.2",
 				"winston": "^3.3.3"
 			},
 			"bin": {
 				"componentsjs-compile-config": "bin/compile-config.js"
-			}
-		},
-		"node_modules/componentsjs/node_modules/@rdfjs/types": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/@rdfjs/types/-/types-1.1.2.tgz",
-			"integrity": "sha512-wqpOJK1QCbmsGNtyzYnojPU8gRDPid2JO0Q0kMtb4j65xhCK880cnKAfEOwC+dX85VJcCByQx5zOwyyfCjDJsg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@types/node": "*"
 			}
 		},
 		"node_modules/componentsjs/node_modules/@types/node": {
@@ -8703,14 +8463,59 @@
 				"jsonld-context-parse": "bin/jsonld-context-parse.js"
 			}
 		},
-		"node_modules/componentsjs/node_modules/rdf-data-factory": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/rdf-data-factory/-/rdf-data-factory-1.1.3.tgz",
-			"integrity": "sha512-ny6CI7m2bq4lfQQmDYvcb2l1F9KtGwz9chipX4oWu2aAtVoXjb7k3d8J1EsgAsEbMXnBipB/iuRen5H2fwRWWQ==",
+		"node_modules/componentsjs/node_modules/rdf-literal": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/rdf-literal/-/rdf-literal-2.0.0.tgz",
+			"integrity": "sha512-jlQ+h7EvnXmncmk8OzOYR8T3gNfd4g0LQXbflHkEkancic8dh0Tdt5RiRq8vUFndjIeNHt1RWeA5TAj6rgrtng==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@rdfjs/types": "^1.0.0"
+				"rdf-data-factory": "^2.0.0"
+			},
+			"funding": {
+				"type": "individual",
+				"url": "https://github.com/sponsors/rubensworks/"
+			}
+		},
+		"node_modules/componentsjs/node_modules/rdf-quad": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/rdf-quad/-/rdf-quad-2.0.0.tgz",
+			"integrity": "sha512-wR3x+ypdPh6jlFy+i/+U3jUlr5078GHfBkqf3TPPJa7zJVurkJY0J8ALKPWYd1V4oyYsqJCHr3xNM5RDlvH32A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"rdf-data-factory": "^2.0.1",
+				"rdf-literal": "^2.0.0",
+				"rdf-string": "^2.0.0"
+			}
+		},
+		"node_modules/componentsjs/node_modules/rdf-string": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/rdf-string/-/rdf-string-2.0.1.tgz",
+			"integrity": "sha512-SMW4ponnKNrsP9kYpOLyICeM4UJmEXIeS3zri7kPK9gzLFsHD88oiza8LnokNYxd76zW4JoYWD+v4x0g8rJBjw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"rdf-data-factory": "^2.0.0"
+			},
+			"funding": {
+				"type": "individual",
+				"url": "https://github.com/sponsors/rubensworks/"
+			}
+		},
+		"node_modules/componentsjs/node_modules/rdf-terms": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/rdf-terms/-/rdf-terms-2.0.0.tgz",
+			"integrity": "sha512-9O+ifVcvY4ZktOr+uXKswoOV6airAsIKeqCr+C47kFZBB8X+NyPSqDRGgI6X+je8It6z2e9jZhWwjJiEZ8Yn5Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"rdf-data-factory": "^2.0.0",
+				"rdf-string": "^2.0.0"
+			},
+			"funding": {
+				"type": "individual",
+				"url": "https://github.com/sponsors/rubensworks/"
 			}
 		},
 		"node_modules/componentsjs/node_modules/undici-types": {
@@ -8762,20 +8567,6 @@
 				"node": ">= 8"
 			}
 		},
-		"node_modules/css-tree": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.1.0.tgz",
-			"integrity": "sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"mdn-data": "2.12.2",
-				"source-map-js": "^1.0.1"
-			},
-			"engines": {
-				"node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
-			}
-		},
 		"node_modules/css.escape": {
 			"version": "1.5.1",
 			"resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
@@ -8796,21 +8587,6 @@
 				"node": ">=4"
 			}
 		},
-		"node_modules/cssstyle": {
-			"version": "5.3.2",
-			"resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-5.3.2.tgz",
-			"integrity": "sha512-zDMqXh8Vs1CdRYZQ2M633m/SFgcjlu8RB8b/1h82i+6vpArF507NSYIWJHGlJaTWoS+imcnctmEz43txhbVkOw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@asamuzakjp/css-color": "^4.0.3",
-				"@csstools/css-syntax-patches-for-csstree": "^1.0.14",
-				"css-tree": "^3.1.0"
-			},
-			"engines": {
-				"node": ">=20"
-			}
-		},
 		"node_modules/cytoscape": {
 			"version": "3.33.1",
 			"resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.33.1.tgz",
@@ -8819,20 +8595,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10"
-			}
-		},
-		"node_modules/data-urls": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/data-urls/-/data-urls-6.0.0.tgz",
-			"integrity": "sha512-BnBS08aLUM+DKamupXs3w2tJJoqU+AkaE/+6vQxi/G/DPmIZFJJp9Dkb1kM03AZx8ADehDUZgsNxju3mPXZYIA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"whatwg-mimetype": "^4.0.0",
-				"whatwg-url": "^15.0.0"
-			},
-			"engines": {
-				"node": ">=20"
 			}
 		},
 		"node_modules/debug": {
@@ -8852,13 +8614,6 @@
 					"optional": true
 				}
 			}
-		},
-		"node_modules/decimal.js": {
-			"version": "10.6.0",
-			"resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
-			"integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
-			"dev": true,
-			"license": "MIT"
 		},
 		"node_modules/deep-is": {
 			"version": "0.1.4",
@@ -8888,9 +8643,9 @@
 			}
 		},
 		"node_modules/detect-libc": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.0.tgz",
-			"integrity": "sha512-vEtk+OcP7VBRtQZ1EJ3bdgzSfBjgnEalLTp5zjJrS+2Z1w2KZly4SBdac/WDU3hhsNAZ9E8SC96ME4Ey8MZ7cg==",
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+			"integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"engines": {
@@ -8898,9 +8653,9 @@
 			}
 		},
 		"node_modules/devalue": {
-			"version": "5.5.0",
-			"resolved": "https://registry.npmjs.org/devalue/-/devalue-5.5.0.tgz",
-			"integrity": "sha512-69sM5yrHfFLJt0AZ9QqZXGCPfJ7fQjvpln3Rq5+PS03LD32Ost1Q9N+eEnaQwGRIriKkMImXD56ocjQmfjbV3w==",
+			"version": "5.6.1",
+			"resolved": "https://registry.npmjs.org/devalue/-/devalue-5.6.1.tgz",
+			"integrity": "sha512-jDwizj+IlEZBunHcOuuFVBnIMPAEHvTsJj0BcIp94xYguLRVBcXO853px/MyIJvbVzWdsGvrRweIUWJw8hBP7A==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -8969,9 +8724,9 @@
 			}
 		},
 		"node_modules/dompurify": {
-			"version": "3.2.7",
-			"resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.7.tgz",
-			"integrity": "sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw==",
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.1.tgz",
+			"integrity": "sha512-qkdCKzLNtrgPFP1Vo+98FRzJnBRGe4ffyCea9IwHB1fyxPOeNTHpLKYGd4Uk9xvNoH0ZoOjwZxNptyMwqrId1Q==",
 			"dev": true,
 			"license": "(MPL-2.0 OR Apache-2.0)",
 			"optionalDependencies": {
@@ -8999,6 +8754,13 @@
 			"integrity": "sha512-0Drusm6MVRXSOJpGbaSVgcQsuB4hEkMpHXaVstcPmhu5LIedxs1xNK/nIxmQIU/RPC0+1/o0AVZfBTkTNJOdUw==",
 			"dev": true,
 			"license": "ISC"
+		},
+		"node_modules/emoji-regex": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/enabled": {
 			"version": "2.0.0",
@@ -9303,9 +9065,9 @@
 			}
 		},
 		"node_modules/esquery": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.6.0.tgz",
-			"integrity": "sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==",
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+			"integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
 			"dev": true,
 			"license": "BSD-3-Clause",
 			"dependencies": {
@@ -9396,9 +9158,9 @@
 			}
 		},
 		"node_modules/expect-type": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.2.2.tgz",
-			"integrity": "sha512-JhFGDVJ7tmDJItKhYgJCGLOWjuK9vPxiXoUFLwLDc99NlmklilbiQJwoctZtt13+xMw91MCk/REan6MWHqDjyA==",
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+			"integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"engines": {
@@ -9749,6 +9511,37 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/happy-dom": {
+			"version": "20.1.0",
+			"resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-20.1.0.tgz",
+			"integrity": "sha512-ebvqjBqzenBk2LjzNEAzoj7yhw7rW/R2/wVevMu6Mrq3MXtcI/RUz4+ozpcOcqVLEWPqLfg2v9EAU7fFXZUUJw==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/node": "^20.0.0",
+				"@types/whatwg-mimetype": "^3.0.2",
+				"@types/ws": "^8.18.1",
+				"whatwg-mimetype": "^3.0.0",
+				"ws": "^8.18.3"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/happy-dom/node_modules/@types/node": {
+			"version": "20.19.28",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.28.tgz",
+			"integrity": "sha512-VyKBr25BuFDzBFCK5sUM6ZXiWfqgCTwTAOK8qzGV/m9FCirXYDlmczJ+d5dXBAQALGCdRRdbteKYfJ84NGEusw==",
+			"license": "MIT",
+			"dependencies": {
+				"undici-types": "~6.21.0"
+			}
+		},
+		"node_modules/happy-dom/node_modules/undici-types": {
+			"version": "6.21.0",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+			"integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+			"license": "MIT"
+		},
 		"node_modules/has-flag": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -9768,19 +9561,6 @@
 			"dependencies": {
 				"inherits": "^2.0.3",
 				"minimalistic-assert": "^1.0.1"
-			}
-		},
-		"node_modules/html-encoding-sniffer": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
-			"integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"whatwg-encoding": "^3.1.1"
-			},
-			"engines": {
-				"node": ">=18"
 			}
 		},
 		"node_modules/html-escaper": {
@@ -9818,47 +9598,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=6.0.0"
-			}
-		},
-		"node_modules/http-proxy-agent": {
-			"version": "7.0.2",
-			"resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
-			"integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"agent-base": "^7.1.0",
-				"debug": "^4.3.4"
-			},
-			"engines": {
-				"node": ">= 14"
-			}
-		},
-		"node_modules/https-proxy-agent": {
-			"version": "7.0.6",
-			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
-			"integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"agent-base": "^7.1.2",
-				"debug": "4"
-			},
-			"engines": {
-				"node": ">= 14"
-			}
-		},
-		"node_modules/iconv-lite": {
-			"version": "0.6.3",
-			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-			"integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"safer-buffer": ">= 2.1.2 < 3.0.0"
-			},
-			"engines": {
-				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/ieee754": {
@@ -9976,13 +9715,6 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/is-potential-custom-element-name": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
-			"integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/is-reference": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/is-reference/-/is-reference-3.0.3.tgz",
@@ -10097,46 +9829,6 @@
 				"js-yaml": "bin/js-yaml.js"
 			}
 		},
-		"node_modules/jsdom": {
-			"version": "27.1.0",
-			"resolved": "https://registry.npmjs.org/jsdom/-/jsdom-27.1.0.tgz",
-			"integrity": "sha512-Pcfm3eZ+eO4JdZCXthW9tCDT3nF4K+9dmeZ+5X39n+Kqz0DDIABRP5CAEOHRFZk8RGuC2efksTJxrjp8EXCunQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@acemir/cssom": "^0.9.19",
-				"@asamuzakjp/dom-selector": "^6.7.3",
-				"cssstyle": "^5.3.2",
-				"data-urls": "^6.0.0",
-				"decimal.js": "^10.6.0",
-				"html-encoding-sniffer": "^4.0.0",
-				"http-proxy-agent": "^7.0.2",
-				"https-proxy-agent": "^7.0.6",
-				"is-potential-custom-element-name": "^1.0.1",
-				"parse5": "^8.0.0",
-				"saxes": "^6.0.0",
-				"symbol-tree": "^3.2.4",
-				"tough-cookie": "^6.0.0",
-				"w3c-xmlserializer": "^5.0.0",
-				"webidl-conversions": "^8.0.0",
-				"whatwg-encoding": "^3.1.1",
-				"whatwg-mimetype": "^4.0.0",
-				"whatwg-url": "^15.1.0",
-				"ws": "^8.18.3",
-				"xml-name-validator": "^5.0.0"
-			},
-			"engines": {
-				"node": "^20.19.0 || ^22.12.0 || >=24.0.0"
-			},
-			"peerDependencies": {
-				"canvas": "^3.0.0"
-			},
-			"peerDependenciesMeta": {
-				"canvas": {
-					"optional": true
-				}
-			}
-		},
 		"node_modules/json-buffer": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
@@ -10215,9 +9907,9 @@
 			}
 		},
 		"node_modules/jsonld-streaming-parser/node_modules/@types/node": {
-			"version": "18.19.127",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.127.tgz",
-			"integrity": "sha512-gSjxjrnKXML/yo0BO099uPixMqfpJU0TKYjpfLU7TrtA2WWDki412Np/RSTPRil1saKBhvVVKzVx/p/6p94nVA==",
+			"version": "18.19.130",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
+			"integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -10720,13 +10412,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/mdn-data": {
-			"version": "2.12.2",
-			"resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.12.2.tgz",
-			"integrity": "sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==",
-			"dev": true,
-			"license": "CC0-1.0"
-		},
 		"node_modules/microdata-rdf-streaming-parser": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/microdata-rdf-streaming-parser/-/microdata-rdf-streaming-parser-2.0.1.tgz",
@@ -10928,31 +10613,6 @@
 				}
 			}
 		},
-		"node_modules/node-fetch/node_modules/tr46": {
-			"version": "0.0.3",
-			"resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-			"integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/node-fetch/node_modules/webidl-conversions": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-			"integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-			"dev": true,
-			"license": "BSD-2-Clause"
-		},
-		"node_modules/node-fetch/node_modules/whatwg-url": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-			"integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"tr46": "~0.0.3",
-				"webidl-conversions": "^3.0.0"
-			}
-		},
 		"node_modules/node-releases": {
 			"version": "2.0.27",
 			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
@@ -11055,19 +10715,6 @@
 			},
 			"engines": {
 				"node": ">=6"
-			}
-		},
-		"node_modules/parse5": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.0.tgz",
-			"integrity": "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"entities": "^6.0.0"
-			},
-			"funding": {
-				"url": "https://github.com/inikulin/parse5?sponsor=1"
 			}
 		},
 		"node_modules/path-exists": {
@@ -11273,9 +10920,9 @@
 			}
 		},
 		"node_modules/postcss-selector-parser": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.0.tgz",
-			"integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
+			"integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -11320,9 +10967,9 @@
 			}
 		},
 		"node_modules/prettier-linter-helpers": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
-			"integrity": "sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.1.tgz",
+			"integrity": "sha512-SxToR7P8Y2lWmv/kTzVLC1t/GDI2WGjMwNhLLE9qtH8Q13C+aEmuRlzDst4Up4s0Wc8sF2M+J57iB3cMLqftfg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -11489,31 +11136,20 @@
 			}
 		},
 		"node_modules/rdf-object": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/rdf-object/-/rdf-object-2.0.0.tgz",
-			"integrity": "sha512-QeSaNt/I0DfYvOC3/EBbZ9aYb1wX1fqc0JUKMAR2gpIE99eWn7+N8dE8Z7a7kIM5tr/w7zvrO710gYs9yvaM9A==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/rdf-object/-/rdf-object-3.0.0.tgz",
+			"integrity": "sha512-qefryIRh1d9gqZUKp2qQwzIWLbmQspsc2bvVoOCCp126MZmKubcUTigHiMlCrUI9g7MDCrdTFAwcAal1lVR09A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@rdfjs/types": "*",
 				"jsonld-context-parser": "^3.0.0",
-				"rdf-data-factory": "^1.1.0",
-				"rdf-string": "^1.6.0",
+				"rdf-data-factory": "^2.0.1",
+				"rdf-string": "^2.0.0",
 				"streamify-array": "^1.0.1"
 			},
 			"funding": {
 				"type": "individual",
 				"url": "https://github.com/sponsors/rubensworks/"
-			}
-		},
-		"node_modules/rdf-object/node_modules/@rdfjs/types": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/@rdfjs/types/-/types-1.1.2.tgz",
-			"integrity": "sha512-wqpOJK1QCbmsGNtyzYnojPU8gRDPid2JO0Q0kMtb4j65xhCK880cnKAfEOwC+dX85VJcCByQx5zOwyyfCjDJsg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@types/node": "*"
 			}
 		},
 		"node_modules/rdf-object/node_modules/@types/node": {
@@ -11542,14 +11178,18 @@
 				"jsonld-context-parse": "bin/jsonld-context-parse.js"
 			}
 		},
-		"node_modules/rdf-object/node_modules/rdf-data-factory": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/rdf-data-factory/-/rdf-data-factory-1.1.3.tgz",
-			"integrity": "sha512-ny6CI7m2bq4lfQQmDYvcb2l1F9KtGwz9chipX4oWu2aAtVoXjb7k3d8J1EsgAsEbMXnBipB/iuRen5H2fwRWWQ==",
+		"node_modules/rdf-object/node_modules/rdf-string": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/rdf-string/-/rdf-string-2.0.1.tgz",
+			"integrity": "sha512-SMW4ponnKNrsP9kYpOLyICeM4UJmEXIeS3zri7kPK9gzLFsHD88oiza8LnokNYxd76zW4JoYWD+v4x0g8rJBjw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@rdfjs/types": "^1.0.0"
+				"rdf-data-factory": "^2.0.0"
+			},
+			"funding": {
+				"type": "individual",
+				"url": "https://github.com/sponsors/rubensworks/"
 			}
 		},
 		"node_modules/rdf-object/node_modules/undici-types": {
@@ -11560,359 +11200,42 @@
 			"license": "MIT"
 		},
 		"node_modules/rdf-parse": {
-			"version": "2.3.3",
-			"resolved": "https://registry.npmjs.org/rdf-parse/-/rdf-parse-2.3.3.tgz",
-			"integrity": "sha512-N5XEHm+ajFzwo/vVNzB4tDtvqMwBosbVJmZl5DlzplQM9ejlJBlN/43i0ImAb/NMtJJgQPC3jYnkCKGA7wdo/w==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/rdf-parse/-/rdf-parse-4.0.0.tgz",
+			"integrity": "sha512-lNVuUKPVAdX9lJYYrJFhdQHFulYjk95BYvuNsE+eUs/M93sdsovH/Ga8bTAxagmpsoQ4LzMPa2YqeHX8ysltOA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/actor-http-fetch": "^2.0.1",
-				"@comunica/actor-http-proxy": "^2.0.1",
-				"@comunica/actor-rdf-parse-html": "^2.0.1",
-				"@comunica/actor-rdf-parse-html-microdata": "^2.0.1",
-				"@comunica/actor-rdf-parse-html-rdfa": "^2.0.1",
-				"@comunica/actor-rdf-parse-html-script": "^2.0.1",
-				"@comunica/actor-rdf-parse-jsonld": "^2.0.1",
-				"@comunica/actor-rdf-parse-n3": "^2.0.1",
-				"@comunica/actor-rdf-parse-rdfxml": "^2.0.1",
-				"@comunica/actor-rdf-parse-shaclc": "^2.6.2",
-				"@comunica/actor-rdf-parse-xml-rdfa": "^2.0.1",
-				"@comunica/bus-http": "^2.0.1",
-				"@comunica/bus-init": "^2.0.1",
-				"@comunica/bus-rdf-parse": "^2.0.1",
-				"@comunica/bus-rdf-parse-html": "^2.0.1",
-				"@comunica/config-query-sparql": "^2.0.1",
-				"@comunica/core": "^2.0.1",
-				"@comunica/mediator-combine-pipeline": "^2.0.1",
-				"@comunica/mediator-combine-union": "^2.0.1",
-				"@comunica/mediator-number": "^2.0.1",
-				"@comunica/mediator-race": "^2.0.1",
+				"@comunica/actor-http-fetch": "^4.0.1",
+				"@comunica/actor-http-proxy": "^4.0.1",
+				"@comunica/actor-rdf-parse-html": "^4.0.1",
+				"@comunica/actor-rdf-parse-html-microdata": "^4.0.1",
+				"@comunica/actor-rdf-parse-html-rdfa": "^4.0.1",
+				"@comunica/actor-rdf-parse-html-script": "^4.0.1",
+				"@comunica/actor-rdf-parse-jsonld": "^4.0.1",
+				"@comunica/actor-rdf-parse-n3": "^4.0.1",
+				"@comunica/actor-rdf-parse-rdfxml": "^4.0.1",
+				"@comunica/actor-rdf-parse-shaclc": "^4.0.1",
+				"@comunica/actor-rdf-parse-xml-rdfa": "^4.0.1",
+				"@comunica/bus-http": "^4.0.1",
+				"@comunica/bus-init": "^4.0.1",
+				"@comunica/bus-rdf-parse": "^4.0.1",
+				"@comunica/bus-rdf-parse-html": "^4.0.1",
+				"@comunica/config-query-sparql": "^4.0.1",
+				"@comunica/context-entries": "^4.0.1",
+				"@comunica/core": "^4.0.1",
+				"@comunica/mediator-combine-pipeline": "^4.0.1",
+				"@comunica/mediator-combine-union": "^4.0.1",
+				"@comunica/mediator-number": "^4.0.1",
+				"@comunica/mediator-race": "^4.0.1",
 				"@rdfjs/types": "*",
-				"readable-stream": "^4.3.0",
-				"stream-to-string": "^1.2.0"
-			}
-		},
-		"node_modules/rdf-parse/node_modules/@comunica/actor-abstract-mediatyped": {
-			"version": "2.10.0",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-abstract-mediatyped/-/actor-abstract-mediatyped-2.10.0.tgz",
-			"integrity": "sha512-0o6WBujsMnIVcwvRJv6Nj+kKPLZzqBS3On48rm01Rh9T1/My0E/buJMXwgcARKCfMonc2mJ9zxpPCh5ilGEU2A==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@comunica/core": "^2.10.0",
-				"@comunica/types": "^2.10.0"
-			}
-		},
-		"node_modules/rdf-parse/node_modules/@comunica/actor-abstract-parse": {
-			"version": "2.10.0",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-abstract-parse/-/actor-abstract-parse-2.10.0.tgz",
-			"integrity": "sha512-0puCWF+y24EDOOAUUVVbC+tOf4UV+LzEbqi8T5v25jcVGCXyTqfra+bDywfrcv3adrVp18jLCJ46ycaH5xhy9Q==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@comunica/core": "^2.10.0",
-				"readable-stream": "^4.4.2"
-			}
-		},
-		"node_modules/rdf-parse/node_modules/@comunica/actor-http-fetch": {
-			"version": "2.10.2",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-http-fetch/-/actor-http-fetch-2.10.2.tgz",
-			"integrity": "sha512-siHGx0TMVNb2gXvOroq0B3JE6uuS+4s+MsDkntqdBNVigwVYqLpNSKEaL5is8pputFfohJfDQY06lAHbfDNEcw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@comunica/bus-http": "^2.10.2",
-				"@comunica/context-entries": "^2.10.0",
-				"@comunica/mediatortype-time": "^2.10.0",
-				"abort-controller": "^3.0.0",
-				"cross-fetch": "^4.0.0"
-			}
-		},
-		"node_modules/rdf-parse/node_modules/@comunica/actor-http-proxy": {
-			"version": "2.10.2",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-http-proxy/-/actor-http-proxy-2.10.2.tgz",
-			"integrity": "sha512-3yUF8BCh4nwq8J6NRILEsyNrQNStkE9ggJ7hYwRfA1XcMgz1pANNaWJ2P2TEKH1jNinr23bL3JeuUZCm9Kz9dA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@comunica/bus-http": "^2.10.2",
-				"@comunica/context-entries": "^2.10.0",
-				"@comunica/mediatortype-time": "^2.10.0",
-				"@comunica/types": "^2.10.0"
-			}
-		},
-		"node_modules/rdf-parse/node_modules/@comunica/actor-rdf-parse-html": {
-			"version": "2.10.0",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-html/-/actor-rdf-parse-html-2.10.0.tgz",
-			"integrity": "sha512-zgImXKpc+BN1i6lQiN1Qhlb1HbKdMIeJMOys6qbzRIijdK8GkGGChwhQp7Cso3lY1Nf4K7M3jPLZeQXeED2w7g==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@comunica/bus-rdf-parse": "^2.10.0",
-				"@comunica/bus-rdf-parse-html": "^2.10.0",
-				"@comunica/core": "^2.10.0",
-				"@comunica/types": "^2.10.0",
-				"@rdfjs/types": "*",
-				"htmlparser2": "^9.0.0",
-				"readable-stream": "^4.4.2"
-			}
-		},
-		"node_modules/rdf-parse/node_modules/@comunica/actor-rdf-parse-html-microdata": {
-			"version": "2.10.0",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-html-microdata/-/actor-rdf-parse-html-microdata-2.10.0.tgz",
-			"integrity": "sha512-JLfiDauq4SmpI6TDS4HaHzI6iJe1j8lSk5FRRYK6YVEu8eO28jPmxQJiOiwbQiYqsjsV7kON/WIZSoUELoI4Ig==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@comunica/bus-rdf-parse-html": "^2.10.0",
-				"@comunica/core": "^2.10.0",
-				"microdata-rdf-streaming-parser": "^2.0.1"
-			}
-		},
-		"node_modules/rdf-parse/node_modules/@comunica/actor-rdf-parse-html-rdfa": {
-			"version": "2.10.0",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-html-rdfa/-/actor-rdf-parse-html-rdfa-2.10.0.tgz",
-			"integrity": "sha512-9K3iaws9+FGl50oZi53hqyzhwjNKZ3mIr2zg/TAJZoapKvc14cthH17zKSSJrqI/NgBStRmZhBBkXcwfu1CANw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@comunica/bus-rdf-parse-html": "^2.10.0",
-				"@comunica/core": "^2.10.0",
-				"rdfa-streaming-parser": "^2.0.1"
-			}
-		},
-		"node_modules/rdf-parse/node_modules/@comunica/actor-rdf-parse-html-script": {
-			"version": "2.10.0",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-html-script/-/actor-rdf-parse-html-script-2.10.0.tgz",
-			"integrity": "sha512-7XYqWchDquWnBLjG7rmmY+tdE81UZ8fPCU0Hn+vI39/MikNOpaiyr/ZYFqhogWFa9SkjmH0a7idVUzmjiwKRZQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@comunica/bus-rdf-parse": "^2.10.0",
-				"@comunica/bus-rdf-parse-html": "^2.10.0",
-				"@comunica/context-entries": "^2.10.0",
-				"@comunica/core": "^2.10.0",
-				"@comunica/types": "^2.10.0",
-				"@rdfjs/types": "*",
-				"readable-stream": "^4.4.2",
-				"relative-to-absolute-iri": "^1.0.7"
-			}
-		},
-		"node_modules/rdf-parse/node_modules/@comunica/actor-rdf-parse-jsonld": {
-			"version": "2.10.2",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-jsonld/-/actor-rdf-parse-jsonld-2.10.2.tgz",
-			"integrity": "sha512-K4fvD0zMU22KkQCqIFVT5Oy2FREEZ9CAo9u6kOcsMxEvg9aHGIM6hkaXR8I+1JCx1mDuEj3zQ8joR4tQh8fYCw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@comunica/bus-http": "^2.10.2",
-				"@comunica/bus-rdf-parse": "^2.10.0",
-				"@comunica/context-entries": "^2.10.0",
-				"@comunica/core": "^2.10.0",
-				"@comunica/types": "^2.10.0",
-				"jsonld-context-parser": "^2.2.2",
-				"jsonld-streaming-parser": "^3.0.1",
-				"stream-to-string": "^1.2.0"
-			}
-		},
-		"node_modules/rdf-parse/node_modules/@comunica/actor-rdf-parse-n3": {
-			"version": "2.10.0",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-n3/-/actor-rdf-parse-n3-2.10.0.tgz",
-			"integrity": "sha512-o1MAbwJxW4Br2WCZdhFoRmAiOP4mfogeQqJ4nqlsOkoMtQ45EvLHsotb3Kqhuk5V+vsTxyK5v/a4zylGtcU7VQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@comunica/bus-rdf-parse": "^2.10.0",
-				"@comunica/types": "^2.10.0",
-				"n3": "^1.17.0"
-			}
-		},
-		"node_modules/rdf-parse/node_modules/@comunica/actor-rdf-parse-rdfxml": {
-			"version": "2.10.0",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-rdfxml/-/actor-rdf-parse-rdfxml-2.10.0.tgz",
-			"integrity": "sha512-HoJN52shXY3cvYtsS0cpin9KXpW3L7g1leebyCRSqnlnHdJv5D6G0Ep8vyt2xhquKNbOQ7LnP5VhiDiqz73XDg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@comunica/bus-rdf-parse": "^2.10.0",
-				"@comunica/types": "^2.10.0",
-				"rdfxml-streaming-parser": "^2.2.3"
-			}
-		},
-		"node_modules/rdf-parse/node_modules/@comunica/actor-rdf-parse-shaclc": {
-			"version": "2.10.0",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-shaclc/-/actor-rdf-parse-shaclc-2.10.0.tgz",
-			"integrity": "sha512-i6tmuZuS+RtDiSXpQc3s/PxtCqwIguo4ANmVB20PK4VWgQgBwoPG7LlNcJ0xmuH/3Bv6C2Agn18PLF6dZX+fKw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@comunica/bus-rdf-parse": "^2.10.0",
-				"@comunica/types": "^2.10.0",
-				"@rdfjs/types": "*",
-				"asynciterator": "^3.8.1",
-				"readable-stream": "^4.4.2",
-				"shaclc-parse": "^1.4.0",
-				"stream-to-string": "^1.2.0"
-			}
-		},
-		"node_modules/rdf-parse/node_modules/@comunica/actor-rdf-parse-xml-rdfa": {
-			"version": "2.10.0",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-xml-rdfa/-/actor-rdf-parse-xml-rdfa-2.10.0.tgz",
-			"integrity": "sha512-68r/6B/fEyA1/OYleVuaPq47J+g4xJcJijpdL1wEj7CqjV+Xa+sDWRpNCyLcD/e1Y/g9UQmLz0ZnSpR00PFddA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@comunica/bus-rdf-parse": "^2.10.0",
-				"@comunica/types": "^2.10.0",
-				"rdfa-streaming-parser": "^2.0.1"
-			}
-		},
-		"node_modules/rdf-parse/node_modules/@comunica/bus-http": {
-			"version": "2.10.2",
-			"resolved": "https://registry.npmjs.org/@comunica/bus-http/-/bus-http-2.10.2.tgz",
-			"integrity": "sha512-MAYRF6uEBAuJ9dCPW2Uyne7w3lNwXFXKfa14XuPG5DFTDpgo/Z2pWupPrBsA1eIWMNJ6WOG6QyEv4rllSIBqlg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@comunica/core": "^2.10.0",
-				"@smessie/readable-web-to-node-stream": "^3.0.3",
-				"is-stream": "^2.0.1",
-				"readable-stream-node-to-web": "^1.0.1",
-				"web-streams-ponyfill": "^1.4.2"
-			}
-		},
-		"node_modules/rdf-parse/node_modules/@comunica/bus-init": {
-			"version": "2.10.0",
-			"resolved": "https://registry.npmjs.org/@comunica/bus-init/-/bus-init-2.10.0.tgz",
-			"integrity": "sha512-hJejHa8sLVhQLFlduCVnhOd5aW3FCEz8wmWjyeLI3kiHFaQibnGVMhUuuNRX5f8bnnPuTdEiHc1nnYHuSi+j8A==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@comunica/core": "^2.10.0",
-				"readable-stream": "^4.4.2"
-			}
-		},
-		"node_modules/rdf-parse/node_modules/@comunica/bus-rdf-parse": {
-			"version": "2.10.0",
-			"resolved": "https://registry.npmjs.org/@comunica/bus-rdf-parse/-/bus-rdf-parse-2.10.0.tgz",
-			"integrity": "sha512-EgCMZACfTG/+mayQpExWt0HoBT32BBVC1aS1lC43fXKBTxJ8kYrSrorVUuMACoh4dQVGTb+7j1j4K0hGNVzXGA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@comunica/actor-abstract-mediatyped": "^2.10.0",
-				"@comunica/actor-abstract-parse": "^2.10.0",
-				"@comunica/core": "^2.10.0",
-				"@rdfjs/types": "*"
-			}
-		},
-		"node_modules/rdf-parse/node_modules/@comunica/bus-rdf-parse-html": {
-			"version": "2.10.0",
-			"resolved": "https://registry.npmjs.org/@comunica/bus-rdf-parse-html/-/bus-rdf-parse-html-2.10.0.tgz",
-			"integrity": "sha512-RZliz4TtKP63QggoohGuIkGb6lq0BoYJ4aztKtGldWtPAVP/pdEvlDpiZWLB/j19g7S2aDLNY/lJtZ5efM1tHQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@comunica/core": "^2.10.0",
-				"@rdfjs/types": "*"
-			}
-		},
-		"node_modules/rdf-parse/node_modules/@comunica/config-query-sparql": {
-			"version": "2.7.0",
-			"resolved": "https://registry.npmjs.org/@comunica/config-query-sparql/-/config-query-sparql-2.7.0.tgz",
-			"integrity": "sha512-rMnFgT7cz9+0z7wV4OzIMY5qM9/Z0mTGrR8y2JokoHyyTcBGOSajFmy61XCSLMCsLLG8qDXsJ4ClCCky3TGfqA==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/rdf-parse/node_modules/@comunica/context-entries": {
-			"version": "2.10.0",
-			"resolved": "https://registry.npmjs.org/@comunica/context-entries/-/context-entries-2.10.0.tgz",
-			"integrity": "sha512-lmCYCcXxW8C6ecFH2whZCt31NT1ejb0P/sbytK7f4ctyA06Q8iYFEcYE4eWOXMdpfkwkcnz31x9XL77OGeSC2Q==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@comunica/core": "^2.10.0",
-				"@comunica/types": "^2.10.0",
-				"@rdfjs/types": "*",
-				"jsonld-context-parser": "^2.2.2",
-				"sparqlalgebrajs": "^4.2.0"
-			}
-		},
-		"node_modules/rdf-parse/node_modules/@comunica/core": {
-			"version": "2.10.0",
-			"resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.10.0.tgz",
-			"integrity": "sha512-onsGs2iKHUPRxxMOdx42vdxslk8q9FQZdRjQtHJ6SGiCpJwIL9ciBgPIOl2RL2YfzXHemr/0umeNOppRDcWhJA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@comunica/types": "^2.10.0",
-				"immutable": "^4.1.0"
+				"rdf-data-factory": "^1.1.2",
+				"readable-stream": "^4.5.2",
+				"stream-to-string": "^1.2.1"
 			},
-			"engines": {
-				"node": ">=14.0"
-			}
-		},
-		"node_modules/rdf-parse/node_modules/@comunica/mediator-combine-pipeline": {
-			"version": "2.10.0",
-			"resolved": "https://registry.npmjs.org/@comunica/mediator-combine-pipeline/-/mediator-combine-pipeline-2.10.0.tgz",
-			"integrity": "sha512-j7+/oUlbhKB4Rq6g9oNKU+e9cQL8U9z8tAUNhoXUSHajcr4huj0t1+riaOD109/DRWhV793ILhBDzgiZbHd7DA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@comunica/core": "^2.10.0",
-				"@comunica/types": "^2.10.0"
-			}
-		},
-		"node_modules/rdf-parse/node_modules/@comunica/mediator-combine-union": {
-			"version": "2.10.0",
-			"resolved": "https://registry.npmjs.org/@comunica/mediator-combine-union/-/mediator-combine-union-2.10.0.tgz",
-			"integrity": "sha512-QbP4zP1i6nMDZ8teC0RoTz5E8pOpxDhWPBr1ylb2jzPUjPpMgrnbHYTondlN0Oau3SMEehItojg/LYDtPOP/GQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@comunica/core": "^2.10.0"
-			}
-		},
-		"node_modules/rdf-parse/node_modules/@comunica/mediator-number": {
-			"version": "2.10.0",
-			"resolved": "https://registry.npmjs.org/@comunica/mediator-number/-/mediator-number-2.10.0.tgz",
-			"integrity": "sha512-0T8D1HGTu5Sd8iKb2dBjc6VRc/U4A15TAN6m561ra9pFlP+w31kby0ZYP6WWBHBobbUsX1LCvnbRQaAC4uWwVw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@comunica/core": "^2.10.0"
-			}
-		},
-		"node_modules/rdf-parse/node_modules/@comunica/mediator-race": {
-			"version": "2.10.0",
-			"resolved": "https://registry.npmjs.org/@comunica/mediator-race/-/mediator-race-2.10.0.tgz",
-			"integrity": "sha512-JiEtOLMkPnbjSLabVpE4VqDbu2ZKKnkUdATGBeWX+o+MjPw6c0hhw01RG4WY2rQhDyNl++nLQe3EowQh8xW9TA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@comunica/core": "^2.10.0"
-			}
-		},
-		"node_modules/rdf-parse/node_modules/@comunica/mediatortype-time": {
-			"version": "2.10.0",
-			"resolved": "https://registry.npmjs.org/@comunica/mediatortype-time/-/mediatortype-time-2.10.0.tgz",
-			"integrity": "sha512-nBz1exxrja1Tj8KSlSevG4Hw2u09tTh6gtNfVjI76i/e7muu4RUWVhi9b8PcwBNAfuUqRl+5OgOSa2X4W+6QlA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@comunica/core": "^2.10.0"
-			}
-		},
-		"node_modules/rdf-parse/node_modules/@comunica/types": {
-			"version": "2.10.0",
-			"resolved": "https://registry.npmjs.org/@comunica/types/-/types-2.10.0.tgz",
-			"integrity": "sha512-1UjPGbZcYrapBjMGUZedrIGcn9rOLpEOlJo1ZkWddFUGTwndVg9d4BZnQw+UnQzXMcLJcdKt94Zns8iEmBqARw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@rdfjs/types": "*",
-				"@types/yargs": "^17.0.24",
-				"asynciterator": "^3.8.1",
-				"sparqlalgebrajs": "^4.2.0"
+			"funding": {
+				"type": "individual",
+				"url": "https://github.com/sponsors/rubensworks/"
 			}
 		},
 		"node_modules/rdf-parse/node_modules/@rdfjs/types": {
@@ -11925,86 +11248,6 @@
 				"@types/node": "*"
 			}
 		},
-		"node_modules/rdf-parse/node_modules/@types/readable-stream": {
-			"version": "2.3.15",
-			"resolved": "https://registry.npmjs.org/@types/readable-stream/-/readable-stream-2.3.15.tgz",
-			"integrity": "sha512-oM5JSKQCcICF1wvGgmecmHldZ48OZamtMxcGGVICOJA8o8cahXC1zEVAif8iwoc5j8etxFaRFnf095+CDsuoFQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@types/node": "*",
-				"safe-buffer": "~5.1.1"
-			}
-		},
-		"node_modules/rdf-parse/node_modules/cross-fetch": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-4.1.0.tgz",
-			"integrity": "sha512-uKm5PU+MHTootlWEY+mZ4vvXoCn4fLQxT9dSc1sXVMSFkINTJVN8cAQROpwcKm8bJ/c7rgZVIBWzH5T78sNZZw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"node-fetch": "^2.7.0"
-			}
-		},
-		"node_modules/rdf-parse/node_modules/entities": {
-			"version": "4.5.0",
-			"resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
-			"integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
-			"dev": true,
-			"license": "BSD-2-Clause",
-			"engines": {
-				"node": ">=0.12"
-			},
-			"funding": {
-				"url": "https://github.com/fb55/entities?sponsor=1"
-			}
-		},
-		"node_modules/rdf-parse/node_modules/htmlparser2": {
-			"version": "9.1.0",
-			"resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-9.1.0.tgz",
-			"integrity": "sha512-5zfg6mHUoaer/97TxnGpxmbR7zJtPwIYFMZ/H5ucTlPZhKvtum05yiPK3Mgai3a0DyVxv7qYqoweaEd2nrYQzQ==",
-			"dev": true,
-			"funding": [
-				"https://github.com/fb55/htmlparser2?sponsor=1",
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/fb55"
-				}
-			],
-			"license": "MIT",
-			"dependencies": {
-				"domelementtype": "^2.3.0",
-				"domhandler": "^5.0.3",
-				"domutils": "^3.1.0",
-				"entities": "^4.5.0"
-			}
-		},
-		"node_modules/rdf-parse/node_modules/immutable": {
-			"version": "4.3.7",
-			"resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.7.tgz",
-			"integrity": "sha512-1hqclzwYwjRDFLjcFxOM5AYkkG0rpFPpr1RLPMEuGczoS7YA8gLhy8SWXYRAA/XwfEHpfo3cw5JGioS32fnMRw==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/rdf-parse/node_modules/jsonld-streaming-parser": {
-			"version": "3.4.0",
-			"resolved": "https://registry.npmjs.org/jsonld-streaming-parser/-/jsonld-streaming-parser-3.4.0.tgz",
-			"integrity": "sha512-897CloyQgQidfkB04dLM5XaAXVX/cN9A2hvgHJo4y4jRhIpvg3KLMBBfcrswepV2N3T8c/Rp2JeFdWfVsbVZ7g==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@bergos/jsonparse": "^1.4.0",
-				"@rdfjs/types": "*",
-				"@types/http-link-header": "^1.0.1",
-				"@types/readable-stream": "^2.3.13",
-				"buffer": "^6.0.3",
-				"canonicalize": "^1.0.1",
-				"http-link-header": "^1.0.2",
-				"jsonld-context-parser": "^2.4.0",
-				"rdf-data-factory": "^1.1.0",
-				"readable-stream": "^4.0.0"
-			}
-		},
 		"node_modules/rdf-parse/node_modules/rdf-data-factory": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/rdf-data-factory/-/rdf-data-factory-1.1.3.tgz",
@@ -12013,81 +11256,6 @@
 			"license": "MIT",
 			"dependencies": {
 				"@rdfjs/types": "^1.0.0"
-			}
-		},
-		"node_modules/rdf-parse/node_modules/rdf-isomorphic": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/rdf-isomorphic/-/rdf-isomorphic-1.3.1.tgz",
-			"integrity": "sha512-6uIhsXTVp2AtO6f41PdnRV5xZsa0zVZQDTBdn0br+DZuFf5M/YD+T6m8hKDUnALI6nFL/IujTMLgEs20MlNidQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@rdfjs/types": "*",
-				"hash.js": "^1.1.7",
-				"rdf-string": "^1.6.0",
-				"rdf-terms": "^1.7.0"
-			}
-		},
-		"node_modules/rdf-parse/node_modules/rdfa-streaming-parser": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/rdfa-streaming-parser/-/rdfa-streaming-parser-2.0.1.tgz",
-			"integrity": "sha512-7Yyaj030LO7iQ38Wh/RNLVeYrVFJeyx3dpCK7C1nvX55eIN/gE4HWfbg4BYI9X7Bd+eUIUMVeiKYLmYjV6apow==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@rdfjs/types": "*",
-				"htmlparser2": "^8.0.0",
-				"rdf-data-factory": "^1.1.0",
-				"readable-stream": "^4.0.0",
-				"relative-to-absolute-iri": "^1.0.2"
-			}
-		},
-		"node_modules/rdf-parse/node_modules/rdfa-streaming-parser/node_modules/htmlparser2": {
-			"version": "8.0.2",
-			"resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.2.tgz",
-			"integrity": "sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==",
-			"dev": true,
-			"funding": [
-				"https://github.com/fb55/htmlparser2?sponsor=1",
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/fb55"
-				}
-			],
-			"license": "MIT",
-			"dependencies": {
-				"domelementtype": "^2.3.0",
-				"domhandler": "^5.0.3",
-				"domutils": "^3.0.1",
-				"entities": "^4.4.0"
-			}
-		},
-		"node_modules/rdf-parse/node_modules/safe-buffer": {
-			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/rdf-parse/node_modules/sparqlalgebrajs": {
-			"version": "4.3.8",
-			"resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-4.3.8.tgz",
-			"integrity": "sha512-Xo1/5icRtVk2N38BrY9NXN8N/ZPjULlns7sDHv0nlcGOsOediBLWVy8LmV+Q90RHvb3atZZbrFy3VqrM4iXciA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@rdfjs/types": "*",
-				"@types/sparqljs": "^3.1.3",
-				"fast-deep-equal": "^3.1.3",
-				"minimist": "^1.2.6",
-				"rdf-data-factory": "^1.1.0",
-				"rdf-isomorphic": "^1.3.0",
-				"rdf-string": "^1.6.0",
-				"rdf-terms": "^1.10.0",
-				"sparqljs": "^3.7.1"
-			},
-			"bin": {
-				"sparqlalgebrajs": "bin/sparqlalgebrajs.js"
 			}
 		},
 		"node_modules/rdf-quad": {
@@ -12513,16 +11681,6 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/require-from-string": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
-			"integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/resolve-from": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -12534,9 +11692,9 @@
 			}
 		},
 		"node_modules/rollup": {
-			"version": "4.52.2",
-			"resolved": "https://registry.npmjs.org/rollup/-/rollup-4.52.2.tgz",
-			"integrity": "sha512-I25/2QgoROE1vYV+NQ1En9T9UFB9Cmfm2CJ83zZOlaDpvz29wGQSZXWKw7MiNXau7wYgB/T9fVIdIuEQ+KbiiA==",
+			"version": "4.55.1",
+			"resolved": "https://registry.npmjs.org/rollup/-/rollup-4.55.1.tgz",
+			"integrity": "sha512-wDv/Ht1BNHB4upNbK74s9usvl7hObDnvVzknxqY/E/O3X6rW1U1rV1aENEfJ54eFZDTNo7zv1f5N4edCluH7+A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -12550,35 +11708,38 @@
 				"npm": ">=8.0.0"
 			},
 			"optionalDependencies": {
-				"@rollup/rollup-android-arm-eabi": "4.52.2",
-				"@rollup/rollup-android-arm64": "4.52.2",
-				"@rollup/rollup-darwin-arm64": "4.52.2",
-				"@rollup/rollup-darwin-x64": "4.52.2",
-				"@rollup/rollup-freebsd-arm64": "4.52.2",
-				"@rollup/rollup-freebsd-x64": "4.52.2",
-				"@rollup/rollup-linux-arm-gnueabihf": "4.52.2",
-				"@rollup/rollup-linux-arm-musleabihf": "4.52.2",
-				"@rollup/rollup-linux-arm64-gnu": "4.52.2",
-				"@rollup/rollup-linux-arm64-musl": "4.52.2",
-				"@rollup/rollup-linux-loong64-gnu": "4.52.2",
-				"@rollup/rollup-linux-ppc64-gnu": "4.52.2",
-				"@rollup/rollup-linux-riscv64-gnu": "4.52.2",
-				"@rollup/rollup-linux-riscv64-musl": "4.52.2",
-				"@rollup/rollup-linux-s390x-gnu": "4.52.2",
-				"@rollup/rollup-linux-x64-gnu": "4.52.2",
-				"@rollup/rollup-linux-x64-musl": "4.52.2",
-				"@rollup/rollup-openharmony-arm64": "4.52.2",
-				"@rollup/rollup-win32-arm64-msvc": "4.52.2",
-				"@rollup/rollup-win32-ia32-msvc": "4.52.2",
-				"@rollup/rollup-win32-x64-gnu": "4.52.2",
-				"@rollup/rollup-win32-x64-msvc": "4.52.2",
+				"@rollup/rollup-android-arm-eabi": "4.55.1",
+				"@rollup/rollup-android-arm64": "4.55.1",
+				"@rollup/rollup-darwin-arm64": "4.55.1",
+				"@rollup/rollup-darwin-x64": "4.55.1",
+				"@rollup/rollup-freebsd-arm64": "4.55.1",
+				"@rollup/rollup-freebsd-x64": "4.55.1",
+				"@rollup/rollup-linux-arm-gnueabihf": "4.55.1",
+				"@rollup/rollup-linux-arm-musleabihf": "4.55.1",
+				"@rollup/rollup-linux-arm64-gnu": "4.55.1",
+				"@rollup/rollup-linux-arm64-musl": "4.55.1",
+				"@rollup/rollup-linux-loong64-gnu": "4.55.1",
+				"@rollup/rollup-linux-loong64-musl": "4.55.1",
+				"@rollup/rollup-linux-ppc64-gnu": "4.55.1",
+				"@rollup/rollup-linux-ppc64-musl": "4.55.1",
+				"@rollup/rollup-linux-riscv64-gnu": "4.55.1",
+				"@rollup/rollup-linux-riscv64-musl": "4.55.1",
+				"@rollup/rollup-linux-s390x-gnu": "4.55.1",
+				"@rollup/rollup-linux-x64-gnu": "4.55.1",
+				"@rollup/rollup-linux-x64-musl": "4.55.1",
+				"@rollup/rollup-openbsd-x64": "4.55.1",
+				"@rollup/rollup-openharmony-arm64": "4.55.1",
+				"@rollup/rollup-win32-arm64-msvc": "4.55.1",
+				"@rollup/rollup-win32-ia32-msvc": "4.55.1",
+				"@rollup/rollup-win32-x64-gnu": "4.55.1",
+				"@rollup/rollup-win32-x64-msvc": "4.55.1",
 				"fsevents": "~2.3.2"
 			}
 		},
 		"node_modules/rollup/node_modules/@rollup/rollup-darwin-arm64": {
-			"version": "4.52.2",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.52.2.tgz",
-			"integrity": "sha512-vngduywkkv8Fkh3wIZf5nFPXzWsNsVu1kvtLETWxTFf/5opZmflgVSeLgdHR56RQh71xhPhWoOkEBvbehwTlVA==",
+			"version": "4.55.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.55.1.tgz",
+			"integrity": "sha512-p3grE2PHcQm2e8PSGZdzIhCKbMCw/xi9XvMPErPhwO17vxtvCN5FEA2mSLgmKlCjHGMQTP6phuQTYWUnKewwGg==",
 			"cpu": [
 				"arm64"
 			],
@@ -12590,9 +11751,9 @@
 			]
 		},
 		"node_modules/rollup/node_modules/@rollup/rollup-darwin-x64": {
-			"version": "4.52.2",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.52.2.tgz",
-			"integrity": "sha512-h11KikYrUCYTrDj6h939hhMNlqU2fo/X4NB0OZcys3fya49o1hmFaczAiJWVAFgrM1NCP6RrO7lQKeVYSKBPSQ==",
+			"version": "4.55.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.55.1.tgz",
+			"integrity": "sha512-rDUjG25C9qoTm+e02Esi+aqTKSBYwVTaoS1wxcN47/Luqef57Vgp96xNANwt5npq9GDxsH7kXxNkJVEsWEOEaQ==",
 			"cpu": [
 				"x64"
 			],
@@ -12604,9 +11765,9 @@
 			]
 		},
 		"node_modules/rollup/node_modules/@rollup/rollup-linux-arm64-gnu": {
-			"version": "4.52.2",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.52.2.tgz",
-			"integrity": "sha512-66lA8vnj5mB/rtDNwPgrrKUOtCLVQypkyDa2gMfOefXK6rcZAxKLO9Fy3GkW8VkPnENv9hBkNOFfGLf6rNKGUg==",
+			"version": "4.55.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.55.1.tgz",
+			"integrity": "sha512-a59mwd1k6x8tXKcUxSyISiquLwB5pX+fJW9TkWU46lCqD/GRDe9uDN31jrMmVP3feI3mhAdvcCClhV8V5MhJFQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -12618,9 +11779,9 @@
 			]
 		},
 		"node_modules/rollup/node_modules/@rollup/rollup-linux-arm64-musl": {
-			"version": "4.52.2",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.52.2.tgz",
-			"integrity": "sha512-s+OPucLNdJHvuZHuIz2WwncJ+SfWHFEmlC5nKMUgAelUeBUnlB4wt7rXWiyG4Zn07uY2Dd+SGyVa9oyLkVGOjA==",
+			"version": "4.55.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.55.1.tgz",
+			"integrity": "sha512-puS1MEgWX5GsHSoiAsF0TYrpomdvkaXm0CofIMG5uVkP6IBV+ZO9xhC5YEN49nsgYo1DuuMquF9+7EDBVYu4uA==",
 			"cpu": [
 				"arm64"
 			],
@@ -12632,9 +11793,9 @@
 			]
 		},
 		"node_modules/rollup/node_modules/@rollup/rollup-linux-x64-gnu": {
-			"version": "4.52.2",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.52.2.tgz",
-			"integrity": "sha512-opH8GSUuVcCSSyHHcl5hELrmnk4waZoVpgn/4FDao9iyE4WpQhyWJ5ryl5M3ocp4qkRuHfyXnGqg8M9oKCEKRA==",
+			"version": "4.55.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.55.1.tgz",
+			"integrity": "sha512-a8G4wiQxQG2BAvo+gU6XrReRRqj+pLS2NGXKm8io19goR+K8lw269eTrPkSdDTALwMmJp4th2Uh0D8J9bEV1vg==",
 			"cpu": [
 				"x64"
 			],
@@ -12646,9 +11807,9 @@
 			]
 		},
 		"node_modules/rollup/node_modules/@rollup/rollup-linux-x64-musl": {
-			"version": "4.52.2",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.52.2.tgz",
-			"integrity": "sha512-LSeBHnGli1pPKVJ79ZVJgeZWWZXkEe/5o8kcn23M8eMKCUANejchJbF/JqzM4RRjOJfNRhKJk8FuqL1GKjF5oQ==",
+			"version": "4.55.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.55.1.tgz",
+			"integrity": "sha512-bD+zjpFrMpP/hqkfEcnjXWHMw5BIghGisOKPj+2NaNDuVT+8Ds4mPf3XcPHuat1tz89WRL+1wbcxKY3WSbiT7w==",
 			"cpu": [
 				"x64"
 			],
@@ -12660,9 +11821,9 @@
 			]
 		},
 		"node_modules/rollup/node_modules/@rollup/rollup-win32-arm64-msvc": {
-			"version": "4.52.2",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.52.2.tgz",
-			"integrity": "sha512-Z9MUCrSgIaUeeHAiNkm3cQyst2UhzjPraR3gYYfOjAuZI7tcFRTOD+4cHLPoS/3qinchth+V56vtqz1Tv+6KPA==",
+			"version": "4.55.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.55.1.tgz",
+			"integrity": "sha512-yR6Bl3tMC/gBok5cz/Qi0xYnVbIxGx5Fcf/ca0eB6/6JwOY+SRUcJfI0OpeTpPls7f194as62thCt/2BjxYN8g==",
 			"cpu": [
 				"arm64"
 			],
@@ -12674,9 +11835,9 @@
 			]
 		},
 		"node_modules/rollup/node_modules/@rollup/rollup-win32-x64-msvc": {
-			"version": "4.52.2",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.52.2.tgz",
-			"integrity": "sha512-ARz+Bs8kY6FtitYM96PqPEVvPXqEZmPZsSkXvyX19YzDqkCaIlhCieLLMI5hxO9SRZ2XtCtm8wxhy0iJ2jxNfw==",
+			"version": "4.55.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.55.1.tgz",
+			"integrity": "sha512-SPEpaL6DX4rmcXtnhdrQYgzQ5W2uW3SCJch88lB2zImhJRhIIK44fkUrgIV/Q8yUNfw5oyZ5vkeQsZLhCb06lw==",
 			"cpu": [
 				"x64"
 			],
@@ -12731,26 +11892,6 @@
 				"node": ">=10"
 			}
 		},
-		"node_modules/safer-buffer": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/saxes": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
-			"integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"xmlchars": "^2.2.0"
-			},
-			"engines": {
-				"node": ">=v12.22.7"
-			}
-		},
 		"node_modules/semver": {
 			"version": "7.7.3",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
@@ -12765,9 +11906,9 @@
 			}
 		},
 		"node_modules/set-cookie-parser": {
-			"version": "2.7.1",
-			"resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
-			"integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==",
+			"version": "2.7.2",
+			"resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+			"integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -12783,15 +11924,43 @@
 			}
 		},
 		"node_modules/shaclc-write": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/shaclc-write/-/shaclc-write-1.5.0.tgz",
-			"integrity": "sha512-5+uFmw28BUqCW5UC4FyFwB8VTsdzPyh4LB2pAI5DRjn6xWgl1bsfied9K9HbQYrONNtmhLpPFse79N3Tvj+kLA==",
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/shaclc-write/-/shaclc-write-1.6.0.tgz",
+			"integrity": "sha512-KCteNxu/a3HDCf32tCURgKA0waY+M6NEuFoRPQcfBvJxUyu4uTXRTPqDc8EMse0TvwwwMTItahb9C47Bh+CP/Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@jeswr/prefixcc": "^1.2.1",
-				"n3": "^1.16.3",
-				"rdf-string-ttl": "^1.3.2"
+				"n3": "^2.0.0",
+				"rdf-string-ttl": "^2.0.1"
+			}
+		},
+		"node_modules/shaclc-write/node_modules/n3": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/n3/-/n3-2.0.1.tgz",
+			"integrity": "sha512-Q6TPsTrlEoELXQ47tSBYcAZ800PQN9gtSImRUqQYoBq+Q7riIUAoDgf3tuMv6PuwonO86SBIx5GfOxvS4A/4kw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"buffer": "^6.0.3",
+				"readable-stream": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=12.0"
+			}
+		},
+		"node_modules/shaclc-write/node_modules/rdf-string-ttl": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/rdf-string-ttl/-/rdf-string-ttl-2.0.1.tgz",
+			"integrity": "sha512-xIZdC6uur9OwaCQrOsjuzLpnQCNGuJFWnYIAdF48tg3wzG5QzsgDMTJISCVh+M2p1e9ivIXlEauSdWokAhpZgA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"rdf-data-factory": "^2.0.0"
+			},
+			"funding": {
+				"type": "individual",
+				"url": "https://github.com/sponsors/rubensworks/"
 			}
 		},
 		"node_modules/shadow-dom-testing-library": {
@@ -13105,6 +12274,34 @@
 				"safe-buffer": "~5.2.0"
 			}
 		},
+		"node_modules/string-width": {
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"emoji-regex": "^8.0.0",
+				"is-fullwidth-code-point": "^3.0.0",
+				"strip-ansi": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/strip-ansi": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^5.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/strip-indent": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
@@ -13196,9 +12393,9 @@
 			}
 		},
 		"node_modules/svelte-eslint-parser": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/svelte-eslint-parser/-/svelte-eslint-parser-1.4.0.tgz",
-			"integrity": "sha512-fjPzOfipR5S7gQ/JvI9r2H8y9gMGXO3JtmrylHLLyahEMquXI0lrebcjT+9/hNgDej0H7abTyox5HpHmW1PSWA==",
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/svelte-eslint-parser/-/svelte-eslint-parser-1.4.1.tgz",
+			"integrity": "sha512-1eqkfQ93goAhjAXxZiu1SaKI9+0/sxp4JIWQwUpsz7ybehRE5L8dNuz7Iry7K22R47p5/+s9EM+38nHV2OlgXA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -13211,7 +12408,7 @@
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0",
-				"pnpm": "10.18.3"
+				"pnpm": "10.24.0"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ota-meshi"
@@ -13234,13 +12431,6 @@
 			"engines": {
 				"node": ">= 0.4"
 			}
-		},
-		"node_modules/symbol-tree": {
-			"version": "3.2.4",
-			"resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
-			"integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
-			"dev": true,
-			"license": "MIT"
 		},
 		"node_modules/synckit": {
 			"version": "0.11.11",
@@ -13337,26 +12527,6 @@
 				"node": ">=14.0.0"
 			}
 		},
-		"node_modules/tldts": {
-			"version": "7.0.16",
-			"resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.16.tgz",
-			"integrity": "sha512-5bdPHSwbKTeHmXrgecID4Ljff8rQjv7g8zKQPkCozRo2HWWni+p310FSn5ImI+9kWw9kK4lzOB5q/a6iv0IJsw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"tldts-core": "^7.0.16"
-			},
-			"bin": {
-				"tldts": "bin/cli.js"
-			}
-		},
-		"node_modules/tldts-core": {
-			"version": "7.0.16",
-			"resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.16.tgz",
-			"integrity": "sha512-XHhPmHxphLi+LGbH0G/O7dmUH9V65OY20R7vH8gETHsp5AZCjBk9l8sqmRKLaGOxnETU7XNSDUPtewAy/K6jbA==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/totalist": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/totalist/-/totalist-3.0.1.tgz",
@@ -13367,31 +12537,12 @@
 				"node": ">=6"
 			}
 		},
-		"node_modules/tough-cookie": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.0.tgz",
-			"integrity": "sha512-kXuRi1mtaKMrsLUxz3sQYvVl37B0Ns6MzfrtV5DvJceE9bPyspOqk9xxv7XbZWcfLWbFmm997vl83qUWVJA64w==",
-			"dev": true,
-			"license": "BSD-3-Clause",
-			"dependencies": {
-				"tldts": "^7.0.5"
-			},
-			"engines": {
-				"node": ">=16"
-			}
-		},
 		"node_modules/tr46": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
-			"integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+			"version": "0.0.3",
+			"resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+			"integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
 			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"punycode": "^2.3.1"
-			},
-			"engines": {
-				"node": ">=20"
-			}
+			"license": "MIT"
 		},
 		"node_modules/triple-beam": {
 			"version": "1.4.1",
@@ -13475,16 +12626,15 @@
 			}
 		},
 		"node_modules/undici-types": {
-			"version": "7.12.0",
-			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.12.0.tgz",
-			"integrity": "sha512-goOacqME2GYyOZZfb5Lgtu+1IDmAlAEu5xnD3+xTzS10hT0vzpf0SPjkXwAw9Jm+4n/mQGDP3LO8CPbYROeBfQ==",
-			"dev": true,
+			"version": "7.16.0",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+			"integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
 			"license": "MIT"
 		},
 		"node_modules/update-browserslist-db": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.2.tgz",
-			"integrity": "sha512-E85pfNzMQ9jpKkA7+TJAi4TJN+tBCuWh5rUcS/sv6cFi+1q9LYDwDI5dpUL0u/73EElyQ8d3TEaeW4sPedBqYA==",
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+			"integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
 			"dev": true,
 			"funding": [
 				{
@@ -13744,71 +12894,31 @@
 				}
 			}
 		},
-		"node_modules/w3c-xmlserializer": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
-			"integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"xml-name-validator": "^5.0.0"
-			},
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/web-streams-ponyfill": {
-			"version": "1.4.2",
-			"resolved": "https://registry.npmjs.org/web-streams-ponyfill/-/web-streams-ponyfill-1.4.2.tgz",
-			"integrity": "sha512-LCHW+fE2UBJ2vjhqJujqmoxh1ytEDEr0dPO3CabMdMDJPKmsaxzS90V1Ar6LtNE5VHLqxR4YMEj1i4lzMAccIA==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/webidl-conversions": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.0.tgz",
-			"integrity": "sha512-n4W4YFyz5JzOfQeA8oN7dUYpR+MBP3PIUsn2jLjWXwK5ASUzt0Jc/A5sAUZoCYFJRGF0FBKJ+1JjN43rNdsQzA==",
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+			"integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
 			"dev": true,
-			"license": "BSD-2-Clause",
-			"engines": {
-				"node": ">=20"
-			}
-		},
-		"node_modules/whatwg-encoding": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
-			"integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"iconv-lite": "0.6.3"
-			},
-			"engines": {
-				"node": ">=18"
-			}
+			"license": "BSD-2-Clause"
 		},
 		"node_modules/whatwg-mimetype": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
-			"integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
-			"dev": true,
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
+			"integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
 			"license": "MIT",
 			"engines": {
-				"node": ">=18"
+				"node": ">=12"
 			}
 		},
 		"node_modules/whatwg-url": {
-			"version": "15.1.0",
-			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-15.1.0.tgz",
-			"integrity": "sha512-2ytDk0kiEj/yu90JOAp44PVPUkO9+jVhyf+SybKlRHSDlvOOZhdPIrr7xTH64l4WixO2cP+wQIcgujkGBPPz6g==",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+			"integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"tr46": "^6.0.0",
-				"webidl-conversions": "^8.0.0"
-			},
-			"engines": {
-				"node": ">=20"
+				"tr46": "~0.0.3",
+				"webidl-conversions": "^3.0.0"
 			}
 		},
 		"node_modules/which": {
@@ -13845,9 +12955,9 @@
 			}
 		},
 		"node_modules/winston": {
-			"version": "3.18.3",
-			"resolved": "https://registry.npmjs.org/winston/-/winston-3.18.3.tgz",
-			"integrity": "sha512-NoBZauFNNWENgsnC9YpgyYwOVrl2m58PpQ8lNHjV3kosGs7KJ7Npk9pCUE+WJlawVSe8mykWDKWFSVfs3QO9ww==",
+			"version": "3.19.0",
+			"resolved": "https://registry.npmjs.org/winston/-/winston-3.19.0.tgz",
+			"integrity": "sha512-LZNJgPzfKR+/J3cHkxcpHKpKKvGfDZVPS4hfJCc4cCG0CgYzvlD6yE/S3CIL/Yt91ak327YCpiF/0MyeZHEHKA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -13922,11 +13032,28 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/ws": {
-			"version": "8.18.3",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
-			"integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+		"node_modules/wrap-ansi": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+			"integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
 			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-styles": "^4.0.0",
+				"string-width": "^4.1.0",
+				"strip-ansi": "^6.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+			}
+		},
+		"node_modules/ws": {
+			"version": "8.19.0",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
+			"integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=10.0.0"
@@ -13944,16 +13071,6 @@
 				}
 			}
 		},
-		"node_modules/xml-name-validator": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
-			"integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"engines": {
-				"node": ">=18"
-			}
-		},
 		"node_modules/xmlchars": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
@@ -13969,6 +13086,24 @@
 			"license": "ISC",
 			"engines": {
 				"node": ">=10"
+			}
+		},
+		"node_modules/yaml": {
+			"version": "2.8.2",
+			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
+			"integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
+			"dev": true,
+			"license": "ISC",
+			"optional": true,
+			"peer": true,
+			"bin": {
+				"yaml": "bin.mjs"
+			},
+			"engines": {
+				"node": ">= 14.6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/eemeli"
 			}
 		},
 		"node_modules/yargs": {
@@ -13998,41 +13133,6 @@
 			"license": "ISC",
 			"engines": {
 				"node": ">=12"
-			}
-		},
-		"node_modules/yargs/node_modules/emoji-regex": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/yargs/node_modules/string-width": {
-			"version": "4.2.3",
-			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"emoji-regex": "^8.0.0",
-				"is-fullwidth-code-point": "^3.0.0",
-				"strip-ansi": "^6.0.1"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/yargs/node_modules/strip-ansi": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"ansi-regex": "^5.0.1"
-			},
-			"engines": {
-				"node": ">=8"
 			}
 		},
 		"node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -23,9 +23,9 @@
 	},
 	"devDependencies": {
 		"@axe-core/playwright": "^4.11.0",
-		"@comunica/utils-bindings-factory": "^4.5.0",
 		"@comunica/query-sparql": "^4.5.0",
 		"@comunica/types": "^4.5.0",
+		"@comunica/utils-bindings-factory": "^4.5.0",
 		"@playwright/test": "^1.57.0",
 		"@sveltejs/adapter-static": "^3.0.10",
 		"@sveltejs/kit": "^2.49.4",
@@ -48,7 +48,6 @@
 		"eslint-plugin-prettier": "^5.5.4",
 		"eslint-plugin-svelte": "^3.14.0",
 		"globals": "^16.5.0",
-		"jsdom": "^27.1.0",
 		"jsonld-streaming-parser": "^5.0.0",
 		"n3": "^1.26.0",
 		"postcss": "^8.5.6",
@@ -67,5 +66,8 @@
 		"vite": "^7.3.1",
 		"vitest": "^4.0.16"
 	},
-	"type": "module"
+	"type": "module",
+	"dependencies": {
+		"happy-dom": "^20.1.0"
+	}
 }

--- a/src/lib/components/ui/Badge.spec.ts
+++ b/src/lib/components/ui/Badge.spec.ts
@@ -21,10 +21,11 @@ describe('Badge component', () => {
 		});
 	});
 
-	//When an ic-badge is supplied an accessible-label attribute, the enclosing div gets the label too
-	it('Renders an aria label if one is given', async () => {
-		const accessibleLabel = 'accessible label';
-		await render(Badge, { type: 'dot', ariaLabel: accessibleLabel });
-		expect(await screen.findByLabelText(accessibleLabel, { selector: 'div' })).toBeInTheDocument();
+	it('Allows an aria label to be passed in', async () => {
+		const accessibleLabel = 'my a11y label';
+		const { container } = await render(Badge, { type: 'dot', ariaLabel: accessibleLabel });
+		expect(
+			container.querySelector("ic-badge[accessible-label='my a11y label']")
+		).toBeInTheDocument();
 	});
 });

--- a/test/helpers/render.ts
+++ b/test/helpers/render.ts
@@ -40,8 +40,8 @@ const waitForHydration = (fn: typeof originalRender) => {
 		const view = fn(...args);
 		await waitFor(() => expect(document.body.innerHTML.length).toBeGreaterThan(0));
 		await waitFor(() => expect(appReadyCount).toBeTruthy(), {
-			timeout: 100000,
-			interval: 1000
+			timeout: 1000,
+			interval: 100
 		});
 
 		return view;

--- a/test/test-setup.ts
+++ b/test/test-setup.ts
@@ -7,12 +7,12 @@ import { configure } from '@testing-library/dom';
 // Register ICDS components with DOM
 beforeAll(() => {
 	defineCustomElements(window);
-}, 100000);
+}, 1000);
 
 // Configure testing library
 configure({
 	// Increase timeout for waitFor and find queries (sometimes the DOM isn't hydrated in 1 second)
-	asyncUtilTimeout: 100000
+	asyncUtilTimeout: 1000
 });
 
 // matchMedia is not provided by the mock DOM - mock it here to allow tests to run.

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -15,7 +15,7 @@ export default defineConfig({
 		PUBLIC_VERSION: JSON.stringify(pkg.version)
 	},
 	test: {
-		environment: 'jsdom', // we're making a web app, so we want a web-like environment
+		environment: 'happy-dom', // we're making a web app, so we want a web-like environment
 		globals: true, // avoid having to import things like "describe" and "expect"
 		include: ['./src/**/*.{test,spec}.{js,ts}'],
 		setupFiles: ['./test/test-setup.ts'],


### PR DESCRIPTION
The exact cause is unclear, but something about a minor JSDOM upgrade caused most of our tests relating to Stencil components to start failing, specifically because the components stopped emitting the `appload` event. Evidently something about that update has pushed LD Explorer beyond the scope of what JSDOM can emulate by default. 

Tried a few of the options for JSDOM, nothing seemed to fix the tests, I suspect this is probably an issue with JSDOM.

After speculatively swapping JSDOM out for HappyDOM, the tests all started passing (bar 1 which has been adjusted) - test suite is also now running faster so this is a good change regardless.

Would have been nice to figure out exactly what is going wrong with JSDOM - my suspicion is as follows:

* JSDOM update from 27.1.0 to 27.2.0 is what causes the tests to fail.
* As well as some JSDOM features, that update also includes an update to the `globals` library from 16.4.0 to 16.5.0 (this update -> https://github.com/sindresorhus/globals/releases/tag/v16.5.0).
* I suspect it's something about the `globals` package that's broken our tests.

Unfortunately we don't currently have the resources to justify dedicating any more time to this.

Fixes #161 