### PR TITLE
Update comunica to latest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,9 @@
 			"license": "Apache-2.0",
 			"devDependencies": {
 				"@axe-core/playwright": "^4.11.2",
-				"@comunica/query-sparql": "^5.1.3",
-				"@comunica/types": "^5.1.3",
-				"@comunica/utils-bindings-factory": "^5.1.3",
+				"@comunica/query-sparql": "^5.2.1",
+				"@comunica/types": "^5.2.0",
+				"@comunica/utils-bindings-factory": "^5.2.0",
 				"@playwright/test": "^1.59.1",
 				"@sveltejs/adapter-static": "^3.0.10",
 				"@sveltejs/kit": "^2.58.0",
@@ -66,13 +66,13 @@
 			"license": "MIT"
 		},
 		"node_modules/@axe-core/playwright": {
-			"version": "4.11.2",
-			"resolved": "https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.11.2.tgz",
-			"integrity": "sha512-iP6hfNl9G0j/SEUSo8M7D80RbcDo9KRAAfDP4IT5OHB+Wm6zUHIrm8Y51BKI+Oyqduvipf9u1hcRy57zCBKzWQ==",
+			"version": "4.11.3",
+			"resolved": "https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.11.3.tgz",
+			"integrity": "sha512-h/kfksv4F0cVIDlKpT4700OehdRgpvuVskuQ2nb7/JmtWUXpe9ftHAPtwyXGvVSsa6SJ64A9ER7Zrzc/sIvC4w==",
 			"dev": true,
 			"license": "MPL-2.0",
 			"dependencies": {
-				"axe-core": "~4.11.3"
+				"axe-core": "~4.11.4"
 			},
 			"peerDependencies": {
 				"playwright-core": ">= 1.0.0"
@@ -114,9 +114,9 @@
 			}
 		},
 		"node_modules/@babel/parser": {
-			"version": "7.29.0",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.0.tgz",
-			"integrity": "sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==",
+			"version": "7.29.3",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
+			"integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -130,9 +130,9 @@
 			}
 		},
 		"node_modules/@babel/runtime": {
-			"version": "7.28.6",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
-			"integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
+			"version": "7.29.2",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+			"integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -176,50 +176,6 @@
 				"buffer": "^6.0.3"
 			}
 		},
-		"node_modules/@chevrotain/cst-dts-gen": {
-			"version": "11.2.0",
-			"resolved": "https://registry.npmjs.org/@chevrotain/cst-dts-gen/-/cst-dts-gen-11.2.0.tgz",
-			"integrity": "sha512-ssJFvn/UXhQQeICw3SR/fZPmYVj+JM2mP+Lx7bZ51cOeHaMWOKp3AUMuyM3QR82aFFXTfcAp67P5GpPjGmbZWQ==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@chevrotain/gast": "11.2.0",
-				"@chevrotain/types": "11.2.0",
-				"lodash-es": "4.17.23"
-			}
-		},
-		"node_modules/@chevrotain/gast": {
-			"version": "11.2.0",
-			"resolved": "https://registry.npmjs.org/@chevrotain/gast/-/gast-11.2.0.tgz",
-			"integrity": "sha512-c+KoD6eSI1xjAZZoNUW+V0l13UEn+a4ShmUrjIKs1BeEWCji0Kwhmqn5FSx1K4BhWL7IQKlV7wLR4r8lLArORQ==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@chevrotain/types": "11.2.0",
-				"lodash-es": "4.17.23"
-			}
-		},
-		"node_modules/@chevrotain/regexp-to-ast": {
-			"version": "11.2.0",
-			"resolved": "https://registry.npmjs.org/@chevrotain/regexp-to-ast/-/regexp-to-ast-11.2.0.tgz",
-			"integrity": "sha512-lG73pBFqbXODTbXhdZwv0oyUaI+3Irm+uOv5/W79lI3g5hasYaJnVJOm3H2NkhA0Ef4XLBU4Scr7TJDJwgFkAw==",
-			"dev": true,
-			"license": "Apache-2.0"
-		},
-		"node_modules/@chevrotain/types": {
-			"version": "11.2.0",
-			"resolved": "https://registry.npmjs.org/@chevrotain/types/-/types-11.2.0.tgz",
-			"integrity": "sha512-vBMSj/lz/LqolbGQEHB0tlpW5BnljHVtp+kzjQfQU+5BtGMTuZCPVgaAjtKvQYXnHb/8i/02Kii00y0tsuwfsw==",
-			"dev": true,
-			"license": "Apache-2.0"
-		},
-		"node_modules/@chevrotain/utils": {
-			"version": "11.2.0",
-			"resolved": "https://registry.npmjs.org/@chevrotain/utils/-/utils-11.2.0.tgz",
-			"integrity": "sha512-+7whECg4yNWHottjvr2To2BRxL4XJVjIyyv5J4+bJ0iMOVU8j/8n1qPDLZS/90W/BObDR8VNL46lFbzY/Hosmw==",
-			"dev": true,
-			"license": "Apache-2.0"
-		},
 		"node_modules/@colors/colors": {
 			"version": "1.6.0",
 			"resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.6.0.tgz",
@@ -231,14 +187,14 @@
 			}
 		},
 		"node_modules/@comunica/actor-abstract-mediatyped": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-abstract-mediatyped/-/actor-abstract-mediatyped-5.1.3.tgz",
-			"integrity": "sha512-vbdSYF/BKH+aiTJXLcR0YAMDxTrma6v8Bsfzxq0/srAe4TWlgw1iny5noMGUPiP5LauqiLgnIcDNgyaAoTz3dQ==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-abstract-mediatyped/-/actor-abstract-mediatyped-5.2.0.tgz",
+			"integrity": "sha512-xlFxU1kvqZZOQKfAV2AH2vvDdUGAeL94ekyA3lATHDl26g7jN9x5IDuRRPIrz9gkf+2h7ckohdCDiR52L0T2pA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/core": "^5.1.3",
-				"@comunica/types": "^5.1.3"
+				"@comunica/core": "^5.2.0",
+				"@comunica/types": "^5.2.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -246,13 +202,13 @@
 			}
 		},
 		"node_modules/@comunica/actor-abstract-parse": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-abstract-parse/-/actor-abstract-parse-5.1.3.tgz",
-			"integrity": "sha512-5oGYbEdWSBWwwN2TF15etay53yc1v59fGVnARxGD05J8HyQCw9syQT7ZgvaicVv/tmQ09PI2LnMKJbxsgj+eHA==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-abstract-parse/-/actor-abstract-parse-5.2.0.tgz",
+			"integrity": "sha512-bELhD3aRI8GCKI3eUQ3YK/IlcTllA/QUQWLS1IH//YGZh2iCkSi123c4J00qqXgermoeXeaEtsMAXMsK/n63jQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/core": "^5.1.3",
+				"@comunica/core": "^5.2.0",
 				"readable-stream": "^4.7.0"
 			},
 			"funding": {
@@ -261,19 +217,19 @@
 			}
 		},
 		"node_modules/@comunica/actor-abstract-path": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-abstract-path/-/actor-abstract-path-5.1.3.tgz",
-			"integrity": "sha512-YiaQwsFxWlnRt/O9f0MAJNkLBz2lv1e+rZuH1u25yWul06YJR5/VFv7FAf5bsvwoJMsO9TrYO3SaVp577infvQ==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-abstract-path/-/actor-abstract-path-5.2.0.tgz",
+			"integrity": "sha512-SHEh7511BxbpQzjMSGZMLiq0cXfuLw8asG0N41FyDGrgvQIddTKjlLFUf04e7UUxwa2GCc4PyYTPz9uoC350aA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-query-operation": "^5.1.3",
-				"@comunica/context-entries": "^5.1.3",
-				"@comunica/core": "^5.1.3",
-				"@comunica/types": "^5.1.3",
-				"@comunica/utils-algebra": "^5.1.3",
-				"@comunica/utils-bindings-factory": "^5.1.3",
-				"@comunica/utils-query-operation": "^5.1.3",
+				"@comunica/bus-query-operation": "^5.2.0",
+				"@comunica/context-entries": "^5.2.0",
+				"@comunica/core": "^5.2.0",
+				"@comunica/types": "^5.2.0",
+				"@comunica/utils-algebra": "^5.2.0",
+				"@comunica/utils-bindings-factory": "^5.2.0",
+				"@comunica/utils-query-operation": "^5.2.0",
 				"@rdfjs/types": "*",
 				"asynciterator": "^3.10.0",
 				"rdf-string": "^2.0.1"
@@ -284,131 +240,131 @@
 			}
 		},
 		"node_modules/@comunica/actor-bindings-aggregator-factory-average": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-bindings-aggregator-factory-average/-/actor-bindings-aggregator-factory-average-5.1.3.tgz",
-			"integrity": "sha512-r2tjjSlmVzzBAWMBWzNy8PDXlT7kdDDew4lgAyv9Veg89/JfTPVNOYvBrtyRktPtbUtiPvu6Ow/7qlsO1XVEZA==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-bindings-aggregator-factory-average/-/actor-bindings-aggregator-factory-average-5.2.0.tgz",
+			"integrity": "sha512-ut5KnXsEIMqb0L+VHeOSCU8jrOSsShYD4MbAHEM5uthic/VgoFezP83e/ElD1N5z5x35G2B6iYhRvBr9mei6LQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-bindings-aggregator-factory": "^5.1.3",
-				"@comunica/bus-function-factory": "^5.1.3",
-				"@comunica/context-entries": "^5.1.3",
-				"@comunica/core": "^5.1.3",
-				"@comunica/types": "^5.1.3",
-				"@comunica/utils-expression-evaluator": "^5.1.3",
+				"@comunica/bus-bindings-aggregator-factory": "^5.2.0",
+				"@comunica/bus-function-factory": "^5.2.0",
+				"@comunica/context-entries": "^5.2.0",
+				"@comunica/core": "^5.2.0",
+				"@comunica/types": "^5.2.0",
+				"@comunica/utils-expression-evaluator": "^5.2.0",
 				"@rdfjs/types": "*"
 			}
 		},
 		"node_modules/@comunica/actor-bindings-aggregator-factory-count": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-bindings-aggregator-factory-count/-/actor-bindings-aggregator-factory-count-5.1.3.tgz",
-			"integrity": "sha512-a/MiLt26IUW7WO+KOH7UfixTmSaSTf2NE2qSfVu5K0x9lG7DZywvz5uuJWgZmmD5UecpYK1iaLb+5xCrQMe2sg==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-bindings-aggregator-factory-count/-/actor-bindings-aggregator-factory-count-5.2.0.tgz",
+			"integrity": "sha512-D70V5ZBHo6oU7zwAe8ht/UXWsrgHuyHjChxLGL/0I2PKMVhknCosqNYcl29ty5TafIOmEWFHyXKCT0/9KPU7ng==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-bindings-aggregator-factory": "^5.1.3",
-				"@comunica/core": "^5.1.3",
-				"@comunica/types": "^5.1.3",
-				"@comunica/utils-algebra": "^5.1.3",
-				"@comunica/utils-expression-evaluator": "^5.1.3",
+				"@comunica/bus-bindings-aggregator-factory": "^5.2.0",
+				"@comunica/core": "^5.2.0",
+				"@comunica/types": "^5.2.0",
+				"@comunica/utils-algebra": "^5.2.0",
+				"@comunica/utils-expression-evaluator": "^5.2.0",
 				"@rdfjs/types": "*"
 			}
 		},
 		"node_modules/@comunica/actor-bindings-aggregator-factory-group-concat": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-bindings-aggregator-factory-group-concat/-/actor-bindings-aggregator-factory-group-concat-5.1.3.tgz",
-			"integrity": "sha512-ZcG0XlE7OIGftsYBcv1iYCxyOBlLqPsKTHHI87tWkXRG6IAC1v0ZDuRZHvbd2e91hmmHtzYGJUhZmpEzG9jEyA==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-bindings-aggregator-factory-group-concat/-/actor-bindings-aggregator-factory-group-concat-5.2.0.tgz",
+			"integrity": "sha512-rHB+EOvFYA36nDaFlm/uIVIpmREWlkRuc54yqsQkAHLzp7c0OgKvPCve31xt4gkWELbaLpGOXP8qx15laM42sQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-bindings-aggregator-factory": "^5.1.3",
-				"@comunica/context-entries": "^5.1.3",
-				"@comunica/core": "^5.1.3",
-				"@comunica/types": "^5.1.3",
-				"@comunica/utils-expression-evaluator": "^5.1.3",
+				"@comunica/bus-bindings-aggregator-factory": "^5.2.0",
+				"@comunica/context-entries": "^5.2.0",
+				"@comunica/core": "^5.2.0",
+				"@comunica/types": "^5.2.0",
+				"@comunica/utils-expression-evaluator": "^5.2.0",
 				"@rdfjs/types": "*"
 			}
 		},
 		"node_modules/@comunica/actor-bindings-aggregator-factory-max": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-bindings-aggregator-factory-max/-/actor-bindings-aggregator-factory-max-5.1.3.tgz",
-			"integrity": "sha512-xksCukc7oLMeIqRg377qi/voWUTR12v0UIkNNOt4nLFOcX9C9YbTWku+GBPT9P7EqCwaQ6XhSy72tLxBM0yb1Q==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-bindings-aggregator-factory-max/-/actor-bindings-aggregator-factory-max-5.2.0.tgz",
+			"integrity": "sha512-niCGPLws86RRxQEwUM++EHc+RNixJZqGIMe6O6qr+MgJ++G8PeVPXUp54nRP3c3A8t78eAOr0yj0DWq88KvMrg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-bindings-aggregator-factory": "^5.1.3",
-				"@comunica/core": "^5.1.3",
-				"@comunica/types": "^5.1.3",
+				"@comunica/bus-bindings-aggregator-factory": "^5.2.0",
+				"@comunica/core": "^5.2.0",
+				"@comunica/types": "^5.2.0",
 				"@rdfjs/types": "*"
 			}
 		},
 		"node_modules/@comunica/actor-bindings-aggregator-factory-min": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-bindings-aggregator-factory-min/-/actor-bindings-aggregator-factory-min-5.1.3.tgz",
-			"integrity": "sha512-pCZnxsAekTBucQ2/8F0f4QVeDM4BYJ31gpuvrLCkXhA0E1AqBzb0IwRYI8Eo0cNuuxIU72J0Bb8apVLrtKrs0g==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-bindings-aggregator-factory-min/-/actor-bindings-aggregator-factory-min-5.2.0.tgz",
+			"integrity": "sha512-8wewEmASGs838aKCvefqYHAVXED2hbGJ97+yh3SN7FFhsCKwmBRjhMuOhh+jKxJqPsI5ima9ZywKJiHzDouG8Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-bindings-aggregator-factory": "^5.1.3",
-				"@comunica/core": "^5.1.3",
-				"@comunica/types": "^5.1.3",
+				"@comunica/bus-bindings-aggregator-factory": "^5.2.0",
+				"@comunica/core": "^5.2.0",
+				"@comunica/types": "^5.2.0",
 				"@rdfjs/types": "*"
 			}
 		},
 		"node_modules/@comunica/actor-bindings-aggregator-factory-sample": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-bindings-aggregator-factory-sample/-/actor-bindings-aggregator-factory-sample-5.1.3.tgz",
-			"integrity": "sha512-VichDq2FPjKPHlhwKB9rKohyF+eqjcmSwUHvXz4ILbWmH0A3kVUQdt03DMqCpUy5qSvfc8x1VuRNx8UYs29t7Q==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-bindings-aggregator-factory-sample/-/actor-bindings-aggregator-factory-sample-5.2.0.tgz",
+			"integrity": "sha512-DjoYsHk+JxI4bUcaxYBcSmwhoPBhwrSz/I1NKiZPAx4wkRhuHVC7XKSMILbMApqu84l0xQdBlu1rZA2VoWFxdA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-bindings-aggregator-factory": "^5.1.3",
-				"@comunica/core": "^5.1.3",
-				"@comunica/types": "^5.1.3",
+				"@comunica/bus-bindings-aggregator-factory": "^5.2.0",
+				"@comunica/core": "^5.2.0",
+				"@comunica/types": "^5.2.0",
 				"@rdfjs/types": "*"
 			}
 		},
 		"node_modules/@comunica/actor-bindings-aggregator-factory-sum": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-bindings-aggregator-factory-sum/-/actor-bindings-aggregator-factory-sum-5.1.3.tgz",
-			"integrity": "sha512-yA8wh43hUJx6QD+x7K3OCPvg0lolsEdy+ro6nXHeyGmeimxAlrClLMiSf63+CuvyS8iIdKW31CN+A4WCNbEPyA==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-bindings-aggregator-factory-sum/-/actor-bindings-aggregator-factory-sum-5.2.0.tgz",
+			"integrity": "sha512-O+xwWi2RymVkeqdQyGC8XfBGCE4LpuHKiTsPAs8lVnRu/zVsGwoml7MbNg+dyVGBwWWvwo//vNYQXqM3fjXSOQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-bindings-aggregator-factory": "^5.1.3",
-				"@comunica/bus-function-factory": "^5.1.3",
-				"@comunica/context-entries": "^5.1.3",
-				"@comunica/core": "^5.1.3",
-				"@comunica/types": "^5.1.3",
-				"@comunica/utils-expression-evaluator": "^5.1.3",
+				"@comunica/bus-bindings-aggregator-factory": "^5.2.0",
+				"@comunica/bus-function-factory": "^5.2.0",
+				"@comunica/context-entries": "^5.2.0",
+				"@comunica/core": "^5.2.0",
+				"@comunica/types": "^5.2.0",
+				"@comunica/utils-expression-evaluator": "^5.2.0",
 				"@rdfjs/types": "*"
 			}
 		},
 		"node_modules/@comunica/actor-bindings-aggregator-factory-wildcard-count": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-bindings-aggregator-factory-wildcard-count/-/actor-bindings-aggregator-factory-wildcard-count-5.1.3.tgz",
-			"integrity": "sha512-YZgs4sf4GD75F8s4+t04FGiiJyt/esYuiPhGYl4m9BzcnOo6eMyDb8AD2bMb6V6AczlrBoTfEusc7rsLhryLnA==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-bindings-aggregator-factory-wildcard-count/-/actor-bindings-aggregator-factory-wildcard-count-5.2.0.tgz",
+			"integrity": "sha512-QXytmgLL3RaZzQOildc1XEooWlL+qT/u3z4yg9J8YLHCGeg1cUmnn9EhiMh4fKh1nWGgy00EyJDQGDJspRsvuQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-bindings-aggregator-factory": "^5.1.3",
-				"@comunica/core": "^5.1.3",
-				"@comunica/types": "^5.1.3",
-				"@comunica/utils-expression-evaluator": "^5.1.3",
+				"@comunica/bus-bindings-aggregator-factory": "^5.2.0",
+				"@comunica/core": "^5.2.0",
+				"@comunica/types": "^5.2.0",
+				"@comunica/utils-expression-evaluator": "^5.2.0",
 				"@rdfjs/types": "*",
 				"rdf-string": "^2.0.1"
 			}
 		},
 		"node_modules/@comunica/actor-context-preprocess-convert-shortcuts": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-context-preprocess-convert-shortcuts/-/actor-context-preprocess-convert-shortcuts-5.1.3.tgz",
-			"integrity": "sha512-HnFsTUNls/HdZRK7xzj+PX0hylBnzIIU7HQFVEyqL2w1Nu5YFHAWgA3Tb1mDClE1kuHwMcL3+b1ZWWwZgp87lg==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-context-preprocess-convert-shortcuts/-/actor-context-preprocess-convert-shortcuts-5.2.0.tgz",
+			"integrity": "sha512-UaqHoe3vg1P3alBGvFgQL163Rwq7rfbndbV2oxXxgR3m48FRlUqZ7tZGzM3rSJm3+2nqR2FFfx4vDmkntfM5ew==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-context-preprocess": "^5.1.3",
-				"@comunica/core": "^5.1.3",
-				"@comunica/types": "^5.1.3"
+				"@comunica/bus-context-preprocess": "^5.2.0",
+				"@comunica/core": "^5.2.0",
+				"@comunica/types": "^5.2.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -416,16 +372,16 @@
 			}
 		},
 		"node_modules/@comunica/actor-context-preprocess-set-defaults": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-context-preprocess-set-defaults/-/actor-context-preprocess-set-defaults-5.1.3.tgz",
-			"integrity": "sha512-IYC4sqzdoW0SqIlH6l/idg5F9ZN4tTNpeIIKgCk/s/ubqAt3IWF5hefIxJp27pato+qCwQf3KKAGcRh9BdY71w==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-context-preprocess-set-defaults/-/actor-context-preprocess-set-defaults-5.2.0.tgz",
+			"integrity": "sha512-r07Hap7rGLSmrDkPayHbSTr3ef/3OLrIr/v5nZyB7bF7dK0VIIedPdv82Rujxac2rhp/ojAHaVBhVRJFTverXQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-context-preprocess": "^5.1.3",
-				"@comunica/context-entries": "^5.1.3",
-				"@comunica/core": "^5.1.3",
-				"@comunica/types": "^5.1.3",
+				"@comunica/bus-context-preprocess": "^5.2.0",
+				"@comunica/context-entries": "^5.2.0",
+				"@comunica/core": "^5.2.0",
+				"@comunica/types": "^5.2.0",
 				"@rdfjs/types": "*",
 				"rdf-data-factory": "^2.0.0"
 			},
@@ -435,16 +391,16 @@
 			}
 		},
 		"node_modules/@comunica/actor-context-preprocess-source-to-destination": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-context-preprocess-source-to-destination/-/actor-context-preprocess-source-to-destination-5.1.3.tgz",
-			"integrity": "sha512-wY4WHiwIyv7MiAaaaY+J7aDLNJMjwhXOb6LHOn0CheCNnfagr2PZf10puFtYGuRXuMEMXvftmTM7CWOe170vlA==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-context-preprocess-source-to-destination/-/actor-context-preprocess-source-to-destination-5.2.0.tgz",
+			"integrity": "sha512-2C0jQDGaiB4IGJcNtM//baUeES+R+3uZInLxF/CN9jfpwe6El/r0UsHi1nCrmQR9i26lD4mziG8BAjNskpEzfw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-context-preprocess": "^5.1.3",
-				"@comunica/context-entries": "^5.1.3",
-				"@comunica/core": "^5.1.3",
-				"@comunica/types": "^5.1.3"
+				"@comunica/bus-context-preprocess": "^5.2.0",
+				"@comunica/context-entries": "^5.2.0",
+				"@comunica/core": "^5.2.0",
+				"@comunica/types": "^5.2.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -452,14 +408,14 @@
 			}
 		},
 		"node_modules/@comunica/actor-dereference-fallback": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-dereference-fallback/-/actor-dereference-fallback-5.1.3.tgz",
-			"integrity": "sha512-Vgx2rUJXme/HDQ9i5rXdoe1j4Ot6w1SFKTin+E3dwr9IW3QbbQ8+cLw6yWu1M8TIdsj86jKuFvKhmk1sV0+zzw==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-dereference-fallback/-/actor-dereference-fallback-5.2.0.tgz",
+			"integrity": "sha512-t4ZDjqWOTlXJYGC0/0Dh/c1hW+6zIhTLlupHNFZKzfUVibr+cWjt0ASJk801DGDtpzj4jebL6Dxip+3fUqTXYw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-dereference": "^5.1.3",
-				"@comunica/core": "^5.1.3"
+				"@comunica/bus-dereference": "^5.2.0",
+				"@comunica/core": "^5.2.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -467,16 +423,16 @@
 			}
 		},
 		"node_modules/@comunica/actor-dereference-http": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-dereference-http/-/actor-dereference-http-5.1.3.tgz",
-			"integrity": "sha512-DDWvSAc/ByIVUgKRkvTub/8a+Ay0u6a2u/gdDdTzU0twZFLfZ3rJDWwp0+297Zk+jndC+waN8xfqgRGnVoKu2Q==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-dereference-http/-/actor-dereference-http-5.2.0.tgz",
+			"integrity": "sha512-vnS9RluRY4NeFhlXOTvbiF1LRp5A2vgefvdO/Gp9UAClyqppODyHfXwoXBhUilP8UEKvepuMsnRIVdUTY+PLQA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-dereference": "^5.1.3",
-				"@comunica/bus-http": "^5.1.3",
-				"@comunica/core": "^5.1.3",
-				"@comunica/types": "^5.1.3",
+				"@comunica/bus-dereference": "^5.2.0",
+				"@comunica/bus-http": "^5.2.0",
+				"@comunica/core": "^5.2.0",
+				"@comunica/types": "^5.2.0",
 				"@jeswr/stream-to-string": "^2.0.0",
 				"relative-to-absolute-iri": "^1.0.7"
 			},
@@ -486,15 +442,15 @@
 			}
 		},
 		"node_modules/@comunica/actor-dereference-rdf-parse": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-dereference-rdf-parse/-/actor-dereference-rdf-parse-5.1.3.tgz",
-			"integrity": "sha512-1h6A/OBg++brmlObv6zAY+wwq/Q3PIwkrtgcNbmnZcHBTcTn6vTzTX7ZVmRoTp88V02e5wTsAZ45R3vDujEgDg==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-dereference-rdf-parse/-/actor-dereference-rdf-parse-5.2.0.tgz",
+			"integrity": "sha512-vYkG3iWeB3I08H3Zw3R8iLjb4k+9uu59c9VWk+3Oe074Yy7TYrK+EXPr09gsV/jgeKDHwbH+qpR3vqhM6kQsJA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-dereference": "^5.1.3",
-				"@comunica/bus-dereference-rdf": "^5.1.3",
-				"@comunica/bus-rdf-parse": "^5.1.3"
+				"@comunica/bus-dereference": "^5.2.0",
+				"@comunica/bus-dereference-rdf": "^5.2.0",
+				"@comunica/bus-rdf-parse": "^5.2.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -502,791 +458,791 @@
 			}
 		},
 		"node_modules/@comunica/actor-expression-evaluator-factory-default": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-expression-evaluator-factory-default/-/actor-expression-evaluator-factory-default-5.1.3.tgz",
-			"integrity": "sha512-rG7MRKnkpUW4vHPyy4OR5MC0zP5XgZf2eSNFPRVn72fkvhffD+mqj37ek1e2VouufhCndEl6nDYLLCw51ThmrA==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-expression-evaluator-factory-default/-/actor-expression-evaluator-factory-default-5.2.0.tgz",
+			"integrity": "sha512-jKerbWFzmdOQ6OxIJ4vwti9RPpAXTMGVrGaLsKc2O2RybgXOmP1OP0Xpxe/LlbzNyWEMZQe3ATu485+rXQ6a+A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-expression-evaluator-factory": "^5.1.3",
-				"@comunica/bus-function-factory": "^5.1.3",
-				"@comunica/bus-query-operation": "^5.1.3",
-				"@comunica/context-entries": "^5.1.3",
-				"@comunica/core": "^5.1.3",
-				"@comunica/types": "^5.1.3",
-				"@comunica/utils-algebra": "^5.1.3",
-				"@comunica/utils-bindings-factory": "^5.1.3",
-				"@comunica/utils-expression-evaluator": "^5.1.3",
-				"@comunica/utils-query-operation": "^5.1.3",
+				"@comunica/bus-expression-evaluator-factory": "^5.2.0",
+				"@comunica/bus-function-factory": "^5.2.0",
+				"@comunica/bus-query-operation": "^5.2.0",
+				"@comunica/context-entries": "^5.2.0",
+				"@comunica/core": "^5.2.0",
+				"@comunica/types": "^5.2.0",
+				"@comunica/utils-algebra": "^5.2.0",
+				"@comunica/utils-bindings-factory": "^5.2.0",
+				"@comunica/utils-expression-evaluator": "^5.2.0",
+				"@comunica/utils-query-operation": "^5.2.0",
 				"@rdfjs/types": "*"
 			}
 		},
 		"node_modules/@comunica/actor-function-factory-expression-bnode": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-expression-bnode/-/actor-function-factory-expression-bnode-5.1.3.tgz",
-			"integrity": "sha512-TbfPi9IZR3bdBToygwlsELvz0YIOv6IYn8EE13snmOXpCG4L80nAsmHSWe23DBLsdmjH6rF9lPKajs1grgluIg==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-expression-bnode/-/actor-function-factory-expression-bnode-5.2.0.tgz",
+			"integrity": "sha512-J6uhaovpPu9Wz53Jo9WCQ5AZKHDrymG9aMAonRrhHfJx4PKHvCgoEg2jCw/pKdplfMBErHszVdw1uDdOQjy70A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-function-factory": "^5.1.3",
-				"@comunica/context-entries": "^5.1.3",
-				"@comunica/types": "^5.1.3",
+				"@comunica/bus-function-factory": "^5.2.0",
+				"@comunica/context-entries": "^5.2.0",
+				"@comunica/types": "^5.2.0",
 				"@comunica/utils-data-factory": "^5.0.0",
-				"@comunica/utils-expression-evaluator": "^5.1.3"
+				"@comunica/utils-expression-evaluator": "^5.2.0"
 			}
 		},
 		"node_modules/@comunica/actor-function-factory-expression-bound": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-expression-bound/-/actor-function-factory-expression-bound-5.1.3.tgz",
-			"integrity": "sha512-JU2JDa2FJqnokRRfiywlbKfzUuX5hxGEewdZJ1GVWThpFV6kow2xfoX71qRY5hh1tvyuJv3bqTUTdKAgzJcRag==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-expression-bound/-/actor-function-factory-expression-bound-5.2.0.tgz",
+			"integrity": "sha512-6aUniIO1DI9qUeoyyq2LjM3O8ItpR2xyiLxV7OcWRuBzhMZj8GjwOL41gqOgMKain3z+krRs92ISFsyQkWvQ6A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-function-factory": "^5.1.3",
-				"@comunica/context-entries": "^5.1.3",
-				"@comunica/types": "^5.1.3",
-				"@comunica/utils-expression-evaluator": "^5.1.3"
+				"@comunica/bus-function-factory": "^5.2.0",
+				"@comunica/context-entries": "^5.2.0",
+				"@comunica/types": "^5.2.0",
+				"@comunica/utils-expression-evaluator": "^5.2.0"
 			}
 		},
 		"node_modules/@comunica/actor-function-factory-expression-coalesce": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-expression-coalesce/-/actor-function-factory-expression-coalesce-5.1.3.tgz",
-			"integrity": "sha512-qX1osTdcqpIOO3eG9zGk43T8B/BWed+8X0p/BCWLpWB5eT/mvxCCQNiaowmIK/A6L2EmNfgo1bK/rXiHCHh3sQ==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-expression-coalesce/-/actor-function-factory-expression-coalesce-5.2.0.tgz",
+			"integrity": "sha512-b4UHIKlIu+ce7tLUdhA+BxI4NihYbUJBjzh9IaRB0TqyAOKqdWmeoM/NpWn5/Efeo4yp3B2wu5TPIIPDcWsX2w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-function-factory": "^5.1.3",
-				"@comunica/utils-expression-evaluator": "^5.1.3"
+				"@comunica/bus-function-factory": "^5.2.0",
+				"@comunica/utils-expression-evaluator": "^5.2.0"
 			}
 		},
 		"node_modules/@comunica/actor-function-factory-expression-concat": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-expression-concat/-/actor-function-factory-expression-concat-5.1.3.tgz",
-			"integrity": "sha512-k7Ixv69XHkdWPDrETgKrbuk6pBQXUkBa2KQWh6bJO4yL1NRtR05Xe0sVmf1Ejd4r6fKG0dOGoFdDxP3iOzIMsg==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-expression-concat/-/actor-function-factory-expression-concat-5.2.0.tgz",
+			"integrity": "sha512-PeECBw7bez8EWGB6iH0fW0gwIqXjWRtKAJT0/2BHXRUzE50RD3m2pdPhNZlJRNTxzkdzFdUGJD1RMI0ROobGXQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-function-factory": "^5.1.3",
-				"@comunica/context-entries": "^5.1.3",
-				"@comunica/utils-expression-evaluator": "^5.1.3"
+				"@comunica/bus-function-factory": "^5.2.0",
+				"@comunica/context-entries": "^5.2.0",
+				"@comunica/utils-expression-evaluator": "^5.2.0"
 			}
 		},
 		"node_modules/@comunica/actor-function-factory-expression-extensions": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-expression-extensions/-/actor-function-factory-expression-extensions-5.1.3.tgz",
-			"integrity": "sha512-ZHKReFE1+CR2rDXSMR07W/Niones4C1nFJHLFRl4UhUAyKKOQ+Re05SYRXpKCQuVvyuV3trAyv7ET2CwYJDrVA==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-expression-extensions/-/actor-function-factory-expression-extensions-5.2.0.tgz",
+			"integrity": "sha512-u0KBxLvjIN9xqw5Aox6HiJ1SSl+GEEo01/CunrwrwZ/2IEJNWo87h+TRKSi3MEoqRUCF5KrMfOql7QzJlSpnTA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-function-factory": "^5.1.3",
-				"@comunica/context-entries": "^5.1.3",
-				"@comunica/core": "^5.1.3",
-				"@comunica/types": "^5.1.3",
-				"@comunica/utils-expression-evaluator": "^5.1.3",
+				"@comunica/bus-function-factory": "^5.2.0",
+				"@comunica/context-entries": "^5.2.0",
+				"@comunica/core": "^5.2.0",
+				"@comunica/types": "^5.2.0",
+				"@comunica/utils-expression-evaluator": "^5.2.0",
 				"rdf-data-factory": "^2.0.0"
 			}
 		},
 		"node_modules/@comunica/actor-function-factory-expression-if": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-expression-if/-/actor-function-factory-expression-if-5.1.3.tgz",
-			"integrity": "sha512-RtXrrddDyp7ePM+elHaBQpIYP5AWHcnbZekqfIS5SpvgzXoxj52mO6w4hMK3SyfVPwvG6LTYBhxqPKho/mEpDg==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-expression-if/-/actor-function-factory-expression-if-5.2.0.tgz",
+			"integrity": "sha512-/PsiSyI09vMYGZOuyGqZcxk+TnqBkkSHNEIeAYzauy9PGKgNsrIQzR04PycrF6KKICETYNEoDOOHpUtpDkyj/A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-function-factory": "^5.1.3",
-				"@comunica/types": "^5.1.3",
-				"@comunica/utils-expression-evaluator": "^5.1.3"
+				"@comunica/bus-function-factory": "^5.2.0",
+				"@comunica/types": "^5.2.0",
+				"@comunica/utils-expression-evaluator": "^5.2.0"
 			}
 		},
 		"node_modules/@comunica/actor-function-factory-expression-in": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-expression-in/-/actor-function-factory-expression-in-5.1.3.tgz",
-			"integrity": "sha512-fBgsRozSBogLbAw0atUwULMYFn54xSfbrcuGt/fueLgK2CG389WVkqyZJ8cVz+/b428MELjm7yLBTdZBn5bH8g==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-expression-in/-/actor-function-factory-expression-in-5.2.0.tgz",
+			"integrity": "sha512-67NQu9ONN8bXb4arCeXvyPD6eab9IwJSjf+hvZ8zJ6ljnN/gBZo5nr9Hvh49XB5DuP0v5ivYoGDUpvSClCdpOQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-function-factory": "^5.1.3",
-				"@comunica/types": "^5.1.3",
-				"@comunica/utils-expression-evaluator": "^5.1.3"
+				"@comunica/bus-function-factory": "^5.2.0",
+				"@comunica/types": "^5.2.0",
+				"@comunica/utils-expression-evaluator": "^5.2.0"
 			}
 		},
 		"node_modules/@comunica/actor-function-factory-expression-logical-and": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-expression-logical-and/-/actor-function-factory-expression-logical-and-5.1.3.tgz",
-			"integrity": "sha512-p8ZoUBxddwh1q2vEaDOlLAunfev4XCHCusdzM40zegPuZrAJcNoZm8zHhSVWN0YKiYGmXKlXkTa870nQXQZ/sA==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-expression-logical-and/-/actor-function-factory-expression-logical-and-5.2.0.tgz",
+			"integrity": "sha512-ArzA/EwrXdUR6vjRzfV9LKZdBZkOMIZDHfERBi42wm9a/BtMybFty1nt7yCK3XB0O5BcSZW28pLube4mwPjSyw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-function-factory": "^5.1.3",
-				"@comunica/types": "^5.1.3",
-				"@comunica/utils-expression-evaluator": "^5.1.3"
+				"@comunica/bus-function-factory": "^5.2.0",
+				"@comunica/types": "^5.2.0",
+				"@comunica/utils-expression-evaluator": "^5.2.0"
 			}
 		},
 		"node_modules/@comunica/actor-function-factory-expression-logical-or": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-expression-logical-or/-/actor-function-factory-expression-logical-or-5.1.3.tgz",
-			"integrity": "sha512-xmQyoqd/kPuhuHl+f4OzTkp0NaULl6Ss/km8YEYMSlIcbHO3k5Hq++ZfjTl0KHNAJvkqpFD4ukdVkh6DyFzsWw==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-expression-logical-or/-/actor-function-factory-expression-logical-or-5.2.0.tgz",
+			"integrity": "sha512-LFbbS79Wt1my9hsFzFMGi1JJ76pi7qyy7Bp6z0l1umPC5PR6M3c3/LebGA6Bp5ye9/GZkkT7Okj9TMevPMiTZw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-function-factory": "^5.1.3",
-				"@comunica/types": "^5.1.3",
-				"@comunica/utils-expression-evaluator": "^5.1.3"
+				"@comunica/bus-function-factory": "^5.2.0",
+				"@comunica/types": "^5.2.0",
+				"@comunica/utils-expression-evaluator": "^5.2.0"
 			}
 		},
 		"node_modules/@comunica/actor-function-factory-expression-not-in": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-expression-not-in/-/actor-function-factory-expression-not-in-5.1.3.tgz",
-			"integrity": "sha512-XzIqRJ7tJYcbe8jhk0QGb1z6jf47DRGdIgQUkAD/PKvN89fVNekRPFgOtDado3udfck/+yXzBgap1qd1D30SAQ==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-expression-not-in/-/actor-function-factory-expression-not-in-5.2.0.tgz",
+			"integrity": "sha512-d0weV7SDhxpP9zo6WuV+QByiI6sKA1umWyQvwsUD0Ht4BWlB/Hs4feuR4wAo9iGUhn6HCn62Pl2BPLxOkkhHhQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-function-factory": "^5.1.3",
-				"@comunica/types": "^5.1.3",
-				"@comunica/utils-expression-evaluator": "^5.1.3"
+				"@comunica/bus-function-factory": "^5.2.0",
+				"@comunica/types": "^5.2.0",
+				"@comunica/utils-expression-evaluator": "^5.2.0"
 			}
 		},
 		"node_modules/@comunica/actor-function-factory-expression-same-term": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-expression-same-term/-/actor-function-factory-expression-same-term-5.1.3.tgz",
-			"integrity": "sha512-8T/+NF7OW2yrsd6bV8DHQpyR5nt06gel0ntLYul8l4rzKGrBgJrK/d7vuZZi5rXCuauK8DoOsgsTUWeRPQ9j2Q==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-expression-same-term/-/actor-function-factory-expression-same-term-5.2.0.tgz",
+			"integrity": "sha512-jBjiTIRke63kpc7gL5VK4cIs1RI3BQLFnI5Vm6ZwG6YPYZQKL8lX6sFLAldKVVH61M5WkIivLqCUjVpyW2HI6Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-function-factory": "^5.1.3",
-				"@comunica/context-entries": "^5.1.3",
-				"@comunica/types": "^5.1.3",
-				"@comunica/utils-expression-evaluator": "^5.1.3"
+				"@comunica/bus-function-factory": "^5.2.0",
+				"@comunica/context-entries": "^5.2.0",
+				"@comunica/types": "^5.2.0",
+				"@comunica/utils-expression-evaluator": "^5.2.0"
 			}
 		},
 		"node_modules/@comunica/actor-function-factory-term-abs": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-abs/-/actor-function-factory-term-abs-5.1.3.tgz",
-			"integrity": "sha512-Y3ZNzAZfpueZY4QusCvB1GP+zYDcyHoHTrgKgvymyX4o1Nd/sfE0zzZkBYIU0O2DVBT9n1sc7p4yyMf/vEccUw==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-abs/-/actor-function-factory-term-abs-5.2.0.tgz",
+			"integrity": "sha512-k9Um2E2WC9PsRYCZuz1gFBceGvlQkN3m3U6VORMpgjJDpuhpa4TOr5M0AMNBaY5VqDDOSaITHSCC4Al43QStcQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-function-factory": "^5.1.3",
-				"@comunica/utils-expression-evaluator": "^5.1.3"
+				"@comunica/bus-function-factory": "^5.2.0",
+				"@comunica/utils-expression-evaluator": "^5.2.0"
 			}
 		},
 		"node_modules/@comunica/actor-function-factory-term-addition": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-addition/-/actor-function-factory-term-addition-5.1.3.tgz",
-			"integrity": "sha512-qXDTFAirN7RKnYXiGOHB5bU8LpKoppIkU/uJ5pB+cUx65NLMEm0xwFCaEXuAQ/plF7z6hCQn4tOmCIiiIgn/cw==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-addition/-/actor-function-factory-term-addition-5.2.0.tgz",
+			"integrity": "sha512-JuJyrPZr68rM8HoL8wjiLjAwobuLtlGRXDzxmVGUSjg+SetQuJCK0ZO3dxWOPOZJufvoOOMmaxA7Y4AodwMWfA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-function-factory": "^5.1.3",
-				"@comunica/utils-expression-evaluator": "^5.1.3",
-				"bignumber.js": "^9.1.2"
+				"@comunica/bus-function-factory": "^5.2.0",
+				"@comunica/utils-expression-evaluator": "^5.2.0",
+				"bignumber.js": "^10.0.0"
 			}
 		},
 		"node_modules/@comunica/actor-function-factory-term-ceil": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-ceil/-/actor-function-factory-term-ceil-5.1.3.tgz",
-			"integrity": "sha512-qCB42PLfWZrHU88HWutcgaKJNybhqgvo6sLvk2bZNe9tRgQwxS0NPR2mZAlxQHf7DN3fJy9j6g81XCqsyCfk7w==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-ceil/-/actor-function-factory-term-ceil-5.2.0.tgz",
+			"integrity": "sha512-6CYQ50j38Pd2PTbhftyZ0UDRd/kMAefE+ChDwSguIzDPALCJ/ngeKkQtkXUVjOA0OTtSiu5Wj6f6/DpNsGnVKQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-function-factory": "^5.1.3",
-				"@comunica/utils-expression-evaluator": "^5.1.3"
+				"@comunica/bus-function-factory": "^5.2.0",
+				"@comunica/utils-expression-evaluator": "^5.2.0"
 			}
 		},
 		"node_modules/@comunica/actor-function-factory-term-contains": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-contains/-/actor-function-factory-term-contains-5.1.3.tgz",
-			"integrity": "sha512-oddB//hRq4le3yZT7Mh7U2np6ZgePRUtlaTeKs+WKp4y7I5DYvsq+My6fsnQ6gvgwehKlFb4YGjxYhjmw+R5qg==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-contains/-/actor-function-factory-term-contains-5.2.0.tgz",
+			"integrity": "sha512-XlJsIN4ynjKYaHTD4sxHXX99i3hmWkpC1MqYX+IkP7NcH98oQN3RtZ4IH1WonhrV0zmmS+zEx1gdB7ebOK26lA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-function-factory": "^5.1.3",
-				"@comunica/utils-expression-evaluator": "^5.1.3"
+				"@comunica/bus-function-factory": "^5.2.0",
+				"@comunica/utils-expression-evaluator": "^5.2.0"
 			}
 		},
 		"node_modules/@comunica/actor-function-factory-term-datatype": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-datatype/-/actor-function-factory-term-datatype-5.1.3.tgz",
-			"integrity": "sha512-kU317ilk071W53lx7hGAmmD4qFikTQO/tubXo2F0XtX5B+9bSBzexBb6AWzpUHq2oaxu0FCysXHmhJSAQTrLTw==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-datatype/-/actor-function-factory-term-datatype-5.2.0.tgz",
+			"integrity": "sha512-HznPmGAJHoNUKOeWKotEUUoBxCxFAbRp2agO81IZo/O98ojyFDOAOQ6w5oCyd0wcFe6xwyqAYJcSaDVhCV6LSA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-function-factory": "^5.1.3",
-				"@comunica/utils-expression-evaluator": "^5.1.3"
+				"@comunica/bus-function-factory": "^5.2.0",
+				"@comunica/utils-expression-evaluator": "^5.2.0"
 			}
 		},
 		"node_modules/@comunica/actor-function-factory-term-day": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-day/-/actor-function-factory-term-day-5.1.3.tgz",
-			"integrity": "sha512-XcZlmxodsfszn/yzvQDjQXtWrzJIU1AWEC2fSNSMY5JKTmFEVpkVN9UsSP1tPOsvmniQ2EM6v4u2E5AnWoHf0Q==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-day/-/actor-function-factory-term-day-5.2.0.tgz",
+			"integrity": "sha512-lCVZgUMunBBF58xjEXcNi+uH5haOdW2W7wUBgifJvk0t64EDKemL8bdyjDAlWJ6nP0kg5lhqMQyeyYpHbHHNYQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-function-factory": "^5.1.3",
-				"@comunica/utils-expression-evaluator": "^5.1.3"
+				"@comunica/bus-function-factory": "^5.2.0",
+				"@comunica/utils-expression-evaluator": "^5.2.0"
 			}
 		},
 		"node_modules/@comunica/actor-function-factory-term-division": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-division/-/actor-function-factory-term-division-5.1.3.tgz",
-			"integrity": "sha512-5PV5dzdQTJbtKqt2TKzXwcFs+jLVMQpFtE05AGmBeeugOZcvpBC68TI6UGQMnCgUz66nE/RgOcz8hzI4M+EOZQ==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-division/-/actor-function-factory-term-division-5.2.0.tgz",
+			"integrity": "sha512-79PmMQO3A6LWWlEJP/UkuyZVB4Qv0MwSXn1zxPJGpy1VOywzGqfRf8LYoibGx7XSnWLb+liI6mdC8U48rrk5Eg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-function-factory": "^5.1.3",
-				"@comunica/utils-expression-evaluator": "^5.1.3",
-				"bignumber.js": "^9.1.2"
+				"@comunica/bus-function-factory": "^5.2.0",
+				"@comunica/utils-expression-evaluator": "^5.2.0",
+				"bignumber.js": "^10.0.0"
 			}
 		},
 		"node_modules/@comunica/actor-function-factory-term-encode-for-uri": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-encode-for-uri/-/actor-function-factory-term-encode-for-uri-5.1.3.tgz",
-			"integrity": "sha512-bKv27rEfyWjgOwnNqxrJ5BBVbiL+/azDRPQD4lYtOnVezKJWSdbcF6VUehBhB+fOMf1MLincDUwvnW/UfbGSaQ==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-encode-for-uri/-/actor-function-factory-term-encode-for-uri-5.2.0.tgz",
+			"integrity": "sha512-vkEf716KppCDjrEa83FkRDm8cg3esdgCDxe8LSq2zjbrfWhKeNN76GVECu4wdWGXr7HStb80dhcvIu0g2e36lQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-function-factory": "^5.1.3",
-				"@comunica/utils-expression-evaluator": "^5.1.3"
+				"@comunica/bus-function-factory": "^5.2.0",
+				"@comunica/utils-expression-evaluator": "^5.2.0"
 			}
 		},
 		"node_modules/@comunica/actor-function-factory-term-equality": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-equality/-/actor-function-factory-term-equality-5.1.3.tgz",
-			"integrity": "sha512-QJpVSjBvQ/yv9T4moT7/KvoGyKgCp9p4KsQJO1in8YaRKKU4qTzp49JXoSxOTjSts2NjD3MfEqb/aM6XkJ6zcA==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-equality/-/actor-function-factory-term-equality-5.2.0.tgz",
+			"integrity": "sha512-57fuqkUltpYsB7pURFRLTpo/P2f8aaXVtBtyKHWsv5yJ+PfItxl5WxpR++sa1w3G3iXdGArTEGelgaAJSntlQw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-function-factory": "^5.1.3",
-				"@comunica/context-entries": "^5.1.3",
-				"@comunica/utils-expression-evaluator": "^5.1.3"
+				"@comunica/bus-function-factory": "^5.2.0",
+				"@comunica/context-entries": "^5.2.0",
+				"@comunica/utils-expression-evaluator": "^5.2.0"
 			}
 		},
 		"node_modules/@comunica/actor-function-factory-term-floor": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-floor/-/actor-function-factory-term-floor-5.1.3.tgz",
-			"integrity": "sha512-AjBhXK7/ts+TdgE6OKybBfKaJewgItmXegSvE7bkHvfD0RxNC9nQ68aSRiFajFbH0HBqPxQMu2aF4ORzQRPVyg==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-floor/-/actor-function-factory-term-floor-5.2.0.tgz",
+			"integrity": "sha512-8P7ygQQ/uyCm8o1kd7fIORzWusQ6DxoP/gRrUeQ9gKPCtbUlq8D/b18kPd9JwFaXpIzkUi575v9tMZhV1SWpMw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-function-factory": "^5.1.3",
-				"@comunica/utils-expression-evaluator": "^5.1.3"
+				"@comunica/bus-function-factory": "^5.2.0",
+				"@comunica/utils-expression-evaluator": "^5.2.0"
 			}
 		},
 		"node_modules/@comunica/actor-function-factory-term-greater-than": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-greater-than/-/actor-function-factory-term-greater-than-5.1.3.tgz",
-			"integrity": "sha512-y3OMO6SOsXkN03XdkLGQbwNuvy76lsLjcV2Hqx1A4Ev1OXcjgsePgoctVhp+OvwCpYsVIxVrGwEApeC7+d5RKw==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-greater-than/-/actor-function-factory-term-greater-than-5.2.0.tgz",
+			"integrity": "sha512-d3615Axug143nFGEs2wmN2g0bLyl0n2WZekWnimeGVq42JoWWh0GntuZX9+YOA+eIOf6MYR3T5hTimZcQoz7Ig==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-function-factory": "^5.1.3",
-				"@comunica/utils-expression-evaluator": "^5.1.3"
+				"@comunica/bus-function-factory": "^5.2.0",
+				"@comunica/utils-expression-evaluator": "^5.2.0"
 			}
 		},
 		"node_modules/@comunica/actor-function-factory-term-greater-than-equal": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-greater-than-equal/-/actor-function-factory-term-greater-than-equal-5.1.3.tgz",
-			"integrity": "sha512-cB5AZe4Lut2GtECirlJJmMsfJNzEtQTYSm1pZM/ojsi+K6ww2Ch5R45ALZxr37dpiAp0McdV/44YnaxrVOKf/Q==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-greater-than-equal/-/actor-function-factory-term-greater-than-equal-5.2.0.tgz",
+			"integrity": "sha512-t1Crxd1bh9/gYcFt7U41oy111iFl6DfKqeT0gIKm5eqCcqcvf83Megaha0K5PhhC+YlajeUPGND/ly8fodyeiw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-function-factory": "^5.1.3",
-				"@comunica/utils-expression-evaluator": "^5.1.3"
+				"@comunica/bus-function-factory": "^5.2.0",
+				"@comunica/utils-expression-evaluator": "^5.2.0"
 			}
 		},
 		"node_modules/@comunica/actor-function-factory-term-has-lang": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-has-lang/-/actor-function-factory-term-has-lang-5.1.3.tgz",
-			"integrity": "sha512-jE9JUBw/MQnaClzD57ZIrjf6FUhZmEa3/QjpxvXjhh5Utf8zpFjTzw754dkDYkvoxyu36pwCUIGZ5bS9yX+OyQ==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-has-lang/-/actor-function-factory-term-has-lang-5.2.0.tgz",
+			"integrity": "sha512-bEjy+G4/43JJmOpkNg18AQBYQBCqvi7sSa2xwzte6AD7EKkfFFvtezGsk84qCd9TZxgAZ8xriKPhWjOYJO0HnA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-function-factory": "^5.1.3",
-				"@comunica/utils-expression-evaluator": "^5.1.3"
+				"@comunica/bus-function-factory": "^5.2.0",
+				"@comunica/utils-expression-evaluator": "^5.2.0"
 			}
 		},
 		"node_modules/@comunica/actor-function-factory-term-has-langdir": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-has-langdir/-/actor-function-factory-term-has-langdir-5.1.3.tgz",
-			"integrity": "sha512-of+JP2AKtLMVg/FbVSey6ya6qmo+tzWc/c2C3QW1iCiQCeDwlU1Wl7u2tvR8kmMINoA26pxN+hEuB6SrWyg8VA==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-has-langdir/-/actor-function-factory-term-has-langdir-5.2.0.tgz",
+			"integrity": "sha512-khILtfWVsRD440z7SyBiCU1G4c6gTUgGjzq1owAuoS1LbBnnNfZXFHz0LYyIKh0H/KsEz7JhOMWvAweJfEQCww==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-function-factory": "^5.1.3",
-				"@comunica/utils-expression-evaluator": "^5.1.3"
+				"@comunica/bus-function-factory": "^5.2.0",
+				"@comunica/utils-expression-evaluator": "^5.2.0"
 			}
 		},
 		"node_modules/@comunica/actor-function-factory-term-hours": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-hours/-/actor-function-factory-term-hours-5.1.3.tgz",
-			"integrity": "sha512-8B79ORJBle3sDp2hYOvCJ/XF4vjH3q3DVP8oTVgsKjGrqfQyi+mN8tQQqVsctvVSRKv7x+OluyvMEOiEUQB/DQ==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-hours/-/actor-function-factory-term-hours-5.2.0.tgz",
+			"integrity": "sha512-l/AYdkGeIFhGldM5X5NV2s7F866S6Dbv3TKBRdh54ZKgKk8Yb4/L79SiHc5PXzYMrliGC47WLzJs0ywipFprgA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-function-factory": "^5.1.3",
-				"@comunica/utils-expression-evaluator": "^5.1.3"
+				"@comunica/bus-function-factory": "^5.2.0",
+				"@comunica/utils-expression-evaluator": "^5.2.0"
 			}
 		},
 		"node_modules/@comunica/actor-function-factory-term-inequality": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-inequality/-/actor-function-factory-term-inequality-5.1.3.tgz",
-			"integrity": "sha512-gt0SjsUR5rnIyQ4AjEXNcetJ9ox6bk1iOyaZY9Ba3Or47qA8HrXXcrqwQBMB60jhw81Q8F2mIMvUHxq+CAsRQQ==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-inequality/-/actor-function-factory-term-inequality-5.2.0.tgz",
+			"integrity": "sha512-IVOD9GW4aztjQqyDsXJvI4XM9SzHAbeDhY5unpPLt3CuvSzYVMXpSIvGFcqRDCof59I/HNVgHWRlQS/tlT2exA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-function-factory": "^5.1.3",
-				"@comunica/utils-expression-evaluator": "^5.1.3"
+				"@comunica/bus-function-factory": "^5.2.0",
+				"@comunica/utils-expression-evaluator": "^5.2.0"
 			}
 		},
 		"node_modules/@comunica/actor-function-factory-term-iri": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-iri/-/actor-function-factory-term-iri-5.1.3.tgz",
-			"integrity": "sha512-k3HnbC7Y7JE/E0T2ZvINzqf2n6KMdIDvo696eBr/RjYH6GwfxA4pGLlWsbylOvwrnO6mreDQayMg381Duu4cpw==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-iri/-/actor-function-factory-term-iri-5.2.0.tgz",
+			"integrity": "sha512-XoMZZAAlUrqNuoJTP4rQNssYUNd3C7N+yrgR+MRHVu3T4KpMLJlFXRtsiXIYzN/vLm3Nps1+Z/1muIgu/1dWRg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-function-factory": "^5.1.3",
-				"@comunica/context-entries": "^5.1.3",
-				"@comunica/utils-expression-evaluator": "^5.1.3",
+				"@comunica/bus-function-factory": "^5.2.0",
+				"@comunica/context-entries": "^5.2.0",
+				"@comunica/utils-expression-evaluator": "^5.2.0",
 				"relative-to-absolute-iri": "^1.0.7"
 			}
 		},
 		"node_modules/@comunica/actor-function-factory-term-is-blank": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-is-blank/-/actor-function-factory-term-is-blank-5.1.3.tgz",
-			"integrity": "sha512-QsVwQFWx5jda5jmL3S9ciym4enMm0rzQ7Lq2/9CRcdDkMcxWXgYguTbVwKuHBrisOtVwE9q1esNrFf/OhXDjSQ==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-is-blank/-/actor-function-factory-term-is-blank-5.2.0.tgz",
+			"integrity": "sha512-33WFKk+f/vNdftMnhaZbb8ClN6y0SoZjIASuM0im34daktI0w/0SnndXA4N2Ahx5xish/ebS9bY9Wi5mIkAZ5A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-function-factory": "^5.1.3",
-				"@comunica/utils-expression-evaluator": "^5.1.3"
+				"@comunica/bus-function-factory": "^5.2.0",
+				"@comunica/utils-expression-evaluator": "^5.2.0"
 			}
 		},
 		"node_modules/@comunica/actor-function-factory-term-is-iri": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-is-iri/-/actor-function-factory-term-is-iri-5.1.3.tgz",
-			"integrity": "sha512-8qlSla8wMvHFwS5hpsnlEdWXl0d+ErsHPqUCPM85T5rofA/SUdGNLnbprnAKngfejDKjkaaXl1NDnHPtsPNCVw==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-is-iri/-/actor-function-factory-term-is-iri-5.2.0.tgz",
+			"integrity": "sha512-AVrQPGR55CtmAXyCAQ6bQ33IW/GL51nwS+LsUicVA9sVpyRg/8go0dkHXFtXDRt19VWSp3Zqmq2xpb9uBJijuA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-function-factory": "^5.1.3",
-				"@comunica/utils-expression-evaluator": "^5.1.3"
+				"@comunica/bus-function-factory": "^5.2.0",
+				"@comunica/utils-expression-evaluator": "^5.2.0"
 			}
 		},
 		"node_modules/@comunica/actor-function-factory-term-is-literal": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-is-literal/-/actor-function-factory-term-is-literal-5.1.3.tgz",
-			"integrity": "sha512-CxGEq0qkVfm3IAg9O+hnglrTLcB/fIGCzWEfQvioTdlZ97cXgEArcPgycECkX58jGStPZlsCR6u7vT0blYjLrA==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-is-literal/-/actor-function-factory-term-is-literal-5.2.0.tgz",
+			"integrity": "sha512-R6li6eymbo5+mGWRCy8DrMRMMJ6AHYHbmJsSOlKeoa10cLoa4QIwfGzAfoK9TN27QAkS/e/0/jom5ea6Yv1DxA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-function-factory": "^5.1.3",
-				"@comunica/utils-expression-evaluator": "^5.1.3"
+				"@comunica/bus-function-factory": "^5.2.0",
+				"@comunica/utils-expression-evaluator": "^5.2.0"
 			}
 		},
 		"node_modules/@comunica/actor-function-factory-term-is-numeric": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-is-numeric/-/actor-function-factory-term-is-numeric-5.1.3.tgz",
-			"integrity": "sha512-yyVISxO6zdBBqm2Y/x5aMJtuCAscfmfG2ZlPa4kjiAWwGyhx791/7SgVATFsERwMugY6exRl0RuRLBb92kUTKA==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-is-numeric/-/actor-function-factory-term-is-numeric-5.2.0.tgz",
+			"integrity": "sha512-teVYmAQUnpGk2zAPe0p7X3rmEVr5hmNPgf8L2nOSOAcIGh4PXQeoZ43no6+mVSX2D2od2oFaI4U+UtMaNZI9nA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-function-factory": "^5.1.3",
-				"@comunica/utils-expression-evaluator": "^5.1.3"
+				"@comunica/bus-function-factory": "^5.2.0",
+				"@comunica/utils-expression-evaluator": "^5.2.0"
 			}
 		},
 		"node_modules/@comunica/actor-function-factory-term-is-triple": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-is-triple/-/actor-function-factory-term-is-triple-5.1.3.tgz",
-			"integrity": "sha512-0T2lKIqowZMToed8SfhXG+k2nhERhrIZdBia6f7oahCdZcoz6IkYufrGwQ3f0JvHXiXChZCI3q/N3RLNK9/33w==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-is-triple/-/actor-function-factory-term-is-triple-5.2.0.tgz",
+			"integrity": "sha512-xaNtvNZwYoPwVZpHJ/n+SEpKrHF4GuXaRZ8Q1aIO4cT3UTj/LscF8C2M3jzPUEXQMa4ORMEmC5+yzWB2nTp4Cw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-function-factory": "^5.1.3",
-				"@comunica/utils-expression-evaluator": "^5.1.3"
+				"@comunica/bus-function-factory": "^5.2.0",
+				"@comunica/utils-expression-evaluator": "^5.2.0"
 			}
 		},
 		"node_modules/@comunica/actor-function-factory-term-lang": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-lang/-/actor-function-factory-term-lang-5.1.3.tgz",
-			"integrity": "sha512-eEEtwaOHWfK/OYyFAKjI8xWg35ZZTrdookV/2aog5PP5+PmRenAC7krIPPInFksbhXLjjguWu6sRhdPohMRGRg==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-lang/-/actor-function-factory-term-lang-5.2.0.tgz",
+			"integrity": "sha512-hEJqMbzu2M5qOJWnrJeoJTVUJ+tVOaWC7/sZerj5vfMLS/9GiBqQH5qqPU+86iPMUF6DudJZ2k5YVR2+f0wA9Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-function-factory": "^5.1.3",
-				"@comunica/utils-expression-evaluator": "^5.1.3"
+				"@comunica/bus-function-factory": "^5.2.0",
+				"@comunica/utils-expression-evaluator": "^5.2.0"
 			}
 		},
 		"node_modules/@comunica/actor-function-factory-term-langdir": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-langdir/-/actor-function-factory-term-langdir-5.1.3.tgz",
-			"integrity": "sha512-I+6GavZW93bPMcNUOCVCc2dqOHKy4Pyq6wSEYDhrkrJ1LsdWsvMKxV84OB+4XXnpUpU7fP1gD5GgQdX/7GICtw==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-langdir/-/actor-function-factory-term-langdir-5.2.0.tgz",
+			"integrity": "sha512-f2h1zdebonUB7lV9cO0UJIQHSyWcGV2pOwjXnuPwcC44GmV4nmhL8J6NShndhRwwfHU1A94qkjhvyUNpfIhThw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-function-factory": "^5.1.3",
-				"@comunica/utils-expression-evaluator": "^5.1.3"
+				"@comunica/bus-function-factory": "^5.2.0",
+				"@comunica/utils-expression-evaluator": "^5.2.0"
 			}
 		},
 		"node_modules/@comunica/actor-function-factory-term-langmatches": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-langmatches/-/actor-function-factory-term-langmatches-5.1.3.tgz",
-			"integrity": "sha512-q57UgmRh3P416jCOVz9x8INRYhtEyDKzYjA40U5aMTeLF6cDYomSEERerQH4hDkgGlLPweNxeHP/+rrLhw5Twg==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-langmatches/-/actor-function-factory-term-langmatches-5.2.0.tgz",
+			"integrity": "sha512-FT7ohPlF7j9cy3Gnsi3ksUoUaaQHZulGf2UcDwBu10LfgDFrk/FdM5ToSEdpyIp0Ew/0FHGWcyNhLm33SFXIMQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-function-factory": "^5.1.3",
-				"@comunica/utils-expression-evaluator": "^5.1.3"
+				"@comunica/bus-function-factory": "^5.2.0",
+				"@comunica/utils-expression-evaluator": "^5.2.0"
 			}
 		},
 		"node_modules/@comunica/actor-function-factory-term-lcase": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-lcase/-/actor-function-factory-term-lcase-5.1.3.tgz",
-			"integrity": "sha512-W5tL/AjcdLmBAhfqgvfVOh7Evx0HcfiHkKWhRQsOF3+juMC1yqL0sLVvXzDErGrJUJOgTvkr1QXP7UgmT+FsAw==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-lcase/-/actor-function-factory-term-lcase-5.2.0.tgz",
+			"integrity": "sha512-otcxFpEIU+TG7gkYm8xL/PHMohc9mBY0u2iWFMTg+t2Hv2i6Uld4xXzyk1YxOA6AQAWz3f/Dw1i4vliJDzVG7Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-function-factory": "^5.1.3",
-				"@comunica/utils-expression-evaluator": "^5.1.3"
+				"@comunica/bus-function-factory": "^5.2.0",
+				"@comunica/utils-expression-evaluator": "^5.2.0"
 			}
 		},
 		"node_modules/@comunica/actor-function-factory-term-lesser-than": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-lesser-than/-/actor-function-factory-term-lesser-than-5.1.3.tgz",
-			"integrity": "sha512-M0CC3CRcw0E/2NuRcHhT4MEOxvp8GQyNtSeqDQPJE4ri75C6bKfmMBFVToX2FVAcfJO6yaXomdE/cRO6Sc4r6Q==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-lesser-than/-/actor-function-factory-term-lesser-than-5.2.0.tgz",
+			"integrity": "sha512-suHiG6JNiP1saSEWDiiHxYnFr+8WpAzYYKOIc6VSKD5J8M8uemR4Bvco/53Dnndk1IV7Bi6uqRC4FDT3IL28Ig==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-function-factory": "^5.1.3",
-				"@comunica/context-entries": "^5.1.3",
-				"@comunica/utils-expression-evaluator": "^5.1.3"
+				"@comunica/bus-function-factory": "^5.2.0",
+				"@comunica/context-entries": "^5.2.0",
+				"@comunica/utils-expression-evaluator": "^5.2.0"
 			}
 		},
 		"node_modules/@comunica/actor-function-factory-term-lesser-than-equal": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-lesser-than-equal/-/actor-function-factory-term-lesser-than-equal-5.1.3.tgz",
-			"integrity": "sha512-iaweBrllVC1YRjoyBeVWr0g1PiIAxUNKX2agP1sFeMmZv8MhW+63I7vflk9I66+t0qMNQpELmAJ7qrpGKrcNfg==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-lesser-than-equal/-/actor-function-factory-term-lesser-than-equal-5.2.0.tgz",
+			"integrity": "sha512-ANYEZI8Oz9rpBhoUSKgRSJY9PaH+WUBmylvfg7Djb5D+xtISWATpCzh7lWm7rI8mGGOUjSiPqmPuoGP+jrKdJA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-function-factory": "^5.1.3",
-				"@comunica/utils-expression-evaluator": "^5.1.3"
+				"@comunica/bus-function-factory": "^5.2.0",
+				"@comunica/utils-expression-evaluator": "^5.2.0"
 			}
 		},
 		"node_modules/@comunica/actor-function-factory-term-md5": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-md5/-/actor-function-factory-term-md5-5.1.3.tgz",
-			"integrity": "sha512-xvdPLK1rWQQvjujsicV69nn11HwCepzLTQnMuhsL0KXQ6lexcDhORSjTtufuOoMQ8+AARb03S972bGEbXN9m1Q==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-md5/-/actor-function-factory-term-md5-5.2.0.tgz",
+			"integrity": "sha512-Ic7+Y0TM8il9KV7OijuWbKwdZ0BR0P57ySU3j10dV/Dl3vkd0NDWQNjp9tx8m41PCwIyMzoIDZGZdlp5+DeTZg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-function-factory": "^5.1.3",
-				"@comunica/utils-expression-evaluator": "^5.1.3",
+				"@comunica/bus-function-factory": "^5.2.0",
+				"@comunica/utils-expression-evaluator": "^5.2.0",
 				"@types/spark-md5": "^3.0.1",
 				"spark-md5": "^3.0.1"
 			}
 		},
 		"node_modules/@comunica/actor-function-factory-term-minutes": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-minutes/-/actor-function-factory-term-minutes-5.1.3.tgz",
-			"integrity": "sha512-ZE79NTZ3TvbG9XD58JuItrX+XbvtAO89Sqpgboju9fPxiruF7x5pqyx/gLvpazOauZ6NOwWNOeVa5zGSdY3SHQ==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-minutes/-/actor-function-factory-term-minutes-5.2.0.tgz",
+			"integrity": "sha512-t6kX5++OoiUifQzkg/CT6+u143+6bJ9lhpSqcOvbuooKOTn6Lvfz0B5OcKSC7HRqtDp9GUlFjDXxpNNFYRsKpQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-function-factory": "^5.1.3",
-				"@comunica/utils-expression-evaluator": "^5.1.3"
+				"@comunica/bus-function-factory": "^5.2.0",
+				"@comunica/utils-expression-evaluator": "^5.2.0"
 			}
 		},
 		"node_modules/@comunica/actor-function-factory-term-month": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-month/-/actor-function-factory-term-month-5.1.3.tgz",
-			"integrity": "sha512-cRS9zhzpfBqPo2zP58/X1idHNWacFMQRHdIO45Gp05O4cak4nxDT2ckvVctoN0O+2Cd56zyySLNRtSvShBaipg==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-month/-/actor-function-factory-term-month-5.2.0.tgz",
+			"integrity": "sha512-DjlbW6VZlQ1nwhwYKSyQ25Ogm05rKCtRJUanYWnweOuXgrhmgWSDqCbVTl4GEcpK2hkiCYuHSy5vaKzDq+/5MA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-function-factory": "^5.1.3",
-				"@comunica/utils-expression-evaluator": "^5.1.3"
+				"@comunica/bus-function-factory": "^5.2.0",
+				"@comunica/utils-expression-evaluator": "^5.2.0"
 			}
 		},
 		"node_modules/@comunica/actor-function-factory-term-multiplication": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-multiplication/-/actor-function-factory-term-multiplication-5.1.3.tgz",
-			"integrity": "sha512-57gI8xdXXdZwJq1b2ZUJrawjiD8fmXLLz+O2mSaMuEtt/YbOaUi1J7P3SAuNiUczZDB1/f4DK/0I0Z7kwZmhcQ==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-multiplication/-/actor-function-factory-term-multiplication-5.2.0.tgz",
+			"integrity": "sha512-++C1X56/zQ/RUXU8XMkf7lo5gc6EmFBJyH2Ceb4TN9qeUIxQJfRS2YyGeZuHJ6W5+S9kvPW/JAc+Gb8iWisX9w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-function-factory": "^5.1.3",
-				"@comunica/utils-expression-evaluator": "^5.1.3",
-				"bignumber.js": "^9.1.2"
+				"@comunica/bus-function-factory": "^5.2.0",
+				"@comunica/utils-expression-evaluator": "^5.2.0",
+				"bignumber.js": "^10.0.0"
 			}
 		},
 		"node_modules/@comunica/actor-function-factory-term-not": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-not/-/actor-function-factory-term-not-5.1.3.tgz",
-			"integrity": "sha512-dloJ0O6YsCMUlt7OIm29258yTHvdmjW+JEnnK9OFn4FXcb9oEQjSotVz1wkfptyhKtSG1TKYFWWxy5nmN4qy6w==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-not/-/actor-function-factory-term-not-5.2.0.tgz",
+			"integrity": "sha512-sT/xAeqe/tKSrq68+FSuz1JA+SFbnhdh4ZY1mhre1lyuvGFEIltYZzVbidYH7RYiUdef/Xbg1N6RBDFfuN+32g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-function-factory": "^5.1.3",
-				"@comunica/utils-expression-evaluator": "^5.1.3"
+				"@comunica/bus-function-factory": "^5.2.0",
+				"@comunica/utils-expression-evaluator": "^5.2.0"
 			}
 		},
 		"node_modules/@comunica/actor-function-factory-term-now": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-now/-/actor-function-factory-term-now-5.1.3.tgz",
-			"integrity": "sha512-s7OchjNQc94Qyw8eCj2CFRx0hQtcuH2catFg0nx2hva3cn//mrLXuEeSqZS3E7ilMlOHvqmcjXhEINl6kihHOQ==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-now/-/actor-function-factory-term-now-5.2.0.tgz",
+			"integrity": "sha512-HD1tM1PYC0PIip+PlpottBph+OKaUgh7IsZg0kyQcfgl0dFbJvLVt1+mdltqXrIOMV+Te62EclT6bM/dyM+ZXQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-function-factory": "^5.1.3",
-				"@comunica/context-entries": "^5.1.3",
-				"@comunica/utils-expression-evaluator": "^5.1.3"
+				"@comunica/bus-function-factory": "^5.2.0",
+				"@comunica/context-entries": "^5.2.0",
+				"@comunica/utils-expression-evaluator": "^5.2.0"
 			}
 		},
 		"node_modules/@comunica/actor-function-factory-term-object": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-object/-/actor-function-factory-term-object-5.1.3.tgz",
-			"integrity": "sha512-L7QNIja8tzpLt/MaNk7yysyCc4oDWyWzMVVwIawGAh95ceFcfjaYgk4mvm5dqH16kB0vBVZWlkdJ2UbXNJZhXw==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-object/-/actor-function-factory-term-object-5.2.0.tgz",
+			"integrity": "sha512-gy+IOOwb/3EJprsSrk4gPjjC0EDF3i/NcMWnAnjZ1vqw1CoswbTQc28tg3plzc4OC4vra06UsG/3PtQ+u+Rtbg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-function-factory": "^5.1.3",
-				"@comunica/utils-expression-evaluator": "^5.1.3"
+				"@comunica/bus-function-factory": "^5.2.0",
+				"@comunica/utils-expression-evaluator": "^5.2.0"
 			}
 		},
 		"node_modules/@comunica/actor-function-factory-term-predicate": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-predicate/-/actor-function-factory-term-predicate-5.1.3.tgz",
-			"integrity": "sha512-zId2EMoGVDfV6b4/6s9pj2qYxv5Sg2vQRcBxPcCRmNb6jENmjgcMxot67B6Qo+0gIj5Kn5Y7mF2PCvhIdrpaFg==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-predicate/-/actor-function-factory-term-predicate-5.2.0.tgz",
+			"integrity": "sha512-DqN/1Z2nSWHQoPgiZgkTohE/3i7qSDWibxm8SNHzvK62ZXi5Ja5XHfDNqHeZFZ0mIwM4I+qXODOYfJMWIxAAsw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-function-factory": "^5.1.3",
-				"@comunica/utils-expression-evaluator": "^5.1.3"
+				"@comunica/bus-function-factory": "^5.2.0",
+				"@comunica/utils-expression-evaluator": "^5.2.0"
 			}
 		},
 		"node_modules/@comunica/actor-function-factory-term-rand": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-rand/-/actor-function-factory-term-rand-5.1.3.tgz",
-			"integrity": "sha512-QDdxcxJZ7ru/ScETVbKwqQUa+pT/JczyegTUbe5/+EGDwgp+IfH6tR7kmjzTvNZNZVtEX/M6ZM4ufjjrVXpBNg==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-rand/-/actor-function-factory-term-rand-5.2.0.tgz",
+			"integrity": "sha512-7O0Qs0Ir2VXkb/N2SHa8HgPjHPPACBm7KR+wtU8WTuKF7PYErrESFJ+goIXdcZy/HleTyg3LG70PSlpuv+v7Xw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-function-factory": "^5.1.3",
-				"@comunica/utils-expression-evaluator": "^5.1.3"
+				"@comunica/bus-function-factory": "^5.2.0",
+				"@comunica/utils-expression-evaluator": "^5.2.0"
 			}
 		},
 		"node_modules/@comunica/actor-function-factory-term-regex": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-regex/-/actor-function-factory-term-regex-5.1.3.tgz",
-			"integrity": "sha512-7PFv5vgggOV4vtGy9pUqcOpigGuPJDZAjoTMplsV8Fb59XyMB5M86y0/zIqK9pP7fpgI3qJ/k2Vv+JqTQt5IqQ==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-regex/-/actor-function-factory-term-regex-5.2.0.tgz",
+			"integrity": "sha512-r0Z9K5yRaXXrg6IOGpyqfDj7lpNyXIOtkYcOh8zdtHbvWCt1WACThfFdLqAz+4Oo0gaEzw9aYCgEpG5Os7ciVg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-function-factory": "^5.1.3",
-				"@comunica/utils-expression-evaluator": "^5.1.3"
+				"@comunica/bus-function-factory": "^5.2.0",
+				"@comunica/utils-expression-evaluator": "^5.2.0"
 			}
 		},
 		"node_modules/@comunica/actor-function-factory-term-replace": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-replace/-/actor-function-factory-term-replace-5.1.3.tgz",
-			"integrity": "sha512-sXzHcXfofeKJ9tJJ/0JT4i97McwdBbFXcCR//u7EU+ZXam5DTCHG8r0jetcD652fCh8RGIL0OUHKpk4pWZYeNg==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-replace/-/actor-function-factory-term-replace-5.2.0.tgz",
+			"integrity": "sha512-/eqFH9gz5txAJehlUMqr6ePu9l7IQe9KPDm9L9Y0p4xd+aObohEXOGFAXk1ysbtrDfC1qZ65CTZveWSrzYm5bw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/actor-function-factory-term-regex": "^5.1.3",
-				"@comunica/bus-function-factory": "^5.1.3",
-				"@comunica/utils-expression-evaluator": "^5.1.3"
+				"@comunica/actor-function-factory-term-regex": "^5.2.0",
+				"@comunica/bus-function-factory": "^5.2.0",
+				"@comunica/utils-expression-evaluator": "^5.2.0"
 			}
 		},
 		"node_modules/@comunica/actor-function-factory-term-round": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-round/-/actor-function-factory-term-round-5.1.3.tgz",
-			"integrity": "sha512-A90Izh7YLpaTCvS55R76LU/B5k+jISAAFjtiGM1RoNJ5gtk/hbJ+vZIfky8LxGhm7p6m9FvO2qB19KD3Mz6oKg==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-round/-/actor-function-factory-term-round-5.2.0.tgz",
+			"integrity": "sha512-k/QsW6NY59nMbAWJen/i953fY0mUvjh2IGU2GbQOmvzY/1HrQZ9K06C2dsb/8vDCjqfW9qL3rc9W2BtUuGaSeg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-function-factory": "^5.1.3",
-				"@comunica/utils-expression-evaluator": "^5.1.3"
+				"@comunica/bus-function-factory": "^5.2.0",
+				"@comunica/utils-expression-evaluator": "^5.2.0"
 			}
 		},
 		"node_modules/@comunica/actor-function-factory-term-seconds": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-seconds/-/actor-function-factory-term-seconds-5.1.3.tgz",
-			"integrity": "sha512-D6QbT7oDzQL3hXD/N26o4r0XjX3ncoWa08mhvFOD9GVyLoKypGfMSS8lwFxr+i4DLtyisPXxNCGKgVvZigD22g==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-seconds/-/actor-function-factory-term-seconds-5.2.0.tgz",
+			"integrity": "sha512-h6klbjJXEbeRMt8K9Tof4o3SyAruqQuimAfurKWBdeitWIUxchHqhTATVLsQ8gaQFDxEcIbUm2N5xBA0q1NQbQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-function-factory": "^5.1.3",
-				"@comunica/utils-expression-evaluator": "^5.1.3"
+				"@comunica/bus-function-factory": "^5.2.0",
+				"@comunica/utils-expression-evaluator": "^5.2.0"
 			}
 		},
 		"node_modules/@comunica/actor-function-factory-term-sha1": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-sha1/-/actor-function-factory-term-sha1-5.1.3.tgz",
-			"integrity": "sha512-InguNZZb/nf5wyb1YuwS7HV3BhWNSlL+7BqUtnjDVihSA2F0HDj2dyqfYyBPw82JEO8M0GJeZIB5KcQbuZGgnw==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-sha1/-/actor-function-factory-term-sha1-5.2.0.tgz",
+			"integrity": "sha512-nqXx/GHQOGUVswEtD1jyWd5SfvBj3oqR/2UTE/AxkUKvgGx2DQMhvu1slXAMpC769gIs9Ljo7e9Qz4zEHPsS6Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-function-factory": "^5.1.3",
-				"@comunica/utils-expression-evaluator": "^5.1.3",
+				"@comunica/bus-function-factory": "^5.2.0",
+				"@comunica/utils-expression-evaluator": "^5.2.0",
 				"hash.js": "^1.1.7"
 			}
 		},
 		"node_modules/@comunica/actor-function-factory-term-sha256": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-sha256/-/actor-function-factory-term-sha256-5.1.3.tgz",
-			"integrity": "sha512-5AbrMYi3+JLaniH2y8lIo7uZHaQ6chMOPbvelUh0Ww60TorP8u52O3ySAYDWaJAq3WkRBoPYL9RacfOnu2Kqmw==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-sha256/-/actor-function-factory-term-sha256-5.2.0.tgz",
+			"integrity": "sha512-xtDWbdSD3M/C45jEzzCq85zDlAFMLG700a4jpEN/T5KK/aU5Xd49CHJpdLFwfozJ9xkOvx4XzfZz6/zquvV+Tg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-function-factory": "^5.1.3",
-				"@comunica/utils-expression-evaluator": "^5.1.3",
+				"@comunica/bus-function-factory": "^5.2.0",
+				"@comunica/utils-expression-evaluator": "^5.2.0",
 				"hash.js": "^1.1.7"
 			}
 		},
 		"node_modules/@comunica/actor-function-factory-term-sha384": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-sha384/-/actor-function-factory-term-sha384-5.1.3.tgz",
-			"integrity": "sha512-uUL0GJ29SMqH4QQrq8W0xg2gTl2YAzyYMy+Jw1Y+VFW7tfTeuMRglDur+St3SLzkmFFarMZOFjPXnCd6bhPi3A==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-sha384/-/actor-function-factory-term-sha384-5.2.0.tgz",
+			"integrity": "sha512-4biwic/jTrHyVKKRUlJIzN8qeI4hQeJyjDTdu2hP7LfyKtmKlkD46nE2FpcPSpxaPH/eqCIecqpaw0fPUysAoQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-function-factory": "^5.1.3",
-				"@comunica/utils-expression-evaluator": "^5.1.3",
+				"@comunica/bus-function-factory": "^5.2.0",
+				"@comunica/utils-expression-evaluator": "^5.2.0",
 				"hash.js": "^1.1.7"
 			}
 		},
 		"node_modules/@comunica/actor-function-factory-term-sha512": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-sha512/-/actor-function-factory-term-sha512-5.1.3.tgz",
-			"integrity": "sha512-S1nU5THkNTZXyha2R6Kw4vf8ov3kV3Y77O76i7d5u754eJdQTH7Zjr4js+BrBjbTOS5Lsim9VPYyTjc7PKBhbQ==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-sha512/-/actor-function-factory-term-sha512-5.2.0.tgz",
+			"integrity": "sha512-pbbzFSg8IcRGJ8E08HrtelyCJxXnRbUZgDJKBc2jG60WphQ7gM8Hb1uZSXTwyaRKVPIVqPGPETlmefAsU+5Zqg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-function-factory": "^5.1.3",
-				"@comunica/utils-expression-evaluator": "^5.1.3",
+				"@comunica/bus-function-factory": "^5.2.0",
+				"@comunica/utils-expression-evaluator": "^5.2.0",
 				"hash.js": "^1.1.7"
 			}
 		},
 		"node_modules/@comunica/actor-function-factory-term-str": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-str/-/actor-function-factory-term-str-5.1.3.tgz",
-			"integrity": "sha512-ufP5prAmmp0J8rijADqsMjh5IG5j/K04KYODkFEMFJAsYBMjv5AecANRG4nlGkvP7lIpVpxVZ8EVE4xSDLacsA==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-str/-/actor-function-factory-term-str-5.2.0.tgz",
+			"integrity": "sha512-uAt7uTdLqA3eQsCUvxr59NIT34EDLaaJuvZ42ag6HTz6zZe8ghA+X2RWNBj1BB+r1LKOxjotHvTBt/9b6Rq9nw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-function-factory": "^5.1.3",
-				"@comunica/utils-expression-evaluator": "^5.1.3"
+				"@comunica/bus-function-factory": "^5.2.0",
+				"@comunica/utils-expression-evaluator": "^5.2.0"
 			}
 		},
 		"node_modules/@comunica/actor-function-factory-term-str-after": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-str-after/-/actor-function-factory-term-str-after-5.1.3.tgz",
-			"integrity": "sha512-z5yXU4kaK7MmkRxPYl6SqipT2Ho8nIgUTqieIdG9L4XcSaeFLqiMyogFDlZd4fXc5Dla/4zu5b6MFGqvzd85mw==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-str-after/-/actor-function-factory-term-str-after-5.2.0.tgz",
+			"integrity": "sha512-dJ4GuessOYl8sO+4Pc9gqjji4s4SBo6IAa57E+pFMsOQPfbn1Mw/ZFLQvNd4kRa8HnXoqRxBH7wsHEKHDPlnIw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-function-factory": "^5.1.3",
-				"@comunica/utils-expression-evaluator": "^5.1.3"
+				"@comunica/bus-function-factory": "^5.2.0",
+				"@comunica/utils-expression-evaluator": "^5.2.0"
 			}
 		},
 		"node_modules/@comunica/actor-function-factory-term-str-before": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-str-before/-/actor-function-factory-term-str-before-5.1.3.tgz",
-			"integrity": "sha512-Gklto9pH8JcYYNpbMk5R47mdYppG2AP7/ZZRvjY47rsK1OoxSm5IdvtkB5MfzmGF3AXNRtCfPAtoxGjRKYpfIQ==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-str-before/-/actor-function-factory-term-str-before-5.2.0.tgz",
+			"integrity": "sha512-rPI8M/M4XaG+HOD2IuhMy8QcEzylwyq7+PGooRkud1tJSMJD8xr0vd52t1JCLtQ6eCgHWYEqKVz8Z2Y2YEB52Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-function-factory": "^5.1.3",
-				"@comunica/utils-expression-evaluator": "^5.1.3"
+				"@comunica/bus-function-factory": "^5.2.0",
+				"@comunica/utils-expression-evaluator": "^5.2.0"
 			}
 		},
 		"node_modules/@comunica/actor-function-factory-term-str-dt": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-str-dt/-/actor-function-factory-term-str-dt-5.1.3.tgz",
-			"integrity": "sha512-EnWblVppmznNUjm/nuSKDoehL3HzEOY+xFY6BAj02TrUH6BUS/S6NwXIx+nxJTPUBlsLg4QHFZ6VsriwXvI4Wg==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-str-dt/-/actor-function-factory-term-str-dt-5.2.0.tgz",
+			"integrity": "sha512-YQLs78oZjkkChncH4JwgiShlUhRIV+XU/zyVlzPzyzuCk9k+90ZXVNGoQHMDk7Uxs4avnrmNffAIWuFiiiIAyA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-function-factory": "^5.1.3",
-				"@comunica/context-entries": "^5.1.3",
-				"@comunica/types": "^5.1.3",
-				"@comunica/utils-expression-evaluator": "^5.1.3"
+				"@comunica/bus-function-factory": "^5.2.0",
+				"@comunica/context-entries": "^5.2.0",
+				"@comunica/types": "^5.2.0",
+				"@comunica/utils-expression-evaluator": "^5.2.0"
 			}
 		},
 		"node_modules/@comunica/actor-function-factory-term-str-ends": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-str-ends/-/actor-function-factory-term-str-ends-5.1.3.tgz",
-			"integrity": "sha512-X/EUa+AjEWEcS6JpDd7b3sY/Pbdwa9fjc5XEqUY48dGIa8zPJa8mLrhE+4MM1MxMJ6QoI0/9J2jjN1Sc6OSQUA==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-str-ends/-/actor-function-factory-term-str-ends-5.2.0.tgz",
+			"integrity": "sha512-++C2JrN+gernsqwWWVyQwHCcFcU60L08h0BhdY0xbNnRezbPYE6HcUd8ZuSoT8jZlc1/m/M2kz/Jt4MS7wZnCw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-function-factory": "^5.1.3",
-				"@comunica/utils-expression-evaluator": "^5.1.3"
+				"@comunica/bus-function-factory": "^5.2.0",
+				"@comunica/utils-expression-evaluator": "^5.2.0"
 			}
 		},
 		"node_modules/@comunica/actor-function-factory-term-str-lang": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-str-lang/-/actor-function-factory-term-str-lang-5.1.3.tgz",
-			"integrity": "sha512-S7AREjtcZebq7Hco09DMWbp5AnlrGKekDoqs8bQJHzpDc4a9aLYX1/3AboyoFP7GQWw6dJLfyszQ6I2NV/fdXw==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-str-lang/-/actor-function-factory-term-str-lang-5.2.0.tgz",
+			"integrity": "sha512-jAJD0GLTityrIFjCBv/RXVozoZwZgLfwolIUpRDQLzWWOlrQgLXDLlXYmxE6Swh7LEuqvk+HYQ9xDd0dEjbPiQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-function-factory": "^5.1.3",
-				"@comunica/utils-expression-evaluator": "^5.1.3"
+				"@comunica/bus-function-factory": "^5.2.0",
+				"@comunica/utils-expression-evaluator": "^5.2.0"
 			}
 		},
 		"node_modules/@comunica/actor-function-factory-term-str-langdir": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-str-langdir/-/actor-function-factory-term-str-langdir-5.1.3.tgz",
-			"integrity": "sha512-HHLwkxBARSRsVtyP6JzkwhcddbUW7/Ce5E5o041ZGbl3DLmQTMR+x/+6fB3Ao6HDaNHGhSvaT+lrFyK/zo5rKQ==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-str-langdir/-/actor-function-factory-term-str-langdir-5.2.0.tgz",
+			"integrity": "sha512-91XudRHzq0lwiFfMq1cvZYLcIy54otr/FdHvgiLqj2om3XM+/kzL3HEEF0QXJGRbDrGgehJPyfG/wo4jg1DOMg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-function-factory": "^5.1.3",
-				"@comunica/utils-expression-evaluator": "^5.1.3"
+				"@comunica/bus-function-factory": "^5.2.0",
+				"@comunica/utils-expression-evaluator": "^5.2.0"
 			}
 		},
 		"node_modules/@comunica/actor-function-factory-term-str-len": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-str-len/-/actor-function-factory-term-str-len-5.1.3.tgz",
-			"integrity": "sha512-pAF1MiemoGiJIXiOc72fx7BiBgqVxxjZORxlmaTnvlz/GgzH3B+VGGzHLuWhY8lQ79aW42oOc2PXTLYWHrGuOA==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-str-len/-/actor-function-factory-term-str-len-5.2.0.tgz",
+			"integrity": "sha512-v1IvEfsCDp16WWLRGAiCG5lpdXdp2kk5TLD1hFiAInmruVjIZSbSYppcHsuGYz15g77KdS2XQTYqH2hnvXMLeg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-function-factory": "^5.1.3",
-				"@comunica/utils-expression-evaluator": "^5.1.3"
+				"@comunica/bus-function-factory": "^5.2.0",
+				"@comunica/utils-expression-evaluator": "^5.2.0"
 			}
 		},
 		"node_modules/@comunica/actor-function-factory-term-str-starts": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-str-starts/-/actor-function-factory-term-str-starts-5.1.3.tgz",
-			"integrity": "sha512-6LdV8WlMLc4hi4BZCq6a4gOB193v8AwYkj3Vc62Ba1+3pRd31XmWbHg5RsDKTXlbB+DYQpNz7DoW9wYiw3NdYg==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-str-starts/-/actor-function-factory-term-str-starts-5.2.0.tgz",
+			"integrity": "sha512-KyoCg6+Y2dSbS+W8oSAg1wA+UGQBb6vOQxR+KKJOJ4O57nkJqtxbNwaJSss4voQVjECbIc1hSCm9idHj0JjvfA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-function-factory": "^5.1.3",
-				"@comunica/utils-expression-evaluator": "^5.1.3"
+				"@comunica/bus-function-factory": "^5.2.0",
+				"@comunica/utils-expression-evaluator": "^5.2.0"
 			}
 		},
 		"node_modules/@comunica/actor-function-factory-term-str-uuid": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-str-uuid/-/actor-function-factory-term-str-uuid-5.1.3.tgz",
-			"integrity": "sha512-O/+9IuFRkmOrcIZmfNGp+XCT/17UvXnwGPWW/1lUVzZm60Jcf4wjQnI1aUmoLy9DCP6G3gE9/8gvSyP+gYrYoQ==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-str-uuid/-/actor-function-factory-term-str-uuid-5.2.0.tgz",
+			"integrity": "sha512-jl1we2m1EV5LRkkTksvC+XL+bOz2ljFXXvURsxrnV0AnjNgDxZvVnko5naBQL/zDs/hSLFeEhs0NjDZJK1iFfg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-function-factory": "^5.1.3",
-				"@comunica/utils-expression-evaluator": "^5.1.3",
+				"@comunica/bus-function-factory": "^5.2.0",
+				"@comunica/utils-expression-evaluator": "^5.2.0",
 				"@types/uuid": "^10.0.0",
 				"uuid": "^11.0.0"
 			}
 		},
 		"node_modules/@comunica/actor-function-factory-term-str-uuid/node_modules/uuid": {
-			"version": "11.1.0",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
-			"integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+			"version": "11.1.1",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+			"integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
 			"dev": true,
 			"funding": [
 				"https://github.com/sponsors/broofa",
@@ -1298,124 +1254,124 @@
 			}
 		},
 		"node_modules/@comunica/actor-function-factory-term-sub-str": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-sub-str/-/actor-function-factory-term-sub-str-5.1.3.tgz",
-			"integrity": "sha512-jKzv1LmqD9+2HE3v3FA+3txuAP1ACgxVwHsDXN/9JwMZXpFyhfqhulz7hDlmYwm3TEPY7g5IqsQv9sAMc4dAQw==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-sub-str/-/actor-function-factory-term-sub-str-5.2.0.tgz",
+			"integrity": "sha512-MJRmeA8ev9XlSvqdE/4hxAjHEInPreJxM7mJsRi6M5TXIvoclKYrKrpxzyJzW7dsMISDLZFP0dgxEJPH/OGwPQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-function-factory": "^5.1.3",
-				"@comunica/utils-expression-evaluator": "^5.1.3"
+				"@comunica/bus-function-factory": "^5.2.0",
+				"@comunica/utils-expression-evaluator": "^5.2.0"
 			}
 		},
 		"node_modules/@comunica/actor-function-factory-term-subject": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-subject/-/actor-function-factory-term-subject-5.1.3.tgz",
-			"integrity": "sha512-DpGtUVGA9ewjssR7YNFDjbwjN2vMoG0Cmcsmg6traxpu9l3QK2M6y/s7hviHYN1NYghf0lUoDRNlG1f5CwdnPg==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-subject/-/actor-function-factory-term-subject-5.2.0.tgz",
+			"integrity": "sha512-2rhQzCpZ5pJm1+UBMJ13tn8OGIxjcCGuybte1r6+5rJw5XVlsVIEc8DzeUNkbpZ5MpRxO63fCEBHqxsKCI9jZg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-function-factory": "^5.1.3",
-				"@comunica/utils-expression-evaluator": "^5.1.3"
+				"@comunica/bus-function-factory": "^5.2.0",
+				"@comunica/utils-expression-evaluator": "^5.2.0"
 			}
 		},
 		"node_modules/@comunica/actor-function-factory-term-subtraction": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-subtraction/-/actor-function-factory-term-subtraction-5.1.3.tgz",
-			"integrity": "sha512-krUL2hGggN2bTyoUyTgyo+JqvsDmID9nJtEQoGPRlH0iDS+EyWVW7AbFKCfuveqZKRLRLqLeZgNLWZLzA6krQQ==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-subtraction/-/actor-function-factory-term-subtraction-5.2.0.tgz",
+			"integrity": "sha512-NQ52WL+9KOBRJ89X+HMvNKnFEUzqApVbxjWqfT7GUl+rLFPbqGHD+PAZdoK2/YlHQuN4T6dcrF9sOEGrI1g4HA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-function-factory": "^5.1.3",
-				"@comunica/context-entries": "^5.1.3",
-				"@comunica/utils-expression-evaluator": "^5.1.3",
-				"bignumber.js": "^9.1.2"
+				"@comunica/bus-function-factory": "^5.2.0",
+				"@comunica/context-entries": "^5.2.0",
+				"@comunica/utils-expression-evaluator": "^5.2.0",
+				"bignumber.js": "^10.0.0"
 			}
 		},
 		"node_modules/@comunica/actor-function-factory-term-timezone": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-timezone/-/actor-function-factory-term-timezone-5.1.3.tgz",
-			"integrity": "sha512-3UZQp+XaKX95wGDa6/Xh7FyaHIHEQyFbwGFNTR0XGyHAu2OLCzJZ2XL5nd+nb4q+anP+Vc5UrhGpexm/yONlyA==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-timezone/-/actor-function-factory-term-timezone-5.2.0.tgz",
+			"integrity": "sha512-CacmCoRkQKvRzZ+Hb727asOjCftsZqkUXxMN6YqbQUU4pz6R7S5pauz3HoLFD5sKHOXLDXPqsADKO/do+ukuaQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-function-factory": "^5.1.3",
-				"@comunica/types": "^5.1.3",
-				"@comunica/utils-expression-evaluator": "^5.1.3"
+				"@comunica/bus-function-factory": "^5.2.0",
+				"@comunica/types": "^5.2.0",
+				"@comunica/utils-expression-evaluator": "^5.2.0"
 			}
 		},
 		"node_modules/@comunica/actor-function-factory-term-triple": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-triple/-/actor-function-factory-term-triple-5.1.3.tgz",
-			"integrity": "sha512-Zov320A/dBAoavJ+Zu3VTuIu7DW0zTM6r1GiqffvKYguPjNAm0bsXQOXSEOMkliEFrUUp3d0vqGmRZaiWtwf0Q==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-triple/-/actor-function-factory-term-triple-5.2.0.tgz",
+			"integrity": "sha512-oqhOb/Sd1j8EGGy9lhQ1U/6MIGi3EEN+42n1/9qJFF83lNoHw5vI5P6W4w7LeHtu4Qvv1TbqXX+fMiDSIv/Bag==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-function-factory": "^5.1.3",
-				"@comunica/utils-expression-evaluator": "^5.1.3"
+				"@comunica/bus-function-factory": "^5.2.0",
+				"@comunica/utils-expression-evaluator": "^5.2.0"
 			}
 		},
 		"node_modules/@comunica/actor-function-factory-term-tz": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-tz/-/actor-function-factory-term-tz-5.1.3.tgz",
-			"integrity": "sha512-vmLB0AIx6KUVhzLj0xXyKs2UqmosRyLZvcgP6uA7CAhjxshoEtQ7JX3bmWbeM3Fx8W/Wb3eb1XopyUE39cHKOA==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-tz/-/actor-function-factory-term-tz-5.2.0.tgz",
+			"integrity": "sha512-WZU+qJwx/iq/+KCZ6Z49ehw2+BeLxzNjAnL1hzyCQjaGhaWRys11VkEUstplE1/lDXoyEVUyDfdQEvfyia8eVQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-function-factory": "^5.1.3",
-				"@comunica/utils-expression-evaluator": "^5.1.3"
+				"@comunica/bus-function-factory": "^5.2.0",
+				"@comunica/utils-expression-evaluator": "^5.2.0"
 			}
 		},
 		"node_modules/@comunica/actor-function-factory-term-ucase": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-ucase/-/actor-function-factory-term-ucase-5.1.3.tgz",
-			"integrity": "sha512-3tXlj/IzwY5y4j4XGzXbn3p+OszccVEl1ijh+tjHfHrlTU/yJnPy0mIQQZrhTJzg6sizKRMYE0WYEHSabCQUCA==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-ucase/-/actor-function-factory-term-ucase-5.2.0.tgz",
+			"integrity": "sha512-PaIY25ZPwcYTCfpvCjBXIXe5TptXglLoO5d9MFMh8sT9y4cADX8BvhLcZ+nsKTi8t6/038YmkIMCPMg0VwXzBA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-function-factory": "^5.1.3",
-				"@comunica/utils-expression-evaluator": "^5.1.3"
+				"@comunica/bus-function-factory": "^5.2.0",
+				"@comunica/utils-expression-evaluator": "^5.2.0"
 			}
 		},
 		"node_modules/@comunica/actor-function-factory-term-unary-minus": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-unary-minus/-/actor-function-factory-term-unary-minus-5.1.3.tgz",
-			"integrity": "sha512-PVhRKzvQf9Oxu698bmVTWvbNc3/2mZLD7IQ420ZKVIzZmPOR9d5Pd7FCapXS7I6ogoQ7Mc/63oeJhcHvSFuCTw==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-unary-minus/-/actor-function-factory-term-unary-minus-5.2.0.tgz",
+			"integrity": "sha512-wrYT8xML3GaXxwKDwH2/dBDlx6fDiLNjxpzOPGwAtA4OUQD9efSXdk3lX/lWSq9++TNHRjJxohIY9IF0u+P8Vw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-function-factory": "^5.1.3",
-				"@comunica/utils-expression-evaluator": "^5.1.3"
+				"@comunica/bus-function-factory": "^5.2.0",
+				"@comunica/utils-expression-evaluator": "^5.2.0"
 			}
 		},
 		"node_modules/@comunica/actor-function-factory-term-unary-plus": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-unary-plus/-/actor-function-factory-term-unary-plus-5.1.3.tgz",
-			"integrity": "sha512-8r4mOJhqc2Zrq5qfOmiK6ZAyzP0Fo8XH/icCDRagGkRCVb8bnI3dmC7HSFu7wnLwgSyKgd4NuLUfWTMF7zw7qw==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-unary-plus/-/actor-function-factory-term-unary-plus-5.2.0.tgz",
+			"integrity": "sha512-UtQDzXJlSd9pXtTEvOvPqd7adPJsMAdzJ+sirLy3P6MdSlBhlUt1FydsE7lFz78voHQ/vYem3+OYiASz0vhgZg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-function-factory": "^5.1.3",
-				"@comunica/utils-expression-evaluator": "^5.1.3"
+				"@comunica/bus-function-factory": "^5.2.0",
+				"@comunica/utils-expression-evaluator": "^5.2.0"
 			}
 		},
 		"node_modules/@comunica/actor-function-factory-term-uuid": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-uuid/-/actor-function-factory-term-uuid-5.1.3.tgz",
-			"integrity": "sha512-Mp76K770ZTvWaUoqOELdTX3tZZuFtHyFnGHy/aKw3DOOHDwvHAR6rssqdYV2VmVwZMDF6Rnzr0oZamGJ/RTsjQ==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-uuid/-/actor-function-factory-term-uuid-5.2.0.tgz",
+			"integrity": "sha512-6Fd6S5em8UnteUSFWyXqZ94N31t23hbF26LFg7nd1P4o6otiNo/pOzwBNZ5M9z2BSSxapubR7YFHJ1x2OYvL9g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-function-factory": "^5.1.3",
-				"@comunica/utils-expression-evaluator": "^5.1.3",
+				"@comunica/bus-function-factory": "^5.2.0",
+				"@comunica/utils-expression-evaluator": "^5.2.0",
 				"@types/uuid": "^10.0.0",
 				"uuid": "^11.0.0"
 			}
 		},
 		"node_modules/@comunica/actor-function-factory-term-uuid/node_modules/uuid": {
-			"version": "11.1.0",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
-			"integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+			"version": "11.1.1",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+			"integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
 			"dev": true,
 			"funding": [
 				"https://github.com/sponsors/broofa",
@@ -1427,163 +1383,163 @@
 			}
 		},
 		"node_modules/@comunica/actor-function-factory-term-xsd-to-boolean": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-xsd-to-boolean/-/actor-function-factory-term-xsd-to-boolean-5.1.3.tgz",
-			"integrity": "sha512-k+BwCv+KqosWOZ2dSNU3aXb8XQb0A0i/HsvQ0C/PGRmq280QScpAh7SDiXwjE9hSZnffFjjWxugcoD2TLpdr0Q==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-xsd-to-boolean/-/actor-function-factory-term-xsd-to-boolean-5.2.0.tgz",
+			"integrity": "sha512-DoqPAlsifmuw7BOzBagdjAip/So5jGzh9QK/hP6fUVKVT1a4LiTxa4j9pmAL+Rp+goWHPl2gsEvK02ZJTTg51Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-function-factory": "^5.1.3",
-				"@comunica/types": "^5.1.3",
-				"@comunica/utils-expression-evaluator": "^5.1.3"
+				"@comunica/bus-function-factory": "^5.2.0",
+				"@comunica/types": "^5.2.0",
+				"@comunica/utils-expression-evaluator": "^5.2.0"
 			}
 		},
 		"node_modules/@comunica/actor-function-factory-term-xsd-to-date": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-xsd-to-date/-/actor-function-factory-term-xsd-to-date-5.1.3.tgz",
-			"integrity": "sha512-CSwyrdCzoXemL9+qkomkAu4vi1kXuZLuYgOhmPltXWcNAanY/QDYYwfNS5FukNTz3OR79yYC5NVI7RKQm+a+iQ==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-xsd-to-date/-/actor-function-factory-term-xsd-to-date-5.2.0.tgz",
+			"integrity": "sha512-dtBx9hy82j234saJ8iZJmJm9K2k4bkl5+FlLpBE4H/mcs+Azi8ot8kBz0AirdBJtuNpJF96YmRcnt88+TmX66g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-function-factory": "^5.1.3",
-				"@comunica/utils-expression-evaluator": "^5.1.3"
+				"@comunica/bus-function-factory": "^5.2.0",
+				"@comunica/utils-expression-evaluator": "^5.2.0"
 			}
 		},
 		"node_modules/@comunica/actor-function-factory-term-xsd-to-datetime": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-xsd-to-datetime/-/actor-function-factory-term-xsd-to-datetime-5.1.3.tgz",
-			"integrity": "sha512-O0TiaJBwqvaf7V+wOmpNkR0uno/dagEkTZAgUzzWDZeZc3iAnb+TqBDL4IqqROL6Il6/tmNSgmAeed3veKl7Iw==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-xsd-to-datetime/-/actor-function-factory-term-xsd-to-datetime-5.2.0.tgz",
+			"integrity": "sha512-Y961DDn1bJNJO1G1+RfBTzSsj3b1YFzXJQVjz6bVpOHkO/mwLYe4OEgcK7FHy9BKqBkpzLZUDbEdMHmySyDihQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-function-factory": "^5.1.3",
-				"@comunica/types": "^5.1.3",
-				"@comunica/utils-expression-evaluator": "^5.1.3"
+				"@comunica/bus-function-factory": "^5.2.0",
+				"@comunica/types": "^5.2.0",
+				"@comunica/utils-expression-evaluator": "^5.2.0"
 			}
 		},
 		"node_modules/@comunica/actor-function-factory-term-xsd-to-day-time-duration": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-xsd-to-day-time-duration/-/actor-function-factory-term-xsd-to-day-time-duration-5.1.3.tgz",
-			"integrity": "sha512-nEMSUF71lTcPdZtlatmnrC4PiASJboZz07k3EoY/k6pQNWiWaKNKYhnRAmRlCeblXFBA1Kf1lrgBJoa8F+aEUg==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-xsd-to-day-time-duration/-/actor-function-factory-term-xsd-to-day-time-duration-5.2.0.tgz",
+			"integrity": "sha512-RLuNAxfwRXidI4K/femQJ3o67X9E8ikFEONcxyM/GPVkNssG9gi6eHRRLMH1BLydFEb+SA55pzcF4B6aGIbNhg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-function-factory": "^5.1.3",
-				"@comunica/types": "^5.1.3",
-				"@comunica/utils-expression-evaluator": "^5.1.3"
+				"@comunica/bus-function-factory": "^5.2.0",
+				"@comunica/types": "^5.2.0",
+				"@comunica/utils-expression-evaluator": "^5.2.0"
 			}
 		},
 		"node_modules/@comunica/actor-function-factory-term-xsd-to-decimal": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-xsd-to-decimal/-/actor-function-factory-term-xsd-to-decimal-5.1.3.tgz",
-			"integrity": "sha512-Pqb/CIAx9+TG6Y76TPmfABAKXnefTnLi0s4lqCLPD1A2eMt7l9EaicmwVK5L/gAgojtC+99AMlzavY+3iekjpg==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-xsd-to-decimal/-/actor-function-factory-term-xsd-to-decimal-5.2.0.tgz",
+			"integrity": "sha512-bVUqlHxfe3je3zdw/Hs5mrTohK6hdJQQ1vtrnnUhP5YDhB8xuErOdEWJ4LQoVpr95Y8n7qc7CIxowAeYzW0Ncg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-function-factory": "^5.1.3",
-				"@comunica/utils-expression-evaluator": "^5.1.3"
+				"@comunica/bus-function-factory": "^5.2.0",
+				"@comunica/utils-expression-evaluator": "^5.2.0"
 			}
 		},
 		"node_modules/@comunica/actor-function-factory-term-xsd-to-double": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-xsd-to-double/-/actor-function-factory-term-xsd-to-double-5.1.3.tgz",
-			"integrity": "sha512-3Fxg5Dj2uOY0qrTjyHlt+KnDu3NPm93NRIZVHPS6JJ+diaMJWJNZKr/83TwEWKUccsUFo/6BLEP7DZV6zoOqhw==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-xsd-to-double/-/actor-function-factory-term-xsd-to-double-5.2.0.tgz",
+			"integrity": "sha512-DhZLiR74MryBgip5tyBG9sEh5gt9V/IEO7fZ74gVbpQAe2yKx5TwgsbYupOOyVcAwOMEsRUQxtaitLlWigxzXw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-function-factory": "^5.1.3",
-				"@comunica/utils-expression-evaluator": "^5.1.3"
+				"@comunica/bus-function-factory": "^5.2.0",
+				"@comunica/utils-expression-evaluator": "^5.2.0"
 			}
 		},
 		"node_modules/@comunica/actor-function-factory-term-xsd-to-duration": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-xsd-to-duration/-/actor-function-factory-term-xsd-to-duration-5.1.3.tgz",
-			"integrity": "sha512-Sa9IoZdZxvXnybIE+2nuy97Oz+0rZBq45FtLvDj5GV8wwUXUY3lGQj2VSn9V5Vk9SevlnK4/GmBoNn+QTOY3NQ==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-xsd-to-duration/-/actor-function-factory-term-xsd-to-duration-5.2.0.tgz",
+			"integrity": "sha512-yCEu+EL6IUzj6rQAvHm8LEp9O7fySTU7u6oF+d14jBt8Lv7eeieBm9azga+W+dVEmr/4PSNQ2o4Yx28gmPXjRA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-function-factory": "^5.1.3",
-				"@comunica/types": "^5.1.3",
-				"@comunica/utils-expression-evaluator": "^5.1.3"
+				"@comunica/bus-function-factory": "^5.2.0",
+				"@comunica/types": "^5.2.0",
+				"@comunica/utils-expression-evaluator": "^5.2.0"
 			}
 		},
 		"node_modules/@comunica/actor-function-factory-term-xsd-to-float": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-xsd-to-float/-/actor-function-factory-term-xsd-to-float-5.1.3.tgz",
-			"integrity": "sha512-BwcOgtH+aMiU6o9a0pV0j1nAsPcg8+7QZgwIsxh5dYQkhbjZ/q9eaRimd3jZM4xskcM6WM0P/ioRSHRAmDz9Pg==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-xsd-to-float/-/actor-function-factory-term-xsd-to-float-5.2.0.tgz",
+			"integrity": "sha512-I5ojS8sE9IzLG9WBeghq8rJhhHPKWUTSQNwP8HiA6tqFJV7HCQ4L/ObV+JcsYGZPhWnKF3AK/DL23U34f/8Adw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-function-factory": "^5.1.3",
-				"@comunica/utils-expression-evaluator": "^5.1.3"
+				"@comunica/bus-function-factory": "^5.2.0",
+				"@comunica/utils-expression-evaluator": "^5.2.0"
 			}
 		},
 		"node_modules/@comunica/actor-function-factory-term-xsd-to-integer": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-xsd-to-integer/-/actor-function-factory-term-xsd-to-integer-5.1.3.tgz",
-			"integrity": "sha512-lRqIc3zZSeofzztaj9XLj4S5hRD/lVch9rJdaYThmVr3VbqN8kKAtYKBpR7535tj011M2uU7B2k0NIQ/AaUwEA==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-xsd-to-integer/-/actor-function-factory-term-xsd-to-integer-5.2.0.tgz",
+			"integrity": "sha512-Un45Jsr2poBD/5kWOs/tYhuj2JdDhcoTmtruMlICGhr53HpRWk0+McMVekQje2JApKDBtJ8DK78MIqd+GM0+Jg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-function-factory": "^5.1.3",
-				"@comunica/utils-expression-evaluator": "^5.1.3"
+				"@comunica/bus-function-factory": "^5.2.0",
+				"@comunica/utils-expression-evaluator": "^5.2.0"
 			}
 		},
 		"node_modules/@comunica/actor-function-factory-term-xsd-to-string": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-xsd-to-string/-/actor-function-factory-term-xsd-to-string-5.1.3.tgz",
-			"integrity": "sha512-4PNK3UMR1FggzqYqQHDiufclMfsv4T+OZw34PFC18VL0si3S87yNGfZUhqnVNZXhbw+eWnO2QutpsHNtzXyxFg==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-xsd-to-string/-/actor-function-factory-term-xsd-to-string-5.2.0.tgz",
+			"integrity": "sha512-9ephL29Jh6snd8HENx5ZfKR6xLIu509L9EfAWlEmZBhBj2y6nvYJpJm6Ufr0kEmPnceUMrGLjoxjjbA832yOqg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-function-factory": "^5.1.3",
-				"@comunica/utils-expression-evaluator": "^5.1.3"
+				"@comunica/bus-function-factory": "^5.2.0",
+				"@comunica/utils-expression-evaluator": "^5.2.0"
 			}
 		},
 		"node_modules/@comunica/actor-function-factory-term-xsd-to-time": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-xsd-to-time/-/actor-function-factory-term-xsd-to-time-5.1.3.tgz",
-			"integrity": "sha512-LCwccyXERS3e4dGYXSbB+LevhBTz0VXQrdUnVHRxR4iR8mVN5u+5PqoodXq02caIUszXzNCykOOXGI0nPoVfBQ==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-xsd-to-time/-/actor-function-factory-term-xsd-to-time-5.2.0.tgz",
+			"integrity": "sha512-SMJTqo9hmZYYZTAN6zVP1m/CBN257Dx7jum5A51HbUd4DEzqYYpRaJz6JLRrRR/Xd/+ONR9wPPYIm70afRY1yw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-function-factory": "^5.1.3",
-				"@comunica/types": "^5.1.3",
-				"@comunica/utils-expression-evaluator": "^5.1.3"
+				"@comunica/bus-function-factory": "^5.2.0",
+				"@comunica/types": "^5.2.0",
+				"@comunica/utils-expression-evaluator": "^5.2.0"
 			}
 		},
 		"node_modules/@comunica/actor-function-factory-term-xsd-to-year-month-duration": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-xsd-to-year-month-duration/-/actor-function-factory-term-xsd-to-year-month-duration-5.1.3.tgz",
-			"integrity": "sha512-/oR43wwW8QNgJCmPLugLrwdFK+tohc62vht/t8hLUja+FIyC5O96WUmP7/HYbjTLfKcESnUjT5V2NG0HlumyVQ==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-xsd-to-year-month-duration/-/actor-function-factory-term-xsd-to-year-month-duration-5.2.0.tgz",
+			"integrity": "sha512-HTijCJIsPhe89CeBbWUXJ3+VAaExOW5s8bGEUffpxIdOYjm8qfnj25rPT4zrMiE3A54tLBgWnewe30iwt/h1ww==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-function-factory": "^5.1.3",
-				"@comunica/types": "^5.1.3",
-				"@comunica/utils-expression-evaluator": "^5.1.3"
+				"@comunica/bus-function-factory": "^5.2.0",
+				"@comunica/types": "^5.2.0",
+				"@comunica/utils-expression-evaluator": "^5.2.0"
 			}
 		},
 		"node_modules/@comunica/actor-function-factory-term-year": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-year/-/actor-function-factory-term-year-5.1.3.tgz",
-			"integrity": "sha512-Qed6JWvT85Wbyn762xRfhBKA0kgVZ2OP0vfMHZhuCNJ8pHDlWAXWO2TbnE3tkbwtFJSYv//NzcAqs+iUvK2wWQ==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-year/-/actor-function-factory-term-year-5.2.0.tgz",
+			"integrity": "sha512-pWq373lztm7zk8bsNUdQKyp+ryoHtckTYpoy44bkwxNETazW3UZK/FcnxS7tNmjfzrytTEpm/HxSTQsEe/LAJA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-function-factory": "^5.1.3",
-				"@comunica/utils-expression-evaluator": "^5.1.3"
+				"@comunica/bus-function-factory": "^5.2.0",
+				"@comunica/utils-expression-evaluator": "^5.2.0"
 			}
 		},
 		"node_modules/@comunica/actor-hash-bindings-murmur": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-hash-bindings-murmur/-/actor-hash-bindings-murmur-5.1.3.tgz",
-			"integrity": "sha512-QEnNB+hiwUhfeVHO0W4b8SkurM4McOS8mhz38pXklYPv81UQA36lNqmK6tcszuFm2uvyKJ/oEVeB7q9wTenKEw==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-hash-bindings-murmur/-/actor-hash-bindings-murmur-5.2.0.tgz",
+			"integrity": "sha512-47DWarGNhpN6JK1275UoX0Z5rZ4i4JS+OmblQhoY/wSiGE01LlTkroeVyg2iGETq8QaRcfZ1K3VSarwAxjkUHQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-hash-bindings": "^5.1.3",
-				"@comunica/core": "^5.1.3",
+				"@comunica/bus-hash-bindings": "^5.2.0",
+				"@comunica/core": "^5.2.0",
 				"@types/imurmurhash": "^0.1.4",
 				"imurmurhash": "^0.1.4"
 			},
@@ -1593,14 +1549,14 @@
 			}
 		},
 		"node_modules/@comunica/actor-hash-quads-murmur": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-hash-quads-murmur/-/actor-hash-quads-murmur-5.1.3.tgz",
-			"integrity": "sha512-y/WNiOqTLC5sachYA7XpkLwwH1WEWpyCzwmLscLiXHGKxn8cW1493IfW5J0rixy00DJcf4az/u9PRICAbNlWOA==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-hash-quads-murmur/-/actor-hash-quads-murmur-5.2.0.tgz",
+			"integrity": "sha512-8A70w9ayJTS06vNiE7sJexdr5voW029iJrBzEhWD5FJwtPcnDbV8nCol5sDU8QGxkHT7tbMOlj41PpHWUTolwQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-hash-quads": "^5.1.3",
-				"@comunica/core": "^5.1.3",
+				"@comunica/bus-hash-quads": "^5.2.0",
+				"@comunica/core": "^5.2.0",
 				"@types/imurmurhash": "^0.1.4",
 				"imurmurhash": "^0.1.4"
 			},
@@ -1610,18 +1566,18 @@
 			}
 		},
 		"node_modules/@comunica/actor-http-fetch": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-http-fetch/-/actor-http-fetch-5.1.3.tgz",
-			"integrity": "sha512-PaU8cm/hFfmUc0zknfQ/WY29ffm3A+3g1nopGn90PCpaTwV4saB7MZAfHnCd9JB+YA5cuO0Z6JDwNr+T/ZiNeQ==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-http-fetch/-/actor-http-fetch-5.2.0.tgz",
+			"integrity": "sha512-EncZr69tVVSACsCuyRdTvB2fB/5ntKySg3K0MM3xckokMSxOvjS6Y7fZOmr3Xl05R1XpV12FG4tOjrbHIn9Hdg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-http": "^5.1.3",
-				"@comunica/bus-http-invalidate": "^5.1.3",
-				"@comunica/context-entries": "^5.1.3",
-				"@comunica/core": "^5.1.3",
-				"@comunica/mediatortype-time": "^5.1.3",
-				"@comunica/types": "^5.1.3",
+				"@comunica/bus-http": "^5.2.0",
+				"@comunica/bus-http-invalidate": "^5.2.0",
+				"@comunica/context-entries": "^5.2.0",
+				"@comunica/core": "^5.2.0",
+				"@comunica/mediatortype-time": "^5.2.0",
+				"@comunica/types": "^5.2.0",
 				"@types/http-cache-semantics": "^4.0.4",
 				"http-cache-semantics": "^4.2.0",
 				"undici": "^7.16.0"
@@ -1632,30 +1588,30 @@
 			}
 		},
 		"node_modules/@comunica/actor-http-limit-rate": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-http-limit-rate/-/actor-http-limit-rate-5.1.3.tgz",
-			"integrity": "sha512-5mOuBTkKNjB6SG5KJFZpeOMnoYLAQ+/5/c96yjULSTGrwU9NewixfwN5OL5wpVq8VO70SjaLhcApciR5rrJHaQ==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-http-limit-rate/-/actor-http-limit-rate-5.2.0.tgz",
+			"integrity": "sha512-wXHMfZ7hQoE4UOGxPdxTs10NxJeYieQEy45zl/jxpM5br9/4ZZJZt6SGSyZwRHX6IkXD262KkLDx+5/67sGKtw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-http": "^5.1.3",
-				"@comunica/bus-http-invalidate": "^5.1.3",
-				"@comunica/core": "^5.1.3",
-				"@comunica/mediatortype-time": "^5.1.3"
+				"@comunica/bus-http": "^5.2.0",
+				"@comunica/bus-http-invalidate": "^5.2.0",
+				"@comunica/core": "^5.2.0",
+				"@comunica/mediatortype-time": "^5.2.0"
 			}
 		},
 		"node_modules/@comunica/actor-http-proxy": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-http-proxy/-/actor-http-proxy-5.1.3.tgz",
-			"integrity": "sha512-RDYgAdASVIXBaCLuvj8b4ILIBp8fyEAyRGJtOJ40U57eOUBW8ZBE1PwRwoIad//VGbGxELN6dxjYdmISwwOvLw==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-http-proxy/-/actor-http-proxy-5.2.0.tgz",
+			"integrity": "sha512-9Y6CxxAytZQgvSsNQbkfuAThNetEQMzJAnJHIkfC54z3KjuvQxelvsiiFboTQAzZv65zQvDFqzL8p85YrOl6qw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-http": "^5.1.3",
-				"@comunica/context-entries": "^5.1.3",
-				"@comunica/core": "^5.1.3",
-				"@comunica/mediatortype-time": "^5.1.3",
-				"@comunica/types": "^5.1.3"
+				"@comunica/bus-http": "^5.2.0",
+				"@comunica/context-entries": "^5.2.0",
+				"@comunica/core": "^5.2.0",
+				"@comunica/mediatortype-time": "^5.2.0",
+				"@comunica/types": "^5.2.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -1663,29 +1619,43 @@
 			}
 		},
 		"node_modules/@comunica/actor-http-retry": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-http-retry/-/actor-http-retry-5.1.3.tgz",
-			"integrity": "sha512-8ZXjjfHOzt/ddCIigid9mBuoAzi4agJ32a9vryn+7SH15wQrUQWcOr6FQUWtcFzbhBCnK2jaTOsjkCE5L7v9gQ==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-http-retry/-/actor-http-retry-5.2.0.tgz",
+			"integrity": "sha512-PA0nvCKJvowJwdbyYtaYRW8dU5zbTqcK90fAerFHIGeRQsuzoVtzPzxjklKo8NjRj6K4f6EFTsvk9j09U/U5XA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-http": "^5.1.3",
-				"@comunica/bus-http-invalidate": "^5.1.3",
-				"@comunica/context-entries": "^5.1.3",
-				"@comunica/core": "^5.1.3",
-				"@comunica/mediatortype-time": "^5.1.3"
+				"@comunica/bus-http": "^5.2.0",
+				"@comunica/bus-http-invalidate": "^5.2.0",
+				"@comunica/context-entries": "^5.2.0",
+				"@comunica/core": "^5.2.0",
+				"@comunica/mediatortype-time": "^5.2.0"
+			}
+		},
+		"node_modules/@comunica/actor-http-retry-body": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-http-retry-body/-/actor-http-retry-body-5.2.0.tgz",
+			"integrity": "sha512-gwNjd9hNsoaABrD1CIZdQzFwg2R7fA2NbGSaGNRT914HdD3f7Mx8h83HAuUJ4hrltLG2cbvglbIAl/SlOBB9MA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@comunica/bus-http": "^5.2.0",
+				"@comunica/context-entries": "^5.2.0",
+				"@comunica/core": "^5.2.0",
+				"@comunica/mediatortype-time": "^5.2.0",
+				"readable-stream": "^4.7.0"
 			}
 		},
 		"node_modules/@comunica/actor-http-wayback": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-http-wayback/-/actor-http-wayback-5.1.3.tgz",
-			"integrity": "sha512-EkHg9vTEblerWEoVh470YoZWntGi0VoFSKss9DGCJxXHgGGfvIGyvG2wKcZ9Ck4+1azsfJhlyPVmkKQIan7CYg==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-http-wayback/-/actor-http-wayback-5.2.0.tgz",
+			"integrity": "sha512-Q4qj6b+GwbnwRGcQH5jmVg3ePIdkwo/tPdHZvRwzZa75TzvT4R4LJlMarEPiUqDvRjGtylVThoMkAafrDmGi1g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-http": "^5.1.3",
-				"@comunica/context-entries": "^5.1.3",
-				"@comunica/core": "^5.1.3",
+				"@comunica/bus-http": "^5.2.0",
+				"@comunica/context-entries": "^5.2.0",
+				"@comunica/core": "^5.2.0",
 				"@jeswr/stream-to-string": "^2.0.0"
 			},
 			"funding": {
@@ -1694,23 +1664,23 @@
 			}
 		},
 		"node_modules/@comunica/actor-init-query": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-init-query/-/actor-init-query-5.1.3.tgz",
-			"integrity": "sha512-U9l5GuTuC5H2m+8LyUOj/UaGQw2nhXDuWvaOIp4XJSAp3jwIju6+vsbcjGrjbaLxvMjhHP6k03JUTtg37m5g3A==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-init-query/-/actor-init-query-5.2.0.tgz",
+			"integrity": "sha512-BNz/XyC/QUOpKVc4Uh83aashdw3xQiiOFjDFhfP6fBXosMoOB8SHiOhtd6ZPQI827cJFVtcDEH0vJv4Pivlh8Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/actor-http-proxy": "^5.1.3",
-				"@comunica/bus-http-invalidate": "^5.1.3",
-				"@comunica/bus-init": "^5.1.3",
-				"@comunica/bus-query-process": "^5.1.3",
-				"@comunica/bus-query-result-serialize": "^5.1.3",
-				"@comunica/context-entries": "^5.1.3",
-				"@comunica/core": "^5.1.3",
-				"@comunica/logger-pretty": "^5.1.3",
-				"@comunica/runner": "^5.1.3",
-				"@comunica/types": "^5.1.3",
-				"@comunica/utils-algebra": "^5.1.3",
+				"@comunica/actor-http-proxy": "^5.2.0",
+				"@comunica/bus-http-invalidate": "^5.2.0",
+				"@comunica/bus-init": "^5.2.0",
+				"@comunica/bus-query-process": "^5.2.0",
+				"@comunica/bus-query-result-serialize": "^5.2.0",
+				"@comunica/context-entries": "^5.2.0",
+				"@comunica/core": "^5.2.0",
+				"@comunica/logger-pretty": "^5.2.0",
+				"@comunica/runner": "^5.2.0",
+				"@comunica/types": "^5.2.0",
+				"@comunica/utils-algebra": "^5.2.0",
 				"@rdfjs/types": "*",
 				"@types/yargs": "^17.0.24",
 				"asynciterator": "^3.10.0",
@@ -1728,18 +1698,18 @@
 			}
 		},
 		"node_modules/@comunica/actor-optimize-query-operation-assign-sources-exhaustive": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-assign-sources-exhaustive/-/actor-optimize-query-operation-assign-sources-exhaustive-5.1.3.tgz",
-			"integrity": "sha512-Bs1sVDuQg4sLYnEITjqKb+zCKkbzxkCtuWu+tc/QTAc1ZeApNqiEvVNOhi3KnnWcNQu8Ul72ACJ9ShcSC266TA==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-assign-sources-exhaustive/-/actor-optimize-query-operation-assign-sources-exhaustive-5.2.0.tgz",
+			"integrity": "sha512-n1kyH7H7XSQA/vo/UfWaU7IkpPLLyUbSV6waS7VKVjoIvLWZ8hNgeFWxKqVURRB2lveUuAR5lLoA1vVvWYO5oA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-optimize-query-operation": "^5.1.3",
-				"@comunica/context-entries": "^5.1.3",
-				"@comunica/core": "^5.1.3",
-				"@comunica/types": "^5.1.3",
-				"@comunica/utils-algebra": "^5.1.3",
-				"@comunica/utils-query-operation": "^5.1.3"
+				"@comunica/bus-optimize-query-operation": "^5.2.0",
+				"@comunica/context-entries": "^5.2.0",
+				"@comunica/core": "^5.2.0",
+				"@comunica/types": "^5.2.0",
+				"@comunica/utils-algebra": "^5.2.0",
+				"@comunica/utils-query-operation": "^5.2.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -1747,16 +1717,16 @@
 			}
 		},
 		"node_modules/@comunica/actor-optimize-query-operation-bgp-to-join": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-bgp-to-join/-/actor-optimize-query-operation-bgp-to-join-5.1.3.tgz",
-			"integrity": "sha512-L3ejXr0fVSWaMtfyFwiZcSITCaiFdzw5PEwSCg1c9QKVaa0QtMJ80V6yHya/xLDa3LmVV7t3m+7yFVGjZIYWzg==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-bgp-to-join/-/actor-optimize-query-operation-bgp-to-join-5.2.0.tgz",
+			"integrity": "sha512-8RfFRDvhL/vQxJydqmjPXOG6g0i3zLX4nniOp8XxInIhAviber2nziPX2tI+/e3WHjO4hRYgfEQUB6MjLM5OaA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-optimize-query-operation": "^5.1.3",
-				"@comunica/context-entries": "^5.1.3",
-				"@comunica/core": "^5.1.3",
-				"@comunica/utils-algebra": "^5.1.3"
+				"@comunica/bus-optimize-query-operation": "^5.2.0",
+				"@comunica/context-entries": "^5.2.0",
+				"@comunica/core": "^5.2.0",
+				"@comunica/utils-algebra": "^5.2.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -1764,16 +1734,16 @@
 			}
 		},
 		"node_modules/@comunica/actor-optimize-query-operation-construct-distinct": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-construct-distinct/-/actor-optimize-query-operation-construct-distinct-5.1.3.tgz",
-			"integrity": "sha512-ZMT5DY2xhg7BSi5AJLdu0kp6jT1SwrxarnlSptXt9wa4EUgYqEkfhOjZdOUMlZRzxZ71ohna4ESyBkta1twvzQ==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-construct-distinct/-/actor-optimize-query-operation-construct-distinct-5.2.0.tgz",
+			"integrity": "sha512-dYdqLhfEgxsfMJ0xEqCl/oFcTEMHOqfMucq0JacMvq4Lag7Q0Z7/AZu/v8XCh29uVcxcIaFwIQImPKiKkBBLcg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-optimize-query-operation": "^5.1.3",
-				"@comunica/context-entries": "^5.1.3",
-				"@comunica/core": "^5.1.3",
-				"@comunica/utils-algebra": "^5.1.3"
+				"@comunica/bus-optimize-query-operation": "^5.2.0",
+				"@comunica/context-entries": "^5.2.0",
+				"@comunica/core": "^5.2.0",
+				"@comunica/utils-algebra": "^5.2.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -1781,16 +1751,35 @@
 			}
 		},
 		"node_modules/@comunica/actor-optimize-query-operation-describe-to-constructs-subject": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-describe-to-constructs-subject/-/actor-optimize-query-operation-describe-to-constructs-subject-5.1.3.tgz",
-			"integrity": "sha512-DbQHo4Hm/lKd9UK9TBgp/62UGXoCos85u3ZLIxtXMxoYBdlEOoosEeqpgYUu1YDCcN+pRCCqi1Ad9Fl1Od3XvA==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-describe-to-constructs-subject/-/actor-optimize-query-operation-describe-to-constructs-subject-5.2.0.tgz",
+			"integrity": "sha512-nMkA/VK1XTZlkxmli+f1s+6ZpXFE9zOcxu1P/9s/28Sa5wA5bBZKjh9oVKK9a6+B3RDmU4GjSmwLD7FwBTTGsw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-optimize-query-operation": "^5.1.3",
-				"@comunica/context-entries": "^5.1.3",
-				"@comunica/core": "^5.1.3",
-				"@comunica/utils-algebra": "^5.1.3"
+				"@comunica/bus-optimize-query-operation": "^5.2.0",
+				"@comunica/context-entries": "^5.2.0",
+				"@comunica/core": "^5.2.0",
+				"@comunica/utils-algebra": "^5.2.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/comunica-association"
+			}
+		},
+		"node_modules/@comunica/actor-optimize-query-operation-distinct-terms-pushdown": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-distinct-terms-pushdown/-/actor-optimize-query-operation-distinct-terms-pushdown-5.2.0.tgz",
+			"integrity": "sha512-aD9Ail1gI5luy6j5Ie3h+VVYh2Su3eNpePWK0UCDSh0nBxFgD0BLy4LYXnpXCIgKT4maxyk9wDvv7Z0jy0HcRw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@comunica/bus-optimize-query-operation": "^5.2.0",
+				"@comunica/context-entries": "^5.2.0",
+				"@comunica/core": "^5.2.0",
+				"@comunica/types": "^5.2.0",
+				"@comunica/utils-algebra": "^5.2.0",
+				"@comunica/utils-query-operation": "^5.2.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -1798,18 +1787,18 @@
 			}
 		},
 		"node_modules/@comunica/actor-optimize-query-operation-filter-pushdown": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-filter-pushdown/-/actor-optimize-query-operation-filter-pushdown-5.1.3.tgz",
-			"integrity": "sha512-xpPDHGX6HXgQEXlNIqi6ZytozVqh/MEcOIE8Ps8WjoE/AiA0v5ktPWu22pbPnjzrmCyjUv+A0L8ALgafR4gJhQ==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-filter-pushdown/-/actor-optimize-query-operation-filter-pushdown-5.2.0.tgz",
+			"integrity": "sha512-YTASRwy7qAMVbT1vdQw6tnaGJQOofaQjF2guA4E/BJPXReW+RDmqm4X76CtC5qLr/wJjQkutBycQmq3TyZf4cQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-optimize-query-operation": "^5.1.3",
-				"@comunica/context-entries": "^5.1.3",
-				"@comunica/core": "^5.1.3",
-				"@comunica/types": "^5.1.3",
-				"@comunica/utils-algebra": "^5.1.3",
-				"@comunica/utils-query-operation": "^5.1.3",
+				"@comunica/bus-optimize-query-operation": "^5.2.0",
+				"@comunica/context-entries": "^5.2.0",
+				"@comunica/core": "^5.2.0",
+				"@comunica/types": "^5.2.0",
+				"@comunica/utils-algebra": "^5.2.0",
+				"@comunica/utils-query-operation": "^5.2.0",
 				"@rdfjs/types": "*",
 				"rdf-terms": "^2.0.0"
 			},
@@ -1818,19 +1807,36 @@
 				"url": "https://opencollective.com/comunica-association"
 			}
 		},
-		"node_modules/@comunica/actor-optimize-query-operation-group-sources": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-group-sources/-/actor-optimize-query-operation-group-sources-5.1.3.tgz",
-			"integrity": "sha512-633uZtt8kUdDazxp05Wlf1NOgSemWdyFKOCCkt9R/DNm2tyw4aODyD/0HFNF5XYTAPXSQxdLOLF6hji9enw0Hw==",
+		"node_modules/@comunica/actor-optimize-query-operation-group-file-sources": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-group-file-sources/-/actor-optimize-query-operation-group-file-sources-5.2.0.tgz",
+			"integrity": "sha512-xI5AJ3HbyP5+MBYgv9wEVQ5n31cmZF3tyibivel36goPxSP0jNJtnM1uPq7E2PxRhPW9jOV0xZc0Ab6rNMVW+Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-optimize-query-operation": "^5.1.3",
-				"@comunica/context-entries": "^5.1.3",
-				"@comunica/core": "^5.1.3",
-				"@comunica/types": "^5.1.3",
-				"@comunica/utils-algebra": "^5.1.3",
-				"@comunica/utils-query-operation": "^5.1.3"
+				"@comunica/bus-optimize-query-operation": "^5.2.0",
+				"@comunica/bus-query-source-identify": "^5.2.0",
+				"@comunica/context-entries": "^5.2.0",
+				"@comunica/core": "^5.2.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/comunica-association"
+			}
+		},
+		"node_modules/@comunica/actor-optimize-query-operation-group-sources": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-group-sources/-/actor-optimize-query-operation-group-sources-5.2.0.tgz",
+			"integrity": "sha512-p8CGASxb6OYw2UdJ2tgpCDSGOx4pdOAmLmMn2pGAfCgcvUEA0BPwCbD9WUhcmcpdBM/HNrEGxn98ju490HvrUA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@comunica/bus-optimize-query-operation": "^5.2.0",
+				"@comunica/context-entries": "^5.2.0",
+				"@comunica/core": "^5.2.0",
+				"@comunica/types": "^5.2.0",
+				"@comunica/utils-algebra": "^5.2.0",
+				"@comunica/utils-query-operation": "^5.2.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -1838,16 +1844,16 @@
 			}
 		},
 		"node_modules/@comunica/actor-optimize-query-operation-join-bgp": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-join-bgp/-/actor-optimize-query-operation-join-bgp-5.1.3.tgz",
-			"integrity": "sha512-fjkB8wZvZHw1JfChC0yAwb0KquZLHDOA/dg0Zbg+Vw/YwXjvB8QVVgw9DVpxFm8y/4XsvazzM/HPKlUd/7qE/A==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-join-bgp/-/actor-optimize-query-operation-join-bgp-5.2.0.tgz",
+			"integrity": "sha512-pyHjIchhXh/j8dXexlnecWMRkssM9tUHCzuzAhcoIl3j7UESKJh8pQc0PFQTy/dmbGLu2cE+hzlwVTV+6dvFng==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-optimize-query-operation": "^5.1.3",
-				"@comunica/context-entries": "^5.1.3",
-				"@comunica/core": "^5.1.3",
-				"@comunica/utils-algebra": "^5.1.3"
+				"@comunica/bus-optimize-query-operation": "^5.2.0",
+				"@comunica/context-entries": "^5.2.0",
+				"@comunica/core": "^5.2.0",
+				"@comunica/utils-algebra": "^5.2.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -1855,17 +1861,17 @@
 			}
 		},
 		"node_modules/@comunica/actor-optimize-query-operation-join-connected": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-join-connected/-/actor-optimize-query-operation-join-connected-5.1.3.tgz",
-			"integrity": "sha512-PfvfsP+jU2+7ikqgfe0C5nJKU1iMDwjWJPKu2hqavSDoGurpH8Xt36GT0qNpaWNEHCTsZTLVj/7Fi9O3XFtpNA==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-join-connected/-/actor-optimize-query-operation-join-connected-5.2.0.tgz",
+			"integrity": "sha512-WSw+GhNKU3q6ytFHlHNNCnbZJ/qxFXrv9xagJco6qmWdKoweH8ZGTDwGbq4oTr8XwEs7qpTG1N2psW++UVFsdQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-optimize-query-operation": "^5.1.3",
-				"@comunica/context-entries": "^5.1.3",
-				"@comunica/core": "^5.1.3",
-				"@comunica/types": "^5.1.3",
-				"@comunica/utils-algebra": "^5.1.3"
+				"@comunica/bus-optimize-query-operation": "^5.2.0",
+				"@comunica/context-entries": "^5.2.0",
+				"@comunica/core": "^5.2.0",
+				"@comunica/types": "^5.2.0",
+				"@comunica/utils-algebra": "^5.2.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -1873,18 +1879,18 @@
 			}
 		},
 		"node_modules/@comunica/actor-optimize-query-operation-leftjoin-expression-pushdown": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-leftjoin-expression-pushdown/-/actor-optimize-query-operation-leftjoin-expression-pushdown-5.1.3.tgz",
-			"integrity": "sha512-CN1RU3v8KBU4GzWj77NeazQ0kNgOPB1Vh5M42qxgi0XecqxdPanvNeMjEhNmCOKcZ4oTdmIme8cmsVvoI2hNeQ==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-leftjoin-expression-pushdown/-/actor-optimize-query-operation-leftjoin-expression-pushdown-5.2.0.tgz",
+			"integrity": "sha512-+3IUKruTGYxheOnQ3Wk94y7t2U60UCoBe2zTyTu5SwwpBhEI/nkb+Zg9lqMNlIlF2NpnkTFxqJ/l64YIue2ANw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-optimize-query-operation": "^5.1.3",
-				"@comunica/context-entries": "^5.1.3",
-				"@comunica/core": "^5.1.3",
-				"@comunica/types": "^5.1.3",
-				"@comunica/utils-algebra": "^5.1.3",
-				"@comunica/utils-query-operation": "^5.1.3",
+				"@comunica/bus-optimize-query-operation": "^5.2.0",
+				"@comunica/context-entries": "^5.2.0",
+				"@comunica/core": "^5.2.0",
+				"@comunica/types": "^5.2.0",
+				"@comunica/utils-algebra": "^5.2.0",
+				"@comunica/utils-query-operation": "^5.2.0",
 				"@rdfjs/types": "*"
 			},
 			"funding": {
@@ -1893,18 +1899,18 @@
 			}
 		},
 		"node_modules/@comunica/actor-optimize-query-operation-prune-empty-source-operations": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-prune-empty-source-operations/-/actor-optimize-query-operation-prune-empty-source-operations-5.1.3.tgz",
-			"integrity": "sha512-jI3/hjcqio8p9f8fHiPD0bCxg8kU5enpeB6WNY+N7edwHHHTzOB6ZKX95eu8CP6rjbTsb2LaW/xTRjz8WXP3bg==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-prune-empty-source-operations/-/actor-optimize-query-operation-prune-empty-source-operations-5.2.0.tgz",
+			"integrity": "sha512-SBoqZXvbypp1VubenOlcqXg8Cda/BlTLwUNIRemO9MXI8WBh62x4yAyDMxq8wNa9CIzt9dx7Eq3sgcpn23+Wew==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-optimize-query-operation": "^5.1.3",
-				"@comunica/context-entries": "^5.1.3",
-				"@comunica/core": "^5.1.3",
-				"@comunica/types": "^5.1.3",
-				"@comunica/utils-algebra": "^5.1.3",
-				"@comunica/utils-query-operation": "^5.1.3"
+				"@comunica/bus-optimize-query-operation": "^5.2.0",
+				"@comunica/context-entries": "^5.2.0",
+				"@comunica/core": "^5.2.0",
+				"@comunica/types": "^5.2.0",
+				"@comunica/utils-algebra": "^5.2.0",
+				"@comunica/utils-query-operation": "^5.2.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -1912,21 +1918,21 @@
 			}
 		},
 		"node_modules/@comunica/actor-optimize-query-operation-query-source-identify": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-query-source-identify/-/actor-optimize-query-operation-query-source-identify-5.1.3.tgz",
-			"integrity": "sha512-Us6BIj/dK/ha0909qdQ/oOqO1vhVbMcoOXRo+7ioeUgK51RHREUsIcy3DA7AzCRA1QAS3UizdphrA60wMGalGA==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-query-source-identify/-/actor-optimize-query-operation-query-source-identify-5.2.0.tgz",
+			"integrity": "sha512-3R6wqO0C2JjOZSO4pLUrRKUO1YHTpFf9oWXzWlg0E1UCDSxra8rN9l8BMte+II2VOE48ph2KVXCKos/TqJPDmg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-context-preprocess": "^5.1.3",
-				"@comunica/bus-http-invalidate": "^5.1.3",
-				"@comunica/bus-optimize-query-operation": "^5.1.3",
-				"@comunica/bus-query-source-identify": "^5.1.3",
-				"@comunica/context-entries": "^5.1.3",
-				"@comunica/core": "^5.1.3",
-				"@comunica/types": "^5.1.3",
-				"@comunica/utils-algebra": "^5.1.3",
-				"@comunica/utils-query-operation": "^5.1.3",
+				"@comunica/bus-context-preprocess": "^5.2.0",
+				"@comunica/bus-http-invalidate": "^5.2.0",
+				"@comunica/bus-optimize-query-operation": "^5.2.0",
+				"@comunica/bus-query-source-identify": "^5.2.0",
+				"@comunica/context-entries": "^5.2.0",
+				"@comunica/core": "^5.2.0",
+				"@comunica/types": "^5.2.0",
+				"@comunica/utils-algebra": "^5.2.0",
+				"@comunica/utils-query-operation": "^5.2.0",
 				"lru-cache": "^11.2.2"
 			},
 			"funding": {
@@ -1935,19 +1941,19 @@
 			}
 		},
 		"node_modules/@comunica/actor-optimize-query-operation-query-source-skolemize": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-query-source-skolemize/-/actor-optimize-query-operation-query-source-skolemize-5.1.3.tgz",
-			"integrity": "sha512-1UKyzyM6iaNETfjdRj15YEWQJYBwYQ8frHbwme443Gt6S5jAP4DSM2iRKanE8RVkXLN1GNawilLlhvlYS+9qrg==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-query-source-skolemize/-/actor-optimize-query-operation-query-source-skolemize-5.2.0.tgz",
+			"integrity": "sha512-WFswfv5qOWylryJJ3qDewakvFW9pNLx2Sd3BvgbQmAO30TGikEdGOIQcMYpi2WueSkXetQ79cmtJWbtXxpLdbQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-optimize-query-operation": "^5.1.3",
-				"@comunica/context-entries": "^5.1.3",
-				"@comunica/core": "^5.1.3",
-				"@comunica/types": "^5.1.3",
-				"@comunica/utils-algebra": "^5.1.3",
+				"@comunica/bus-optimize-query-operation": "^5.2.0",
+				"@comunica/context-entries": "^5.2.0",
+				"@comunica/core": "^5.2.0",
+				"@comunica/types": "^5.2.0",
+				"@comunica/utils-algebra": "^5.2.0",
 				"@comunica/utils-data-factory": "^5.0.0",
-				"@comunica/utils-metadata": "^5.1.3",
+				"@comunica/utils-metadata": "^5.2.0",
 				"@rdfjs/types": "*",
 				"asynciterator": "^3.10.0",
 				"rdf-terms": "^2.0.0"
@@ -1958,17 +1964,17 @@
 			}
 		},
 		"node_modules/@comunica/actor-optimize-query-operation-rewrite-add": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-rewrite-add/-/actor-optimize-query-operation-rewrite-add-5.1.3.tgz",
-			"integrity": "sha512-DvcgxOF8s+jXQvrQ5JNx96HOHrNQy/BhNn34o4iCoSrmJUjECv59d6lNbUpyKhZA13U2/fYO9QNpexbn09C1DA==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-rewrite-add/-/actor-optimize-query-operation-rewrite-add-5.2.0.tgz",
+			"integrity": "sha512-4oEnyZcOMKssPe/b03dfLZQ3q6tQjUskNTM1i/+ebfCTjULRVahobXzmiba1f2yXJEuSz8O5CrSU+O1NJWIXvg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-optimize-query-operation": "^5.1.3",
-				"@comunica/context-entries": "^5.1.3",
-				"@comunica/core": "^5.1.3",
-				"@comunica/types": "^5.1.3",
-				"@comunica/utils-algebra": "^5.1.3",
+				"@comunica/bus-optimize-query-operation": "^5.2.0",
+				"@comunica/context-entries": "^5.2.0",
+				"@comunica/core": "^5.2.0",
+				"@comunica/types": "^5.2.0",
+				"@comunica/utils-algebra": "^5.2.0",
 				"@rdfjs/types": "*",
 				"rdf-data-factory": "^2.0.0"
 			},
@@ -1978,17 +1984,17 @@
 			}
 		},
 		"node_modules/@comunica/actor-optimize-query-operation-rewrite-copy": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-rewrite-copy/-/actor-optimize-query-operation-rewrite-copy-5.1.3.tgz",
-			"integrity": "sha512-Ypp64eG2TDkvWub1MLkGXhiciMdAMI42qmJTVNq4i13/8vfSWOi42/qAfGF2Y185rF5fh3Xv1Z8GtOe+swnMxw==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-rewrite-copy/-/actor-optimize-query-operation-rewrite-copy-5.2.0.tgz",
+			"integrity": "sha512-7twtR/aasM4wxfPbYmypVfOaa/smYE7t35K1sottrExppWTKYesqKlzjMOap48QVx+kuD1nkZ0okHZbYhKezJQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-optimize-query-operation": "^5.1.3",
-				"@comunica/context-entries": "^5.1.3",
-				"@comunica/core": "^5.1.3",
-				"@comunica/types": "^5.1.3",
-				"@comunica/utils-algebra": "^5.1.3"
+				"@comunica/bus-optimize-query-operation": "^5.2.0",
+				"@comunica/context-entries": "^5.2.0",
+				"@comunica/core": "^5.2.0",
+				"@comunica/types": "^5.2.0",
+				"@comunica/utils-algebra": "^5.2.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -1996,17 +2002,17 @@
 			}
 		},
 		"node_modules/@comunica/actor-optimize-query-operation-rewrite-move": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-rewrite-move/-/actor-optimize-query-operation-rewrite-move-5.1.3.tgz",
-			"integrity": "sha512-BV3sEh/cOCPWw0eq3R+iS5O+XDIMpd10J2GfrltPjPUo9yDE4yZbQW2JIIPrxBEmQJT5fIzO/IfiqxVwS+uLkQ==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-rewrite-move/-/actor-optimize-query-operation-rewrite-move-5.2.0.tgz",
+			"integrity": "sha512-UaNSuYMFM8VW2O5Hfz7yfIWDyB7k3W2dM04atKDKFW+Q5EzG3sZafOhBUra2tmM57UtDhR0fjiBBrDzPWaZ+wg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-optimize-query-operation": "^5.1.3",
-				"@comunica/context-entries": "^5.1.3",
-				"@comunica/core": "^5.1.3",
-				"@comunica/types": "^5.1.3",
-				"@comunica/utils-algebra": "^5.1.3"
+				"@comunica/bus-optimize-query-operation": "^5.2.0",
+				"@comunica/context-entries": "^5.2.0",
+				"@comunica/core": "^5.2.0",
+				"@comunica/types": "^5.2.0",
+				"@comunica/utils-algebra": "^5.2.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -2014,17 +2020,17 @@
 			}
 		},
 		"node_modules/@comunica/actor-query-operation-ask": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-ask/-/actor-query-operation-ask-5.1.3.tgz",
-			"integrity": "sha512-qassrHOJzl7F7wyLIylCl2tOf0NRPzma7A7Km00c9IwHBBFTKFRgGI3TXbQfckNu8EXQVQBMe3ghPteqIJ/FnQ==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-ask/-/actor-query-operation-ask-5.2.0.tgz",
+			"integrity": "sha512-9+/9SoK+4nBe46t4iAv+b/6JFZgKGmg6DmKujheqaTTnlZMVo56B2DAydf2uxAJSYWS25kIoJNFw5z4UgmY6Ug==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-query-operation": "^5.1.3",
-				"@comunica/core": "^5.1.3",
-				"@comunica/types": "^5.1.3",
-				"@comunica/utils-algebra": "^5.1.3",
-				"@comunica/utils-query-operation": "^5.1.3"
+				"@comunica/bus-query-operation": "^5.2.0",
+				"@comunica/core": "^5.2.0",
+				"@comunica/types": "^5.2.0",
+				"@comunica/utils-algebra": "^5.2.0",
+				"@comunica/utils-query-operation": "^5.2.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -2032,17 +2038,17 @@
 			}
 		},
 		"node_modules/@comunica/actor-query-operation-bgp-join": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-bgp-join/-/actor-query-operation-bgp-join-5.1.3.tgz",
-			"integrity": "sha512-22BiyoUVSwZA200rSEzQDLjWQNHOPeRQZziqMKnLlJN/Uk18RUL96SwbwpWmALoL3fJqktk4xl/tz9aRn1eWmg==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-bgp-join/-/actor-query-operation-bgp-join-5.2.0.tgz",
+			"integrity": "sha512-Ow1pN17egO4tscXTsRBfei2M85/AGYTRbVrHckNpecwJ2Ehmnbq0AaGTxtDK1ec5uFSldbnoH2E3k+u8y1Vc5w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-query-operation": "^5.1.3",
-				"@comunica/context-entries": "^5.1.3",
-				"@comunica/core": "^5.1.3",
-				"@comunica/types": "^5.1.3",
-				"@comunica/utils-algebra": "^5.1.3"
+				"@comunica/bus-query-operation": "^5.2.0",
+				"@comunica/context-entries": "^5.2.0",
+				"@comunica/core": "^5.2.0",
+				"@comunica/types": "^5.2.0",
+				"@comunica/utils-algebra": "^5.2.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -2050,18 +2056,18 @@
 			}
 		},
 		"node_modules/@comunica/actor-query-operation-construct": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-construct/-/actor-query-operation-construct-5.1.3.tgz",
-			"integrity": "sha512-Bt7dXh5L5y0p/I7QCfCzh3C0CX3EQ2bFNI+ONmyBUjPpynXbeEEIJMkoax6KJrGVuEXpgmRhorK4cIye2e72KA==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-construct/-/actor-query-operation-construct-5.2.0.tgz",
+			"integrity": "sha512-DsDVnJTnHwl3QP8Pdhd7xhBOdAV06R5DimleU+qfYTThnTNPv+uey8sJ44hJMrScc2Ijl9rYKEPyFDVvLbjwyw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-query-operation": "^5.1.3",
-				"@comunica/context-entries": "^5.1.3",
-				"@comunica/core": "^5.1.3",
-				"@comunica/types": "^5.1.3",
-				"@comunica/utils-algebra": "^5.1.3",
-				"@comunica/utils-query-operation": "^5.1.3",
+				"@comunica/bus-query-operation": "^5.2.0",
+				"@comunica/context-entries": "^5.2.0",
+				"@comunica/core": "^5.2.0",
+				"@comunica/types": "^5.2.0",
+				"@comunica/utils-algebra": "^5.2.0",
+				"@comunica/utils-query-operation": "^5.2.0",
 				"@rdfjs/types": "*",
 				"asynciterator": "^3.10.0",
 				"rdf-terms": "^2.0.0"
@@ -2072,17 +2078,17 @@
 			}
 		},
 		"node_modules/@comunica/actor-query-operation-distinct-identity": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-distinct-identity/-/actor-query-operation-distinct-identity-5.1.3.tgz",
-			"integrity": "sha512-K6pdznqyMU2kKmeTkaGpw6AAM3TZscAD6fmBD0NXWL6EXRC6nPLVz1YxVGrMqmtDA722yTD74LnPq4oMgae5TQ==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-distinct-identity/-/actor-query-operation-distinct-identity-5.2.0.tgz",
+			"integrity": "sha512-v7nz7CLXycRuRDi5DJvyxqefB39nORHYoFoV9gniRb9lV8C1Q/n6duoSY7U3eK7YfrmfJI4pzuWNLpUFoPWqHg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-query-operation": "^5.1.3",
-				"@comunica/core": "^5.1.3",
-				"@comunica/types": "^5.1.3",
-				"@comunica/utils-algebra": "^5.1.3",
-				"@comunica/utils-query-operation": "^5.1.3",
+				"@comunica/bus-query-operation": "^5.2.0",
+				"@comunica/core": "^5.2.0",
+				"@comunica/types": "^5.2.0",
+				"@comunica/utils-algebra": "^5.2.0",
+				"@comunica/utils-query-operation": "^5.2.0",
 				"@rdfjs/types": "*",
 				"asynciterator": "^3.10.0",
 				"rdf-string": "^2.0.1"
@@ -2093,20 +2099,20 @@
 			}
 		},
 		"node_modules/@comunica/actor-query-operation-extend": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-extend/-/actor-query-operation-extend-5.1.3.tgz",
-			"integrity": "sha512-Uu+T3L2M8QLap0w8jKUU+U5p3UjHsPG3Z4WVsg/vIeTxEF3wqQXmg0LpBgzCIBaHfuCTqzSyGwjZ4QZtxUvmig==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-extend/-/actor-query-operation-extend-5.2.0.tgz",
+			"integrity": "sha512-lzQUWswB723v7dtgyE3KgY1lmtsn5sdD4rfk1kZ3pwMZGZq4WG55sMbYntANge5ZIZexAD1qbaoCbjVNe2UJvA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-expression-evaluator-factory": "^5.1.3",
-				"@comunica/bus-query-operation": "^5.1.3",
-				"@comunica/core": "^5.1.3",
-				"@comunica/types": "^5.1.3",
-				"@comunica/utils-algebra": "^5.1.3",
-				"@comunica/utils-bindings-factory": "^5.1.3",
-				"@comunica/utils-expression-evaluator": "^5.1.3",
-				"@comunica/utils-query-operation": "^5.1.3"
+				"@comunica/bus-expression-evaluator-factory": "^5.2.0",
+				"@comunica/bus-query-operation": "^5.2.0",
+				"@comunica/core": "^5.2.0",
+				"@comunica/types": "^5.2.0",
+				"@comunica/utils-algebra": "^5.2.0",
+				"@comunica/utils-bindings-factory": "^5.2.0",
+				"@comunica/utils-expression-evaluator": "^5.2.0",
+				"@comunica/utils-query-operation": "^5.2.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -2114,20 +2120,20 @@
 			}
 		},
 		"node_modules/@comunica/actor-query-operation-filter": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-filter/-/actor-query-operation-filter-5.1.3.tgz",
-			"integrity": "sha512-dR7oydhaamslDRUubtT5vJNe7VOFPOmT+of7eesn2GOV+VQXzps0RHxTaG85wrOOrM+JU6MVrRgE+Mtp6ZSQcA==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-filter/-/actor-query-operation-filter-5.2.0.tgz",
+			"integrity": "sha512-Qxs52U7llZi3/ANJJFs+kDwkHfdn0GQQ9vZUGps4X/uJub/+Bvqm5B1T6X4lJD9JOzRKWDNglh3rQN3a2yewTA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-expression-evaluator-factory": "^5.1.3",
-				"@comunica/bus-query-operation": "^5.1.3",
-				"@comunica/core": "^5.1.3",
-				"@comunica/types": "^5.1.3",
-				"@comunica/utils-algebra": "^5.1.3",
-				"@comunica/utils-bindings-factory": "^5.1.3",
-				"@comunica/utils-expression-evaluator": "^5.1.3",
-				"@comunica/utils-query-operation": "^5.1.3"
+				"@comunica/bus-expression-evaluator-factory": "^5.2.0",
+				"@comunica/bus-query-operation": "^5.2.0",
+				"@comunica/core": "^5.2.0",
+				"@comunica/types": "^5.2.0",
+				"@comunica/utils-algebra": "^5.2.0",
+				"@comunica/utils-bindings-factory": "^5.2.0",
+				"@comunica/utils-expression-evaluator": "^5.2.0",
+				"@comunica/utils-query-operation": "^5.2.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -2135,17 +2141,17 @@
 			}
 		},
 		"node_modules/@comunica/actor-query-operation-from-quad": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-from-quad/-/actor-query-operation-from-quad-5.1.3.tgz",
-			"integrity": "sha512-n1a+UEqJ7QhYQswRmXSzJvYcqKticCmAJoJFDS6qqj1A4IptB2HlH2Xl5oWnKwwZKhzvP0OM2BvHp6aIy9Qdvg==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-from-quad/-/actor-query-operation-from-quad-5.2.0.tgz",
+			"integrity": "sha512-QYdJc9SkFgXbyAXswqrLxeAh5ghTKac7+XGXCRpjcr/SFW5z/nhqrQYGv5Bv4PPnSPcVYrdGkPL9ZZkyDaelcw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-query-operation": "^5.1.3",
-				"@comunica/context-entries": "^5.1.3",
-				"@comunica/core": "^5.1.3",
-				"@comunica/types": "^5.1.3",
-				"@comunica/utils-algebra": "^5.1.3",
+				"@comunica/bus-query-operation": "^5.2.0",
+				"@comunica/context-entries": "^5.2.0",
+				"@comunica/core": "^5.2.0",
+				"@comunica/types": "^5.2.0",
+				"@comunica/utils-algebra": "^5.2.0",
 				"@rdfjs/types": "*"
 			},
 			"funding": {
@@ -2154,21 +2160,21 @@
 			}
 		},
 		"node_modules/@comunica/actor-query-operation-group": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-group/-/actor-query-operation-group-5.1.3.tgz",
-			"integrity": "sha512-fcIWFhR2yKHxFxJN/ECgNhpqTzeUfInhCoczxoMXlboaF80i1p5Q7WvUS74JTpd1NLtU3tjrHdNDIsG8ZaH3gQ==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-group/-/actor-query-operation-group-5.2.0.tgz",
+			"integrity": "sha512-XQ7MWOezXGeD71DYPq8dWkExzRdYAxpyoXZpoFaxufN/Hd7jaTwEekokk6tXjw+0fzNx03Af3eBbMNFQBgOMLQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-bindings-aggregator-factory": "^5.1.3",
-				"@comunica/bus-merge-bindings-context": "^5.1.3",
-				"@comunica/bus-query-operation": "^5.1.3",
-				"@comunica/context-entries": "^5.1.3",
-				"@comunica/core": "^5.1.3",
-				"@comunica/types": "^5.1.3",
-				"@comunica/utils-algebra": "^5.1.3",
-				"@comunica/utils-bindings-factory": "^5.1.3",
-				"@comunica/utils-query-operation": "^5.1.3",
+				"@comunica/bus-bindings-aggregator-factory": "^5.2.0",
+				"@comunica/bus-merge-bindings-context": "^5.2.0",
+				"@comunica/bus-query-operation": "^5.2.0",
+				"@comunica/context-entries": "^5.2.0",
+				"@comunica/core": "^5.2.0",
+				"@comunica/types": "^5.2.0",
+				"@comunica/utils-algebra": "^5.2.0",
+				"@comunica/utils-bindings-factory": "^5.2.0",
+				"@comunica/utils-query-operation": "^5.2.0",
 				"@rdfjs/types": "*",
 				"asynciterator": "^3.10.0"
 			},
@@ -2178,19 +2184,19 @@
 			}
 		},
 		"node_modules/@comunica/actor-query-operation-join": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-join/-/actor-query-operation-join-5.1.3.tgz",
-			"integrity": "sha512-9BMLJLcc1GSEDo+vMj5pRBnBR8/CZ2aNka9wtFrzNOz0g176et1I8vx/embZ5e9NmHK0oQaZMVCKaXVzc9cXOg==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-join/-/actor-query-operation-join-5.2.0.tgz",
+			"integrity": "sha512-+iv/kftaUUVMc45pXG3qtHDEqCLX6E1JqX1fJI7tc2Wabx2T/P4rGeHl/emsp9dSIbsMWJ/RvnZ8fxAAQkflng==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-query-operation": "^5.1.3",
-				"@comunica/bus-rdf-join": "^5.1.3",
-				"@comunica/core": "^5.1.3",
-				"@comunica/types": "^5.1.3",
-				"@comunica/utils-algebra": "^5.1.3",
-				"@comunica/utils-metadata": "^5.1.3",
-				"@comunica/utils-query-operation": "^5.1.3",
+				"@comunica/bus-query-operation": "^5.2.0",
+				"@comunica/bus-rdf-join": "^5.2.0",
+				"@comunica/core": "^5.2.0",
+				"@comunica/types": "^5.2.0",
+				"@comunica/utils-algebra": "^5.2.0",
+				"@comunica/utils-metadata": "^5.2.0",
+				"@comunica/utils-query-operation": "^5.2.0",
 				"@rdfjs/types": "*",
 				"asynciterator": "^3.10.0",
 				"rdf-data-factory": "^2.0.0"
@@ -2201,19 +2207,19 @@
 			}
 		},
 		"node_modules/@comunica/actor-query-operation-leftjoin": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-leftjoin/-/actor-query-operation-leftjoin-5.1.3.tgz",
-			"integrity": "sha512-xrUySlJ1/Gc32afciLJ+bQ/WdqeV5TNpFeE6yZiKIWN3GlWYVL1q/qHaABbEhkyN/9bdZLS6iB3O53SDByWoDg==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-leftjoin/-/actor-query-operation-leftjoin-5.2.0.tgz",
+			"integrity": "sha512-mXJnMgrK6q+LfxU8XrqbeYhQNrrYPi9W3RylVpzWz3wuqsprXK99V5ke6bL7ivREqIXro1RQ+XQNucV/Df9fHQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-query-operation": "^5.1.3",
-				"@comunica/bus-rdf-join": "^5.1.3",
-				"@comunica/context-entries": "^5.1.3",
-				"@comunica/core": "^5.1.3",
-				"@comunica/types": "^5.1.3",
-				"@comunica/utils-algebra": "^5.1.3",
-				"@comunica/utils-query-operation": "^5.1.3"
+				"@comunica/bus-query-operation": "^5.2.0",
+				"@comunica/bus-rdf-join": "^5.2.0",
+				"@comunica/context-entries": "^5.2.0",
+				"@comunica/core": "^5.2.0",
+				"@comunica/types": "^5.2.0",
+				"@comunica/utils-algebra": "^5.2.0",
+				"@comunica/utils-query-operation": "^5.2.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -2221,18 +2227,37 @@
 			}
 		},
 		"node_modules/@comunica/actor-query-operation-minus": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-minus/-/actor-query-operation-minus-5.1.3.tgz",
-			"integrity": "sha512-q6UA5eemPhdOFH9QUCUHB1nYuCyzrrqt5Rh3rmB0swDL9CcNs+bZES150oMe7GDq8JfKGRdebJEf0wycqJFHLQ==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-minus/-/actor-query-operation-minus-5.2.0.tgz",
+			"integrity": "sha512-j6vediTttbPdwolz1S69pgSMzLjzrecu3/JrHI5gOLp/ANjf3JbiiSzK8G2G79SvzQP43JvcOIVJx2DhN/s1vg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-query-operation": "^5.1.3",
-				"@comunica/bus-rdf-join": "^5.1.3",
-				"@comunica/core": "^5.1.3",
-				"@comunica/types": "^5.1.3",
-				"@comunica/utils-algebra": "^5.1.3",
-				"@comunica/utils-query-operation": "^5.1.3"
+				"@comunica/bus-query-operation": "^5.2.0",
+				"@comunica/bus-rdf-join": "^5.2.0",
+				"@comunica/core": "^5.2.0",
+				"@comunica/types": "^5.2.0",
+				"@comunica/utils-algebra": "^5.2.0",
+				"@comunica/utils-query-operation": "^5.2.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/comunica-association"
+			}
+		},
+		"node_modules/@comunica/actor-query-operation-nodes": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-nodes/-/actor-query-operation-nodes-5.2.0.tgz",
+			"integrity": "sha512-2aD5I6AfVqMqX1zXfCAGDmWWGCmMRly5BCazNFJc7Y6sgDVx/P9ksIYr6hVqs2cedzzpLCPuiwu5RIzEbRHT7A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@comunica/bus-query-operation": "^5.2.0",
+				"@comunica/context-entries": "^5.2.0",
+				"@comunica/core": "^5.2.0",
+				"@comunica/types": "^5.2.0",
+				"@comunica/utils-algebra": "^5.2.0",
+				"@comunica/utils-query-operation": "^5.2.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -2240,20 +2265,20 @@
 			}
 		},
 		"node_modules/@comunica/actor-query-operation-nop": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-nop/-/actor-query-operation-nop-5.1.3.tgz",
-			"integrity": "sha512-qsUBnqt/AM2T+Wb3SfSabg9rdq97Qwl8YIlQe0E/RqeoFXvEvfPwUEc6NYzoEXeAqDwwTcxNVsL3KiZNvb1XUw==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-nop/-/actor-query-operation-nop-5.2.0.tgz",
+			"integrity": "sha512-SwcNRi3IejTOxG3RmEk4Uuz9pEWL50XBEKo9idYUptRlY2PxwWvo2MsSFVCiy5K/ynaH5XzzpyK9f7l2lVitzw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-merge-bindings-context": "^5.1.3",
-				"@comunica/bus-query-operation": "^5.1.3",
-				"@comunica/context-entries": "^5.1.3",
-				"@comunica/core": "^5.1.3",
-				"@comunica/types": "^5.1.3",
-				"@comunica/utils-algebra": "^5.1.3",
-				"@comunica/utils-bindings-factory": "^5.1.3",
-				"@comunica/utils-metadata": "^5.1.3",
+				"@comunica/bus-merge-bindings-context": "^5.2.0",
+				"@comunica/bus-query-operation": "^5.2.0",
+				"@comunica/context-entries": "^5.2.0",
+				"@comunica/core": "^5.2.0",
+				"@comunica/types": "^5.2.0",
+				"@comunica/utils-algebra": "^5.2.0",
+				"@comunica/utils-bindings-factory": "^5.2.0",
+				"@comunica/utils-metadata": "^5.2.0",
 				"@rdfjs/types": "*",
 				"asynciterator": "^3.10.0"
 			},
@@ -2263,20 +2288,20 @@
 			}
 		},
 		"node_modules/@comunica/actor-query-operation-orderby": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-orderby/-/actor-query-operation-orderby-5.1.3.tgz",
-			"integrity": "sha512-iC3G5KdGbIyKIfnsNqdwp2la2eMtDG+kujv8BE3Y4/q6eLzRvTVid/RaJQyQfg4ZQIPbbCEWc5W8UBKG0OUAYA==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-orderby/-/actor-query-operation-orderby-5.2.0.tgz",
+			"integrity": "sha512-KQJMZHUasdBjMuIZ2E0FHZXBNAXWkgv+N0MG74SqABtNv5zD8bZxraAI88fx2fUBUwSrNPz5EYAgDopcbJudNA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-expression-evaluator-factory": "^5.1.3",
-				"@comunica/bus-query-operation": "^5.1.3",
-				"@comunica/bus-term-comparator-factory": "^5.1.3",
-				"@comunica/core": "^5.1.3",
-				"@comunica/types": "^5.1.3",
-				"@comunica/utils-algebra": "^5.1.3",
-				"@comunica/utils-expression-evaluator": "^5.1.3",
-				"@comunica/utils-query-operation": "^5.1.3",
+				"@comunica/bus-expression-evaluator-factory": "^5.2.0",
+				"@comunica/bus-query-operation": "^5.2.0",
+				"@comunica/bus-term-comparator-factory": "^5.2.0",
+				"@comunica/core": "^5.2.0",
+				"@comunica/types": "^5.2.0",
+				"@comunica/utils-algebra": "^5.2.0",
+				"@comunica/utils-expression-evaluator": "^5.2.0",
+				"@comunica/utils-query-operation": "^5.2.0",
 				"asynciterator": "^3.10.0"
 			},
 			"funding": {
@@ -2285,20 +2310,20 @@
 			}
 		},
 		"node_modules/@comunica/actor-query-operation-path-alt": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-alt/-/actor-query-operation-path-alt-5.1.3.tgz",
-			"integrity": "sha512-1TnXdLxkipPGyG2a/yISU4eMjr2WzTkLoxijmoVK4jXGmcJD+mGBnhocsUJPnfg+wOATwBIlfdLg7uoS9sMAqA==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-alt/-/actor-query-operation-path-alt-5.2.0.tgz",
+			"integrity": "sha512-TZLwAmrDO840ZyeWDDhJjLKq7mu4dkJVLDwOrlk2nGBfqtPKCbzZ3R9uvZ8b0xUb581JxMkwsozoKa01PYT8QQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/actor-abstract-path": "^5.1.3",
-				"@comunica/actor-query-operation-union": "^5.1.3",
-				"@comunica/bus-query-operation": "^5.1.3",
-				"@comunica/bus-rdf-metadata-accumulate": "^5.1.3",
-				"@comunica/context-entries": "^5.1.3",
-				"@comunica/types": "^5.1.3",
-				"@comunica/utils-algebra": "^5.1.3",
-				"@comunica/utils-query-operation": "^5.1.3",
+				"@comunica/actor-abstract-path": "^5.2.0",
+				"@comunica/actor-query-operation-union": "^5.2.0",
+				"@comunica/bus-query-operation": "^5.2.0",
+				"@comunica/bus-rdf-metadata-accumulate": "^5.2.0",
+				"@comunica/context-entries": "^5.2.0",
+				"@comunica/types": "^5.2.0",
+				"@comunica/utils-algebra": "^5.2.0",
+				"@comunica/utils-query-operation": "^5.2.0",
 				"asynciterator": "^3.10.0"
 			},
 			"funding": {
@@ -2307,17 +2332,17 @@
 			}
 		},
 		"node_modules/@comunica/actor-query-operation-path-inv": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-inv/-/actor-query-operation-path-inv-5.1.3.tgz",
-			"integrity": "sha512-oGgJlytnxxacq359eu5gDGjwRPj2le/rG6u4p8bgIR/mBb8oD+v3Wbt9BVXcjskDk0/j2L0fvk1FH3MzWhPtfA==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-inv/-/actor-query-operation-path-inv-5.2.0.tgz",
+			"integrity": "sha512-BUNi60L+bIjGQ9H89etYSWgReDfKACBb0KyQb5nysXFPFFSm12MaRL6aT8annxCDnkTrQ07PpM7xhMq+f9+qFA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/actor-abstract-path": "^5.1.3",
-				"@comunica/bus-query-operation": "^5.1.3",
-				"@comunica/context-entries": "^5.1.3",
-				"@comunica/types": "^5.1.3",
-				"@comunica/utils-algebra": "^5.1.3"
+				"@comunica/actor-abstract-path": "^5.2.0",
+				"@comunica/bus-query-operation": "^5.2.0",
+				"@comunica/context-entries": "^5.2.0",
+				"@comunica/types": "^5.2.0",
+				"@comunica/utils-algebra": "^5.2.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -2325,17 +2350,17 @@
 			}
 		},
 		"node_modules/@comunica/actor-query-operation-path-link": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-link/-/actor-query-operation-path-link-5.1.3.tgz",
-			"integrity": "sha512-Qe3XAFvBiQJmdUhiK3bl6niS6ZpvXDqFRg/ypZjLPiK5vk5RVfqTRue7+eVLsc30kdOdSUFqh/TY4cUZFuArtQ==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-link/-/actor-query-operation-path-link-5.2.0.tgz",
+			"integrity": "sha512-Y5Ei6S9UYerjcXqnh6cCpcW8QYaas2aeYJab2gxgoIBK81ro18VainhAPfgB3nb3xXi0x85Kmoyz5VqW/gUMhw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/actor-abstract-path": "^5.1.3",
-				"@comunica/bus-query-operation": "^5.1.3",
-				"@comunica/context-entries": "^5.1.3",
-				"@comunica/types": "^5.1.3",
-				"@comunica/utils-algebra": "^5.1.3"
+				"@comunica/actor-abstract-path": "^5.2.0",
+				"@comunica/bus-query-operation": "^5.2.0",
+				"@comunica/context-entries": "^5.2.0",
+				"@comunica/types": "^5.2.0",
+				"@comunica/utils-algebra": "^5.2.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -2343,18 +2368,18 @@
 			}
 		},
 		"node_modules/@comunica/actor-query-operation-path-nps": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-nps/-/actor-query-operation-path-nps-5.1.3.tgz",
-			"integrity": "sha512-zSX7dAudTFTJ2YTjhvkjSXIVhlSJyFAMwxQSP6Z014Sa8qQVrRFjHElCFZEIf1cwtxD4PIk0NpqWH/a3GAhkFA==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-nps/-/actor-query-operation-path-nps-5.2.0.tgz",
+			"integrity": "sha512-UaMRCjhB6O7uqDXUusHeRPrhXZ3GTEPQ9kduploQ2dZGH0nUPWYpJX0MHNsPIC1ViX2f37y7axXI9FF3KKir6A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/actor-abstract-path": "^5.1.3",
-				"@comunica/bus-query-operation": "^5.1.3",
-				"@comunica/context-entries": "^5.1.3",
-				"@comunica/types": "^5.1.3",
-				"@comunica/utils-algebra": "^5.1.3",
-				"@comunica/utils-query-operation": "^5.1.3"
+				"@comunica/actor-abstract-path": "^5.2.0",
+				"@comunica/bus-query-operation": "^5.2.0",
+				"@comunica/context-entries": "^5.2.0",
+				"@comunica/types": "^5.2.0",
+				"@comunica/utils-algebra": "^5.2.0",
+				"@comunica/utils-query-operation": "^5.2.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -2362,20 +2387,20 @@
 			}
 		},
 		"node_modules/@comunica/actor-query-operation-path-one-or-more": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-one-or-more/-/actor-query-operation-path-one-or-more-5.1.3.tgz",
-			"integrity": "sha512-ZwfyEKtCvDFY1N5DeFSc7WZJIfUtIMyJkAqsDVP3zgqQW4cbsXcsuGXgr/P7P+TcPtn47cESspGGnX61BB4RlA==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-one-or-more/-/actor-query-operation-path-one-or-more-5.2.0.tgz",
+			"integrity": "sha512-5170BWmligcDLESxMO1f4WkhWZsE2MoUiwp5PO8I7cbO6oG1hZMs75quGDl86QEB+NmXCnByr/kSXAegwCC8Rg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/actor-abstract-path": "^5.1.3",
-				"@comunica/bus-merge-bindings-context": "^5.1.3",
-				"@comunica/bus-query-operation": "^5.1.3",
-				"@comunica/context-entries": "^5.1.3",
-				"@comunica/types": "^5.1.3",
-				"@comunica/utils-algebra": "^5.1.3",
-				"@comunica/utils-bindings-factory": "^5.1.3",
-				"@comunica/utils-query-operation": "^5.1.3",
+				"@comunica/actor-abstract-path": "^5.2.0",
+				"@comunica/bus-merge-bindings-context": "^5.2.0",
+				"@comunica/bus-query-operation": "^5.2.0",
+				"@comunica/context-entries": "^5.2.0",
+				"@comunica/types": "^5.2.0",
+				"@comunica/utils-algebra": "^5.2.0",
+				"@comunica/utils-bindings-factory": "^5.2.0",
+				"@comunica/utils-query-operation": "^5.2.0",
 				"asynciterator": "^3.10.0"
 			},
 			"funding": {
@@ -2384,19 +2409,19 @@
 			}
 		},
 		"node_modules/@comunica/actor-query-operation-path-seq": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-seq/-/actor-query-operation-path-seq-5.1.3.tgz",
-			"integrity": "sha512-iEoGvlHtLHnj5n9tWfFoePGglWft2cFmZyrxEHm8rZqLV/4vLk0LI6i38kc4a3HSAAwTRVPtbnx4140bXCfJfA==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-seq/-/actor-query-operation-path-seq-5.2.0.tgz",
+			"integrity": "sha512-9KlRlI9zks27dZ4ndO/RxIkuFJyF2KKguBhEAnjtr7rZ8vSJxg2ovsCvfF6NZkoBOVqgjAjdoIAqzH2gQOeEBQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/actor-abstract-path": "^5.1.3",
-				"@comunica/bus-query-operation": "^5.1.3",
-				"@comunica/bus-rdf-join": "^5.1.3",
-				"@comunica/context-entries": "^5.1.3",
-				"@comunica/types": "^5.1.3",
-				"@comunica/utils-algebra": "^5.1.3",
-				"@comunica/utils-query-operation": "^5.1.3"
+				"@comunica/actor-abstract-path": "^5.2.0",
+				"@comunica/bus-query-operation": "^5.2.0",
+				"@comunica/bus-rdf-join": "^5.2.0",
+				"@comunica/context-entries": "^5.2.0",
+				"@comunica/types": "^5.2.0",
+				"@comunica/utils-algebra": "^5.2.0",
+				"@comunica/utils-query-operation": "^5.2.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -2404,22 +2429,20 @@
 			}
 		},
 		"node_modules/@comunica/actor-query-operation-path-zero-or-more": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-zero-or-more/-/actor-query-operation-path-zero-or-more-5.1.3.tgz",
-			"integrity": "sha512-r4kSzraaJc+X/NUz+bTKKu7hlYUc6r8MQkqUJlWlK9zTs8s858pX2UQ1pGwzvrw1Q89WzUeYjxH6hE7IgobWjg==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-zero-or-more/-/actor-query-operation-path-zero-or-more-5.2.0.tgz",
+			"integrity": "sha512-gwHYiRY2Qzr1vER9c8v99JXUT/lX8yzwsbCwggWjyIqjLIRCqdAY1nmvYe0QimTdD7VPuBPYc+50y+SIoyyBiQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/actor-abstract-path": "^5.1.3",
-				"@comunica/bus-merge-bindings-context": "^5.1.3",
-				"@comunica/bus-query-operation": "^5.1.3",
-				"@comunica/context-entries": "^5.1.3",
-				"@comunica/types": "^5.1.3",
-				"@comunica/utils-algebra": "^5.1.3",
-				"@comunica/utils-bindings-factory": "^5.1.3",
-				"@comunica/utils-query-operation": "^5.1.3",
-				"asynciterator": "^3.10.0",
-				"rdf-string": "^2.0.1"
+				"@comunica/actor-abstract-path": "^5.2.0",
+				"@comunica/bus-merge-bindings-context": "^5.2.0",
+				"@comunica/bus-query-operation": "^5.2.0",
+				"@comunica/context-entries": "^5.2.0",
+				"@comunica/types": "^5.2.0",
+				"@comunica/utils-algebra": "^5.2.0",
+				"@comunica/utils-bindings-factory": "^5.2.0",
+				"asynciterator": "^3.10.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -2427,21 +2450,21 @@
 			}
 		},
 		"node_modules/@comunica/actor-query-operation-path-zero-or-one": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-zero-or-one/-/actor-query-operation-path-zero-or-one-5.1.3.tgz",
-			"integrity": "sha512-T1pxhiz8HdMyjN1ZVBOnBS9ZX0W6wvwN3GdVVH+Xx5HKdh/H8hWA+mKKc/r8L+VloOWDo1c+PjrtIMus46aRSg==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-zero-or-one/-/actor-query-operation-path-zero-or-one-5.2.0.tgz",
+			"integrity": "sha512-auprxlLVkptxbRh09TB2FeuZBQW1HIGMB8zX4GIiOh/v3wzLvwO915ExLU/5mw4HEoKqZUU73kveqW2MvnL92g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/actor-abstract-path": "^5.1.3",
-				"@comunica/bus-merge-bindings-context": "^5.1.3",
-				"@comunica/bus-query-operation": "^5.1.3",
-				"@comunica/context-entries": "^5.1.3",
-				"@comunica/types": "^5.1.3",
-				"@comunica/utils-algebra": "^5.1.3",
-				"@comunica/utils-bindings-factory": "^5.1.3",
-				"@comunica/utils-metadata": "^5.1.3",
-				"@comunica/utils-query-operation": "^5.1.3",
+				"@comunica/actor-abstract-path": "^5.2.0",
+				"@comunica/bus-merge-bindings-context": "^5.2.0",
+				"@comunica/bus-query-operation": "^5.2.0",
+				"@comunica/context-entries": "^5.2.0",
+				"@comunica/types": "^5.2.0",
+				"@comunica/utils-algebra": "^5.2.0",
+				"@comunica/utils-bindings-factory": "^5.2.0",
+				"@comunica/utils-metadata": "^5.2.0",
+				"@comunica/utils-query-operation": "^5.2.0",
 				"asynciterator": "^3.10.0"
 			},
 			"funding": {
@@ -2450,19 +2473,19 @@
 			}
 		},
 		"node_modules/@comunica/actor-query-operation-project": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-project/-/actor-query-operation-project-5.1.3.tgz",
-			"integrity": "sha512-TlK6zHhrnoJc4PmSuxkY1oA62jMsNWgSnrJXvumgsLZO0XvP73bK8UDi7x4eCZReG1oTsBAwZF7BKJqgFJl22w==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-project/-/actor-query-operation-project-5.2.0.tgz",
+			"integrity": "sha512-NiUCN/Gem5SbrboLZ7+eHT0HXRQWiEbpQv//zuEsOvBlwE7UCSbu1lfV+GgMLXZEwAsDFMW4h+Rwwo3WFbp8zQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-query-operation": "^5.1.3",
-				"@comunica/context-entries": "^5.1.3",
-				"@comunica/core": "^5.1.3",
-				"@comunica/types": "^5.1.3",
-				"@comunica/utils-algebra": "^5.1.3",
+				"@comunica/bus-query-operation": "^5.2.0",
+				"@comunica/context-entries": "^5.2.0",
+				"@comunica/core": "^5.2.0",
+				"@comunica/types": "^5.2.0",
+				"@comunica/utils-algebra": "^5.2.0",
 				"@comunica/utils-data-factory": "^5.0.0",
-				"@comunica/utils-query-operation": "^5.1.3",
+				"@comunica/utils-query-operation": "^5.2.0",
 				"@rdfjs/types": "*"
 			},
 			"funding": {
@@ -2471,18 +2494,18 @@
 			}
 		},
 		"node_modules/@comunica/actor-query-operation-reduced-hash": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-reduced-hash/-/actor-query-operation-reduced-hash-5.1.3.tgz",
-			"integrity": "sha512-ZJh2GX94Lp+/+c8SJ9CKAtiziyFiwmR75kNgQoerq8DelLmx7pgmhiEn8bOYj2vEVHobwo1BiflMIFUOBIEiEg==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-reduced-hash/-/actor-query-operation-reduced-hash-5.2.0.tgz",
+			"integrity": "sha512-jhljPCqCqX46BzdKMwPy9MB8naXqon2sjvvMURoy5TVZ+cSF33xya+e5k+L6tjaqO0dll0yhiXrrmK4LpIevTQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-hash-bindings": "^5.1.3",
-				"@comunica/bus-query-operation": "^5.1.3",
-				"@comunica/core": "^5.1.3",
-				"@comunica/types": "^5.1.3",
-				"@comunica/utils-algebra": "^5.1.3",
-				"@comunica/utils-query-operation": "^5.1.3",
+				"@comunica/bus-hash-bindings": "^5.2.0",
+				"@comunica/bus-query-operation": "^5.2.0",
+				"@comunica/core": "^5.2.0",
+				"@comunica/types": "^5.2.0",
+				"@comunica/utils-algebra": "^5.2.0",
+				"@comunica/utils-query-operation": "^5.2.0",
 				"@rdfjs/types": "*",
 				"lru-cache": "^11.2.2"
 			},
@@ -2492,17 +2515,17 @@
 			}
 		},
 		"node_modules/@comunica/actor-query-operation-slice": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-slice/-/actor-query-operation-slice-5.1.3.tgz",
-			"integrity": "sha512-IGirpu0mB/jzmRTRNb695ORi7XgmQtJ7871hkIZjmuUTUqaZO2nssKj7gAvsliq0Vh9fEL+e7Td1NSOPCgJLtw==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-slice/-/actor-query-operation-slice-5.2.0.tgz",
+			"integrity": "sha512-Ew6ixGy+N+GDrGGfemuowndEiVP1Lnold84zE0TmtQ8euxcvfuFsqNyl+Qdt/op9oDnxr4+OSDg3/kmErCNfmA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-query-operation": "^5.1.3",
-				"@comunica/context-entries": "^5.1.3",
-				"@comunica/core": "^5.1.3",
-				"@comunica/types": "^5.1.3",
-				"@comunica/utils-algebra": "^5.1.3"
+				"@comunica/bus-query-operation": "^5.2.0",
+				"@comunica/context-entries": "^5.2.0",
+				"@comunica/core": "^5.2.0",
+				"@comunica/types": "^5.2.0",
+				"@comunica/utils-algebra": "^5.2.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -2510,19 +2533,19 @@
 			}
 		},
 		"node_modules/@comunica/actor-query-operation-source": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-source/-/actor-query-operation-source-5.1.3.tgz",
-			"integrity": "sha512-NQJW48VhoamebHzdxBXj07YkBTEoxEwp0cj9o62NeP6qJP1J+P/Ij29APhYwMAV+3Tc2DcUw82Ljq2yf/gLCqQ==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-source/-/actor-query-operation-source-5.2.0.tgz",
+			"integrity": "sha512-geI4xa2qV3+MOzrw7/xyroTJzkOVE4oLW8DPAn7KjUpN23tWYuHgfWhm2zRcB19IhK64BrE60od3K4FmbjssAA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-query-operation": "^5.1.3",
-				"@comunica/context-entries": "^5.1.3",
-				"@comunica/core": "^5.1.3",
-				"@comunica/types": "^5.1.3",
-				"@comunica/utils-algebra": "^5.1.3",
-				"@comunica/utils-metadata": "^5.1.3",
-				"@comunica/utils-query-operation": "^5.1.3"
+				"@comunica/bus-query-operation": "^5.2.0",
+				"@comunica/context-entries": "^5.2.0",
+				"@comunica/core": "^5.2.0",
+				"@comunica/types": "^5.2.0",
+				"@comunica/utils-algebra": "^5.2.0",
+				"@comunica/utils-metadata": "^5.2.0",
+				"@comunica/utils-query-operation": "^5.2.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -2530,19 +2553,19 @@
 			}
 		},
 		"node_modules/@comunica/actor-query-operation-union": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-union/-/actor-query-operation-union-5.1.3.tgz",
-			"integrity": "sha512-HQLDkQkmO5fmvQauH+niQJ9q0KGnHH+6UBn9VGQA28ptpGtn5D+xX+yYcRBaNxF5Y3t/0Se0RG/0PashhwCj4A==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-union/-/actor-query-operation-union-5.2.0.tgz",
+			"integrity": "sha512-16cuPi3Tz7ek3dUEh5EHRs1Zv0f80QhQpkjw3epbmUKC2+riBxOyMNSS71l62jG5OzSOvM70IImslu/IDS6IjA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-query-operation": "^5.1.3",
-				"@comunica/bus-rdf-metadata-accumulate": "^5.1.3",
-				"@comunica/core": "^5.1.3",
-				"@comunica/types": "^5.1.3",
-				"@comunica/utils-algebra": "^5.1.3",
-				"@comunica/utils-metadata": "^5.1.3",
-				"@comunica/utils-query-operation": "^5.1.3",
+				"@comunica/bus-query-operation": "^5.2.0",
+				"@comunica/bus-rdf-metadata-accumulate": "^5.2.0",
+				"@comunica/core": "^5.2.0",
+				"@comunica/types": "^5.2.0",
+				"@comunica/utils-algebra": "^5.2.0",
+				"@comunica/utils-metadata": "^5.2.0",
+				"@comunica/utils-query-operation": "^5.2.0",
 				"asynciterator": "^3.10.0"
 			},
 			"funding": {
@@ -2551,19 +2574,19 @@
 			}
 		},
 		"node_modules/@comunica/actor-query-operation-update-clear": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-update-clear/-/actor-query-operation-update-clear-5.1.3.tgz",
-			"integrity": "sha512-dwR6nn0kKXWcAAFNIKl4WpoMJtPweP4kwo8a9qTu4JaYqk7RGRgrJi8ufzHTifFVzqlLafs811PWe52h25YzyA==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-update-clear/-/actor-query-operation-update-clear-5.2.0.tgz",
+			"integrity": "sha512-QAR88RxSR/5VE+uSTeZ+cLOjvvy88/kszvSIGK/hNLDiK3NDRz6PPLh8g/srSJsedapbJhdmyFLSS8OmkxpmHw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-query-operation": "^5.1.3",
-				"@comunica/bus-rdf-update-quads": "^5.1.3",
-				"@comunica/context-entries": "^5.1.3",
-				"@comunica/core": "^5.1.3",
-				"@comunica/types": "^5.1.3",
-				"@comunica/utils-algebra": "^5.1.3",
-				"@comunica/utils-query-operation": "^5.1.3",
+				"@comunica/bus-query-operation": "^5.2.0",
+				"@comunica/bus-rdf-update-quads": "^5.2.0",
+				"@comunica/context-entries": "^5.2.0",
+				"@comunica/core": "^5.2.0",
+				"@comunica/types": "^5.2.0",
+				"@comunica/utils-algebra": "^5.2.0",
+				"@comunica/utils-query-operation": "^5.2.0",
 				"@rdfjs/types": "*"
 			},
 			"funding": {
@@ -2572,17 +2595,17 @@
 			}
 		},
 		"node_modules/@comunica/actor-query-operation-update-compositeupdate": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-update-compositeupdate/-/actor-query-operation-update-compositeupdate-5.1.3.tgz",
-			"integrity": "sha512-LuIsU2TXaCWKNdUNQDGphgKfni+O/8PNwdR773YE67vpIEY8hC7uorrvh0FGn0hWr7aAGhZGJyGkb0Oy2XMkSA==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-update-compositeupdate/-/actor-query-operation-update-compositeupdate-5.2.0.tgz",
+			"integrity": "sha512-2UfJGUcdL1yijjljB533B3J/nnKs23JK87catiHJmk5HLfQ/gOIHe+MjzpIA57xBCHa/QUEQfxCpW7j+b2+8EQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-query-operation": "^5.1.3",
-				"@comunica/core": "^5.1.3",
-				"@comunica/types": "^5.1.3",
-				"@comunica/utils-algebra": "^5.1.3",
-				"@comunica/utils-query-operation": "^5.1.3"
+				"@comunica/bus-query-operation": "^5.2.0",
+				"@comunica/core": "^5.2.0",
+				"@comunica/types": "^5.2.0",
+				"@comunica/utils-algebra": "^5.2.0",
+				"@comunica/utils-query-operation": "^5.2.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -2590,18 +2613,18 @@
 			}
 		},
 		"node_modules/@comunica/actor-query-operation-update-create": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-update-create/-/actor-query-operation-update-create-5.1.3.tgz",
-			"integrity": "sha512-I3ct5yxqQQWzxMUcdAcF41tGBCkoRBNRQYaF6JY7eZ4TRfmjdky+pXjnXK33vkJYRJyJ1Wy8kx+fNGGzvEQ3uQ==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-update-create/-/actor-query-operation-update-create-5.2.0.tgz",
+			"integrity": "sha512-s8dPwt0vKz+dnX0Og4DvEhwEF4eNc5TlsGRfODtuQscQ+KmpnK2y3CBCp7Mbq7W1ppns7/QaIA5fTtaeLquatA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-query-operation": "^5.1.3",
-				"@comunica/bus-rdf-update-quads": "^5.1.3",
-				"@comunica/core": "^5.1.3",
-				"@comunica/types": "^5.1.3",
-				"@comunica/utils-algebra": "^5.1.3",
-				"@comunica/utils-query-operation": "^5.1.3"
+				"@comunica/bus-query-operation": "^5.2.0",
+				"@comunica/bus-rdf-update-quads": "^5.2.0",
+				"@comunica/core": "^5.2.0",
+				"@comunica/types": "^5.2.0",
+				"@comunica/utils-algebra": "^5.2.0",
+				"@comunica/utils-query-operation": "^5.2.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -2609,22 +2632,22 @@
 			}
 		},
 		"node_modules/@comunica/actor-query-operation-update-deleteinsert": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-update-deleteinsert/-/actor-query-operation-update-deleteinsert-5.1.3.tgz",
-			"integrity": "sha512-s2PD+xOJCtBbnSJf9YPCBf5wVkXp2S2oudY6SkFsN8oUTc6wxet0aowzuKTivB9ykob72AAZYKazOime0LTsDQ==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-update-deleteinsert/-/actor-query-operation-update-deleteinsert-5.2.0.tgz",
+			"integrity": "sha512-fn9u8l4urz4NrB20mNuEknVtaO4YLi7HcbPSLsozQErYD+aDMiJxpQEgdcZjK8FXHscuCIBmivUOthQpnALU2A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/actor-query-operation-construct": "^5.1.3",
-				"@comunica/bus-merge-bindings-context": "^5.1.3",
-				"@comunica/bus-query-operation": "^5.1.3",
-				"@comunica/bus-rdf-update-quads": "^5.1.3",
-				"@comunica/context-entries": "^5.1.3",
-				"@comunica/core": "^5.1.3",
-				"@comunica/types": "^5.1.3",
-				"@comunica/utils-algebra": "^5.1.3",
-				"@comunica/utils-bindings-factory": "^5.1.3",
-				"@comunica/utils-query-operation": "^5.1.3",
+				"@comunica/actor-query-operation-construct": "^5.2.0",
+				"@comunica/bus-merge-bindings-context": "^5.2.0",
+				"@comunica/bus-query-operation": "^5.2.0",
+				"@comunica/bus-rdf-update-quads": "^5.2.0",
+				"@comunica/context-entries": "^5.2.0",
+				"@comunica/core": "^5.2.0",
+				"@comunica/types": "^5.2.0",
+				"@comunica/utils-algebra": "^5.2.0",
+				"@comunica/utils-bindings-factory": "^5.2.0",
+				"@comunica/utils-query-operation": "^5.2.0",
 				"@rdfjs/types": "*",
 				"asynciterator": "^3.10.0"
 			},
@@ -2634,19 +2657,19 @@
 			}
 		},
 		"node_modules/@comunica/actor-query-operation-update-drop": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-update-drop/-/actor-query-operation-update-drop-5.1.3.tgz",
-			"integrity": "sha512-CO3o2FGhI+seZCKeXM2hpbZ7m47wT21qRBJ872P8aEf/7MJP2Ta92EVNgwIzcYHc4GuE2yaJE1YdRtYgPtASkg==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-update-drop/-/actor-query-operation-update-drop-5.2.0.tgz",
+			"integrity": "sha512-h7cuPcqKG5MpjMnbBnNgDHZHXmwIEct71hJIVgDDEZd2NyUYLfaIfmkGT/jRY7w+f9RgHl/La097wETCQ91PSA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-query-operation": "^5.1.3",
-				"@comunica/bus-rdf-update-quads": "^5.1.3",
-				"@comunica/context-entries": "^5.1.3",
-				"@comunica/core": "^5.1.3",
-				"@comunica/types": "^5.1.3",
-				"@comunica/utils-algebra": "^5.1.3",
-				"@comunica/utils-query-operation": "^5.1.3",
+				"@comunica/bus-query-operation": "^5.2.0",
+				"@comunica/bus-rdf-update-quads": "^5.2.0",
+				"@comunica/context-entries": "^5.2.0",
+				"@comunica/core": "^5.2.0",
+				"@comunica/types": "^5.2.0",
+				"@comunica/utils-algebra": "^5.2.0",
+				"@comunica/utils-query-operation": "^5.2.0",
 				"@rdfjs/types": "*"
 			},
 			"funding": {
@@ -2655,20 +2678,20 @@
 			}
 		},
 		"node_modules/@comunica/actor-query-operation-update-load": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-update-load/-/actor-query-operation-update-load-5.1.3.tgz",
-			"integrity": "sha512-fI7/xx2A0EO/vInE5eNDhYvjPA3fC5AekNiMtpUr/hpA8GoSSspkng3qCuq8eJZkkKJMelA3qiSH9Gvg5DxkmQ==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-update-load/-/actor-query-operation-update-load-5.2.0.tgz",
+			"integrity": "sha512-bsGw9q+bI4MNNwBMOD22eFpKQsddgG3lG7mjGp+oIywXkeZEyAMgmBkmJZAYI9aAo2cbocNz6WQa/fzwteZWMQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-query-operation": "^5.1.3",
-				"@comunica/bus-query-source-identify": "^5.1.3",
-				"@comunica/bus-rdf-update-quads": "^5.1.3",
-				"@comunica/context-entries": "^5.1.3",
-				"@comunica/core": "^5.1.3",
-				"@comunica/types": "^5.1.3",
-				"@comunica/utils-algebra": "^5.1.3",
-				"@comunica/utils-query-operation": "^5.1.3"
+				"@comunica/bus-query-operation": "^5.2.0",
+				"@comunica/bus-query-source-identify": "^5.2.0",
+				"@comunica/bus-rdf-update-quads": "^5.2.0",
+				"@comunica/context-entries": "^5.2.0",
+				"@comunica/core": "^5.2.0",
+				"@comunica/types": "^5.2.0",
+				"@comunica/utils-algebra": "^5.2.0",
+				"@comunica/utils-query-operation": "^5.2.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -2676,20 +2699,20 @@
 			}
 		},
 		"node_modules/@comunica/actor-query-operation-values": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-values/-/actor-query-operation-values-5.1.3.tgz",
-			"integrity": "sha512-Eu19fMgyvQei9IM7C+f1N74XngZUR0/urg5umvN521XccebegzgSw+Wci+PBtFrU3mlESFm/599J3WUw9OEijA==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-values/-/actor-query-operation-values-5.2.0.tgz",
+			"integrity": "sha512-LwRETA06uC5nNEGbYDc2GDXDu3tTsl0VFljy5rAu3HPBsx9cZbjMaofPN6WD+nNF+kpL4Ft5OagKHnmfhxHeZw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-merge-bindings-context": "^5.1.3",
-				"@comunica/bus-query-operation": "^5.1.3",
-				"@comunica/context-entries": "^5.1.3",
-				"@comunica/core": "^5.1.3",
-				"@comunica/types": "^5.1.3",
-				"@comunica/utils-algebra": "^5.1.3",
-				"@comunica/utils-bindings-factory": "^5.1.3",
-				"@comunica/utils-metadata": "^5.1.3",
+				"@comunica/bus-merge-bindings-context": "^5.2.0",
+				"@comunica/bus-query-operation": "^5.2.0",
+				"@comunica/context-entries": "^5.2.0",
+				"@comunica/core": "^5.2.0",
+				"@comunica/types": "^5.2.0",
+				"@comunica/utils-algebra": "^5.2.0",
+				"@comunica/utils-bindings-factory": "^5.2.0",
+				"@comunica/utils-metadata": "^5.2.0",
 				"asynciterator": "^3.10.0"
 			},
 			"funding": {
@@ -2698,15 +2721,15 @@
 			}
 		},
 		"node_modules/@comunica/actor-query-parse-graphql": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-query-parse-graphql/-/actor-query-parse-graphql-5.1.3.tgz",
-			"integrity": "sha512-8qZZ2z/l+tqqZqP0ESJMybLwkloiPS+qeQcvbrGTtBZ+KAxQjZzxcOx7eUfQL06hxe/bqtcHV0b0OGRT+XbT1Q==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-query-parse-graphql/-/actor-query-parse-graphql-5.2.0.tgz",
+			"integrity": "sha512-FQMZNNnzl9nkZQrdG3dzvgonwBTHCI9+CllR/0PFVW8Xc3WsYSDtPMV3wD7sv0bf+frM9bi0Lc3BphF6D8bArA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-query-parse": "^5.1.3",
-				"@comunica/context-entries": "^5.1.3",
-				"@comunica/core": "^5.1.3",
+				"@comunica/bus-query-parse": "^5.2.0",
+				"@comunica/context-entries": "^5.2.0",
+				"@comunica/core": "^5.2.0",
 				"graphql-to-sparql": "^6.0.0"
 			},
 			"funding": {
@@ -2715,16 +2738,16 @@
 			}
 		},
 		"node_modules/@comunica/actor-query-parse-sparql": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-query-parse-sparql/-/actor-query-parse-sparql-5.1.3.tgz",
-			"integrity": "sha512-4yHDWglryUd1alDBu7OW2lKH2tirxE26Z6RtcNPCNA9NNz55gufPJtB1eBwnoq/anNgzAvlwnaZohmDDnLKrGg==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-query-parse-sparql/-/actor-query-parse-sparql-5.2.0.tgz",
+			"integrity": "sha512-kXbMJAne7FYY1NMv/M+btvKr2+cyeUl7p9h2LcOr5pL/ELkYHcq2YF33zYG6SIhXdpukPgqyuR5F9t3LL5c7HQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-query-parse": "^5.1.3",
-				"@comunica/context-entries": "^5.1.3",
-				"@comunica/core": "^5.1.3",
-				"@comunica/types": "^5.1.3",
+				"@comunica/bus-query-parse": "^5.2.0",
+				"@comunica/context-entries": "^5.2.0",
+				"@comunica/core": "^5.2.0",
+				"@comunica/types": "^5.2.0",
 				"@traqula/algebra-sparql-1-2": "^1.0.1",
 				"@traqula/parser-sparql-1-2": "^1.0.1",
 				"@traqula/rules-sparql-1-2": "^1.0.1"
@@ -2735,15 +2758,15 @@
 			}
 		},
 		"node_modules/@comunica/actor-query-process-explain-logical": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-query-process-explain-logical/-/actor-query-process-explain-logical-5.1.3.tgz",
-			"integrity": "sha512-LFXhzoSGVwSXcaYwRD/EN5QhGxtyEVwdQd1hJNtxyalN5qGOt1i69y/fJLI/RQV4Vc4yfVxhdgfpqgEeGUy1+g==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-query-process-explain-logical/-/actor-query-process-explain-logical-5.2.0.tgz",
+			"integrity": "sha512-EI9mQuk91YdKgCViYkrVXBKgntq+5u0AmdrK4SPmK1B8SSIlkQD0SwRnkvB3GrZv8CNefp2ap1Ck4MdtNjTbLA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-query-process": "^5.1.3",
-				"@comunica/context-entries": "^5.1.3",
-				"@comunica/core": "^5.1.3"
+				"@comunica/bus-query-process": "^5.2.0",
+				"@comunica/context-entries": "^5.2.0",
+				"@comunica/core": "^5.2.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -2751,15 +2774,15 @@
 			}
 		},
 		"node_modules/@comunica/actor-query-process-explain-parsed": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-query-process-explain-parsed/-/actor-query-process-explain-parsed-5.1.3.tgz",
-			"integrity": "sha512-836hDnrxSgMohK2zaDhRWTqPWgJXm3KX19QaE+oR4PSoh+fUk84dDYGL6q9Mwgwcg7lihHfbKkHYtdQ0Ye52rg==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-query-process-explain-parsed/-/actor-query-process-explain-parsed-5.2.0.tgz",
+			"integrity": "sha512-bMXVLSOZCPvS+BlmpIdEjgzN5ITjg+yihr4tiNhGlg6KSqPXG/MES/ag4LYMlb2YHbBg79CUWXXRIh1gjKJu2A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-query-process": "^5.1.3",
-				"@comunica/context-entries": "^5.1.3",
-				"@comunica/core": "^5.1.3"
+				"@comunica/bus-query-process": "^5.2.0",
+				"@comunica/context-entries": "^5.2.0",
+				"@comunica/core": "^5.2.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -2767,17 +2790,17 @@
 			}
 		},
 		"node_modules/@comunica/actor-query-process-explain-physical": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-query-process-explain-physical/-/actor-query-process-explain-physical-5.1.3.tgz",
-			"integrity": "sha512-9KEhPFUALAkyfnUghNMubfP9zcVJ4t8e410CljCAyTxdu4iZNQ1Au+7Ny53wNkF1ZYfUwbxxT7tgr+7NYMKdAA==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-query-process-explain-physical/-/actor-query-process-explain-physical-5.2.0.tgz",
+			"integrity": "sha512-Jnb9Z3Z17ThTRiUxgAKko+mA6gfurgjw9GKq0gO+8xpx0zJObrVAZ4iCwAwXCTQjSux+FawQbzV+jPlXoMt+Eg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-query-process": "^5.1.3",
-				"@comunica/context-entries": "^5.1.3",
-				"@comunica/core": "^5.1.3",
-				"@comunica/types": "^5.1.3",
-				"@comunica/utils-algebra": "^5.1.3",
+				"@comunica/bus-query-process": "^5.2.0",
+				"@comunica/context-entries": "^5.2.0",
+				"@comunica/core": "^5.2.0",
+				"@comunica/types": "^5.2.0",
+				"@comunica/utils-algebra": "^5.2.0",
 				"@rdfjs/types": "*",
 				"rdf-string": "^2.0.1"
 			},
@@ -2787,18 +2810,18 @@
 			}
 		},
 		"node_modules/@comunica/actor-query-process-explain-query": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-query-process-explain-query/-/actor-query-process-explain-query-5.1.3.tgz",
-			"integrity": "sha512-ZPAaV3WT5R2lBnOEcNj/NQHeyFippHrQgVegfTTVNe5cTx9eQf/Kn5C/ZLOpISXjGwPiNVBlfmjI/LkIwl6CTg==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-query-process-explain-query/-/actor-query-process-explain-query-5.2.0.tgz",
+			"integrity": "sha512-/SWVPEC+5AjDv+YvQhL9Pj3Q6ibYlbOWJRFa/zSdEyOGL24QBr1cv1gKuf++w8hTuT7Dt7YiPccmtR2K4LW/EA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-query-process": "^5.1.3",
-				"@comunica/bus-query-serialize": "^5.1.3",
-				"@comunica/context-entries": "^5.1.3",
-				"@comunica/core": "^5.1.3",
-				"@comunica/utils-algebra": "^5.1.3",
-				"@comunica/utils-query-operation": "^5.1.3",
+				"@comunica/bus-query-process": "^5.2.0",
+				"@comunica/bus-query-serialize": "^5.2.0",
+				"@comunica/context-entries": "^5.2.0",
+				"@comunica/core": "^5.2.0",
+				"@comunica/utils-algebra": "^5.2.0",
+				"@comunica/utils-query-operation": "^5.2.0",
 				"@rdfjs/types": "*"
 			},
 			"funding": {
@@ -2807,24 +2830,24 @@
 			}
 		},
 		"node_modules/@comunica/actor-query-process-sequential": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-query-process-sequential/-/actor-query-process-sequential-5.1.3.tgz",
-			"integrity": "sha512-5u8mtXzKiG7Nfy50jfMWBDsAlYSMjr962NV+eBfuddE4+ZP+zql0AJRhRtJWx2HW5rinwuuHmRYtJdHeVGLIQQ==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-query-process-sequential/-/actor-query-process-sequential-5.2.0.tgz",
+			"integrity": "sha512-yCDnd7DVb0xI/rGs0evLT5LMN26wWJ87Pxs4NpJS+LwUt8l1C1yV39ebPE211XGBnsqh64l6Lo/dKSUVxWnaXA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-context-preprocess": "^5.1.3",
-				"@comunica/bus-merge-bindings-context": "^5.1.3",
-				"@comunica/bus-optimize-query-operation": "^5.1.3",
-				"@comunica/bus-query-operation": "^5.1.3",
-				"@comunica/bus-query-parse": "^5.1.3",
-				"@comunica/bus-query-process": "^5.1.3",
-				"@comunica/context-entries": "^5.1.3",
-				"@comunica/core": "^5.1.3",
-				"@comunica/types": "^5.1.3",
-				"@comunica/utils-algebra": "^5.1.3",
-				"@comunica/utils-bindings-factory": "^5.1.3",
-				"@comunica/utils-query-operation": "^5.1.3",
+				"@comunica/bus-context-preprocess": "^5.2.0",
+				"@comunica/bus-merge-bindings-context": "^5.2.0",
+				"@comunica/bus-optimize-query-operation": "^5.2.0",
+				"@comunica/bus-query-operation": "^5.2.0",
+				"@comunica/bus-query-parse": "^5.2.0",
+				"@comunica/bus-query-process": "^5.2.0",
+				"@comunica/context-entries": "^5.2.0",
+				"@comunica/core": "^5.2.0",
+				"@comunica/types": "^5.2.0",
+				"@comunica/utils-algebra": "^5.2.0",
+				"@comunica/utils-bindings-factory": "^5.2.0",
+				"@comunica/utils-query-operation": "^5.2.0",
 				"@rdfjs/types": "*"
 			},
 			"funding": {
@@ -2833,15 +2856,15 @@
 			}
 		},
 		"node_modules/@comunica/actor-query-result-serialize-json": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-query-result-serialize-json/-/actor-query-result-serialize-json-5.1.3.tgz",
-			"integrity": "sha512-PbFpwsDbXUtVQC5m17eXc+9r+9tRiOjs4O6IbBvaS8AVDFKc4PRdGVz47HAM4FQ5uJoIai1Rzho79CKvZuRXcw==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-query-result-serialize-json/-/actor-query-result-serialize-json-5.2.0.tgz",
+			"integrity": "sha512-V7gJRiyMS1508huCcIWJKMc+HnIqd9GXsvr6hzO6OisOQot1/Xg8XOdVgVCAQoRdGJN8Ra6rTFuRDcksP1wVbg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-query-result-serialize": "^5.1.3",
-				"@comunica/core": "^5.1.3",
-				"@comunica/types": "^5.1.3",
+				"@comunica/bus-query-result-serialize": "^5.2.0",
+				"@comunica/core": "^5.2.0",
+				"@comunica/types": "^5.2.0",
 				"asynciterator": "^3.10.0",
 				"rdf-string": "^2.0.1",
 				"readable-stream": "^4.7.0"
@@ -2852,16 +2875,16 @@
 			}
 		},
 		"node_modules/@comunica/actor-query-result-serialize-rdf": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-query-result-serialize-rdf/-/actor-query-result-serialize-rdf-5.1.3.tgz",
-			"integrity": "sha512-53+khlxRA9Ji8oTHjooPgdzA9fcKQRJUQ2aj14L/c7dc9X9R8bURjJZ+4J1ur0kDm0OSi4NVL5qLgS6/+NMhCA==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-query-result-serialize-rdf/-/actor-query-result-serialize-rdf-5.2.0.tgz",
+			"integrity": "sha512-EHG801QfM0ARbZuW1RmkFJR7IYm9ly95VLkUCmFEkjf9W832SzUTHdJWkjgdDACQn9Yh30KXH4petTEm2Z1JDw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-query-result-serialize": "^5.1.3",
-				"@comunica/bus-rdf-serialize": "^5.1.3",
-				"@comunica/core": "^5.1.3",
-				"@comunica/types": "^5.1.3"
+				"@comunica/bus-query-result-serialize": "^5.2.0",
+				"@comunica/bus-rdf-serialize": "^5.2.0",
+				"@comunica/core": "^5.2.0",
+				"@comunica/types": "^5.2.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -2869,15 +2892,15 @@
 			}
 		},
 		"node_modules/@comunica/actor-query-result-serialize-simple": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-query-result-serialize-simple/-/actor-query-result-serialize-simple-5.1.3.tgz",
-			"integrity": "sha512-OyPToQhjnkxiLkDFwetknKoz8gQj49yVCwdtGANJ7MYkMNpUlarBF73WKjnTCw4so2enGvH2ADBn4Vy3YeQK5A==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-query-result-serialize-simple/-/actor-query-result-serialize-simple-5.2.0.tgz",
+			"integrity": "sha512-S7tWfEEbrZT8F2cPHcOEa2AIWfqj418J8p570LhSLKOFgOBgrYwCdq+bxy6SPnrKx41KomIqhkQa76N/OQ5OwA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-query-result-serialize": "^5.1.3",
-				"@comunica/core": "^5.1.3",
-				"@comunica/types": "^5.1.3",
+				"@comunica/bus-query-result-serialize": "^5.2.0",
+				"@comunica/core": "^5.2.0",
+				"@comunica/types": "^5.2.0",
 				"@rdfjs/types": "*",
 				"asynciterator": "^3.10.0",
 				"rdf-string": "^2.0.1",
@@ -2889,15 +2912,15 @@
 			}
 		},
 		"node_modules/@comunica/actor-query-result-serialize-sparql-csv": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-query-result-serialize-sparql-csv/-/actor-query-result-serialize-sparql-csv-5.1.3.tgz",
-			"integrity": "sha512-hu5WYAwg2IG9AfSZ9OUzdeo9eABCfpx1c+dcnn2EwHdM1TQAe23gr1s51Cj0lzX0QahksbfyR/r13elhHNvomA==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-query-result-serialize-sparql-csv/-/actor-query-result-serialize-sparql-csv-5.2.0.tgz",
+			"integrity": "sha512-vSdxqxzDV3MsI2fBctX1wflGkamLcLcA16ReuiQmgXFMgqCi/1uRVQ2+yD3xrZ52gpRmijk3YcHvFMMLQ/Za8w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-query-result-serialize": "^5.1.3",
-				"@comunica/core": "^5.1.3",
-				"@comunica/types": "^5.1.3",
+				"@comunica/bus-query-result-serialize": "^5.2.0",
+				"@comunica/core": "^5.2.0",
+				"@comunica/types": "^5.2.0",
 				"@rdfjs/types": "*",
 				"readable-stream": "^4.7.0"
 			},
@@ -2907,17 +2930,17 @@
 			}
 		},
 		"node_modules/@comunica/actor-query-result-serialize-sparql-json": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-query-result-serialize-sparql-json/-/actor-query-result-serialize-sparql-json-5.1.3.tgz",
-			"integrity": "sha512-+4RrVkf+L0xDWyvHhydqWGWFUzaecYnS3P1gM2Aapb55IG/uvG2N03HQRfcrfr2DCPOgOyFzomX/+p/fU4EGEw==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-query-result-serialize-sparql-json/-/actor-query-result-serialize-sparql-json-5.2.0.tgz",
+			"integrity": "sha512-3DjYvys9cUGVy8Pj1q1whXKjeOOZfM6pWYHeV/RUkwD7yvaoY4v+/hHmUhA4sbLLCWo+l5lKvdB4fNHdF8OMQA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-http": "^5.1.3",
-				"@comunica/bus-http-invalidate": "^5.1.3",
-				"@comunica/bus-query-result-serialize": "^5.1.3",
-				"@comunica/core": "^5.1.3",
-				"@comunica/types": "^5.1.3",
+				"@comunica/bus-http": "^5.2.0",
+				"@comunica/bus-http-invalidate": "^5.2.0",
+				"@comunica/bus-query-result-serialize": "^5.2.0",
+				"@comunica/core": "^5.2.0",
+				"@comunica/types": "^5.2.0",
 				"@rdfjs/types": "*",
 				"asynciterator": "^3.10.0",
 				"readable-stream": "^4.7.0"
@@ -2928,15 +2951,15 @@
 			}
 		},
 		"node_modules/@comunica/actor-query-result-serialize-sparql-tsv": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-query-result-serialize-sparql-tsv/-/actor-query-result-serialize-sparql-tsv-5.1.3.tgz",
-			"integrity": "sha512-/4f0y2svSvMUJk4ZSCldFIa7vgzOZeY663BUkRU0FB5EPeoKDJXq5igxL1rUSWLERhURpFa7aitNbP/wmKlFQw==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-query-result-serialize-sparql-tsv/-/actor-query-result-serialize-sparql-tsv-5.2.0.tgz",
+			"integrity": "sha512-XzURyocPrV9DjLnX+JHjK9QZQa7/N8uiiTCO1oAGoqNyLoh9yQNrRz2CSP1NsX43+p1+/j96BvC3EExh1INukQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-query-result-serialize": "^5.1.3",
-				"@comunica/core": "^5.1.3",
-				"@comunica/types": "^5.1.3",
+				"@comunica/bus-query-result-serialize": "^5.2.0",
+				"@comunica/core": "^5.2.0",
+				"@comunica/types": "^5.2.0",
 				"@rdfjs/types": "*",
 				"rdf-string-ttl": "^2.0.1",
 				"readable-stream": "^4.7.0"
@@ -2947,15 +2970,15 @@
 			}
 		},
 		"node_modules/@comunica/actor-query-result-serialize-sparql-xml": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-query-result-serialize-sparql-xml/-/actor-query-result-serialize-sparql-xml-5.1.3.tgz",
-			"integrity": "sha512-ZhDWW16tM+XmDWmyZfGYugsir7a8Q6q+sHSw6P1QHgd3Dj0s4x4Ud1P+fHcX8kQx4Br3SXmFtbsZ2oBeJt3zgQ==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-query-result-serialize-sparql-xml/-/actor-query-result-serialize-sparql-xml-5.2.0.tgz",
+			"integrity": "sha512-KFLZpOF64jk1rE1tfZZGbA11wZXvknmQk1zg4bmejSWjzEM0YUhC5NRQES0yGowI7WmNRKtxhLRmzaMougFERw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-query-result-serialize": "^5.1.3",
-				"@comunica/core": "^5.1.3",
-				"@comunica/types": "^5.1.3",
+				"@comunica/bus-query-result-serialize": "^5.2.0",
+				"@comunica/core": "^5.2.0",
+				"@comunica/types": "^5.2.0",
 				"@rdfjs/types": "*",
 				"asynciterator": "^3.10.0",
 				"readable-stream": "^4.7.0"
@@ -2966,18 +2989,18 @@
 			}
 		},
 		"node_modules/@comunica/actor-query-result-serialize-stats": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-query-result-serialize-stats/-/actor-query-result-serialize-stats-5.1.3.tgz",
-			"integrity": "sha512-Z7JoaYxc/uOK1J1QZIRYZjpZDySuZuHbxJM1K25aOXXSay79kr96+ZnlaXtne41kZfLszhkUTWJ8eJO1Vo8Wdg==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-query-result-serialize-stats/-/actor-query-result-serialize-stats-5.2.0.tgz",
+			"integrity": "sha512-P8rUWOXXjynEycuz3yPvV2gZS6o3+oebu6EI9kcfHg28rZd56nmT215KIfWXKkFrA11sN9vfy8lTTL4Axr+u9Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-http": "^5.1.3",
-				"@comunica/bus-http-invalidate": "^5.1.3",
-				"@comunica/bus-query-result-serialize": "^5.1.3",
-				"@comunica/context-entries": "^5.1.3",
-				"@comunica/core": "^5.1.3",
-				"@comunica/types": "^5.1.3",
+				"@comunica/bus-http": "^5.2.0",
+				"@comunica/bus-http-invalidate": "^5.2.0",
+				"@comunica/bus-query-result-serialize": "^5.2.0",
+				"@comunica/context-entries": "^5.2.0",
+				"@comunica/core": "^5.2.0",
+				"@comunica/types": "^5.2.0",
 				"asynciterator": "^3.10.0",
 				"readable-stream": "^4.7.0"
 			},
@@ -2987,16 +3010,16 @@
 			}
 		},
 		"node_modules/@comunica/actor-query-result-serialize-table": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-query-result-serialize-table/-/actor-query-result-serialize-table-5.1.3.tgz",
-			"integrity": "sha512-I/wMesFuxpfRcohBQid6kjcmZB+vRQHq96s5L5jJMCPG1mn3nlGehCNcupjYhPsH8YgfhWe3BXtVOfAI8fXxQA==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-query-result-serialize-table/-/actor-query-result-serialize-table-5.2.0.tgz",
+			"integrity": "sha512-39LssD/2JutFHaZWt+Ut+hO9+xezqB/FwsSmpw6F+/nh7wZCd08/iF6GScwAilvkkxUiP4aEkI3lPf7Qai6xZQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-query-result-serialize": "^5.1.3",
-				"@comunica/context-entries": "^5.1.3",
-				"@comunica/core": "^5.1.3",
-				"@comunica/types": "^5.1.3",
+				"@comunica/bus-query-result-serialize": "^5.2.0",
+				"@comunica/context-entries": "^5.2.0",
+				"@comunica/core": "^5.2.0",
+				"@comunica/types": "^5.2.0",
 				"@rdfjs/types": "*",
 				"rdf-string": "^2.0.1",
 				"rdf-terms": "^2.0.0",
@@ -3008,16 +3031,16 @@
 			}
 		},
 		"node_modules/@comunica/actor-query-result-serialize-tree": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-query-result-serialize-tree/-/actor-query-result-serialize-tree-5.1.3.tgz",
-			"integrity": "sha512-nEerT7fxbn7bZh+CXW0/NddeXgp5jcriiSYx3PAztEj9jHFCRBs4Bv3yH5iXCCpsUlwXX8yhhQxjNkj9l+AEOQ==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-query-result-serialize-tree/-/actor-query-result-serialize-tree-5.2.0.tgz",
+			"integrity": "sha512-R91naa1pY771E/wS3n2AYzeVgFkEtiwLZbm5Awn8aQ7/fRnFXlMfYcTslDBFAjZaoW5cY84q/4Tl/kFYMSluRg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-query-result-serialize": "^5.1.3",
-				"@comunica/context-entries": "^5.1.3",
-				"@comunica/core": "^5.1.3",
-				"@comunica/types": "^5.1.3",
+				"@comunica/bus-query-result-serialize": "^5.2.0",
+				"@comunica/context-entries": "^5.2.0",
+				"@comunica/core": "^5.2.0",
+				"@comunica/types": "^5.2.0",
 				"readable-stream": "^4.7.0",
 				"sparqljson-to-tree": "^3.0.1"
 			},
@@ -3027,14 +3050,14 @@
 			}
 		},
 		"node_modules/@comunica/actor-query-serialize-sparql": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-query-serialize-sparql/-/actor-query-serialize-sparql-5.1.3.tgz",
-			"integrity": "sha512-RbAP8vkply/q/+m04VibBRLtpG8G0kjOK8Nt49yuQeXRuy5WSiFYJJtFM0SjxDwdWbG4DAL+A9W5zFrhLuQZZA==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-query-serialize-sparql/-/actor-query-serialize-sparql-5.2.0.tgz",
+			"integrity": "sha512-tjY4JHiY4CawLv04Svb2wQHzxwdKttupiVuGVMAi+UAqgktFeYTb0QxSn76k67Q9zewQVkbgushHxYSiVlqpBQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-query-serialize": "^5.1.3",
-				"@comunica/core": "^5.1.3",
+				"@comunica/bus-query-serialize": "^5.2.0",
+				"@comunica/core": "^5.2.0",
 				"@traqula/algebra-sparql-1-2": "^1.0.1",
 				"@traqula/core": "^1.0.0",
 				"@traqula/generator-sparql-1-2": "^1.0.1"
@@ -3045,17 +3068,17 @@
 			}
 		},
 		"node_modules/@comunica/actor-query-source-dereference-link-force-sparql": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-query-source-dereference-link-force-sparql/-/actor-query-source-dereference-link-force-sparql-5.1.3.tgz",
-			"integrity": "sha512-GD1smY0eGFpxodhAHgF1uJbM+JaANxF3IWmMSHgKd8aJeQLCnShVdk1H6w+5wHzOGrJH3kb4pqo9WYSbvKl79Q==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-query-source-dereference-link-force-sparql/-/actor-query-source-dereference-link-force-sparql-5.2.0.tgz",
+			"integrity": "sha512-EpSYW+026ts4aX8hNAOsHS1F7NE3JEiq1AEU+4h/JrilvXqHSaLyFmecainQM8LaCPTwm7IVqk2iETn15KCnXg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-query-source-dereference-link": "^5.1.3",
-				"@comunica/bus-query-source-identify-hypermedia": "^5.1.3",
-				"@comunica/bus-rdf-metadata-accumulate": "^5.1.3",
-				"@comunica/context-entries": "^5.1.3",
-				"@comunica/core": "^5.1.3",
+				"@comunica/bus-query-source-dereference-link": "^5.2.0",
+				"@comunica/bus-query-source-identify-hypermedia": "^5.2.0",
+				"@comunica/bus-rdf-metadata-accumulate": "^5.2.0",
+				"@comunica/context-entries": "^5.2.0",
+				"@comunica/core": "^5.2.0",
 				"readable-stream": "^4.7.0"
 			},
 			"funding": {
@@ -3064,22 +3087,22 @@
 			}
 		},
 		"node_modules/@comunica/actor-query-source-dereference-link-hypermedia": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-query-source-dereference-link-hypermedia/-/actor-query-source-dereference-link-hypermedia-5.1.3.tgz",
-			"integrity": "sha512-8C9M7yd1W8s3aVJvSua3AuKKYW2TWy/vk2HF5/Ph13TtZ+nTnxZNmC1VsgUIpaKasw7En1/PStp8xOV90YYgmg==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-query-source-dereference-link-hypermedia/-/actor-query-source-dereference-link-hypermedia-5.2.0.tgz",
+			"integrity": "sha512-sP1PVSFTBrqp0+HUdX4PO0CyZOWaIWuj1by8i4mnLcp2efmTk7ERo5fkI5VrshSzjXg8rp2FgePZVjdMsb8A7w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-dereference": "^5.1.3",
-				"@comunica/bus-dereference-rdf": "^5.1.3",
-				"@comunica/bus-query-source-dereference-link": "^5.1.3",
-				"@comunica/bus-query-source-identify-hypermedia": "^5.1.3",
-				"@comunica/bus-rdf-metadata": "^5.1.3",
-				"@comunica/bus-rdf-metadata-accumulate": "^5.1.3",
-				"@comunica/bus-rdf-metadata-extract": "^5.1.3",
-				"@comunica/context-entries": "^5.1.3",
-				"@comunica/core": "^5.1.3",
-				"@comunica/types": "^5.1.3",
+				"@comunica/bus-dereference": "^5.2.0",
+				"@comunica/bus-dereference-rdf": "^5.2.0",
+				"@comunica/bus-query-source-dereference-link": "^5.2.0",
+				"@comunica/bus-query-source-identify-hypermedia": "^5.2.0",
+				"@comunica/bus-rdf-metadata": "^5.2.0",
+				"@comunica/bus-rdf-metadata-accumulate": "^5.2.0",
+				"@comunica/bus-rdf-metadata-extract": "^5.2.0",
+				"@comunica/context-entries": "^5.2.0",
+				"@comunica/core": "^5.2.0",
+				"@comunica/types": "^5.2.0",
 				"readable-stream": "^4.7.0"
 			},
 			"funding": {
@@ -3087,25 +3110,46 @@
 				"url": "https://opencollective.com/comunica-association"
 			}
 		},
-		"node_modules/@comunica/actor-query-source-identify-hypermedia": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-query-source-identify-hypermedia/-/actor-query-source-identify-hypermedia-5.1.3.tgz",
-			"integrity": "sha512-kQ8+u2ug+MALmm6StYaI95DevwiTXt3QunG0VUOXvZ2/5hPIxnsmijTniUKXIB9anGR0NH8cZuomJRzFdvoXpQ==",
+		"node_modules/@comunica/actor-query-source-identify-compositefile": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-query-source-identify-compositefile/-/actor-query-source-identify-compositefile-5.2.0.tgz",
+			"integrity": "sha512-5joLg/WcrUTvOCJobjwowCYSSPzVYtfi95uzmK64rVUl7fxnpDg+ZPLA8kg/OZCEc9E35NjlS2BwuLjV2EbKDg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-merge-bindings-context": "^5.1.3",
-				"@comunica/bus-query-source-dereference-link": "^5.1.3",
-				"@comunica/bus-query-source-identify": "^5.1.3",
-				"@comunica/bus-rdf-metadata-accumulate": "^5.1.3",
-				"@comunica/bus-rdf-resolve-hypermedia-links": "^5.1.3",
-				"@comunica/bus-rdf-resolve-hypermedia-links-queue": "^5.1.3",
-				"@comunica/context-entries": "^5.1.3",
-				"@comunica/core": "^5.1.3",
-				"@comunica/types": "^5.1.3",
-				"@comunica/utils-algebra": "^5.1.3",
-				"@comunica/utils-bindings-factory": "^5.1.3",
-				"@comunica/utils-metadata": "^5.1.3",
+				"@comunica/actor-query-source-identify-rdfjs": "^5.2.0",
+				"@comunica/bus-merge-bindings-context": "^5.2.0",
+				"@comunica/bus-query-source-identify": "^5.2.0",
+				"@comunica/context-entries": "^5.2.0",
+				"@comunica/core": "^5.2.0",
+				"@comunica/utils-algebra": "^5.2.0",
+				"@comunica/utils-bindings-factory": "^5.2.0",
+				"rdf-stores": "^2.2.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/comunica-association"
+			}
+		},
+		"node_modules/@comunica/actor-query-source-identify-hypermedia": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-query-source-identify-hypermedia/-/actor-query-source-identify-hypermedia-5.2.0.tgz",
+			"integrity": "sha512-/Sy0pQ9GxJDK1VHIbwwE2h8zW/0fNjU/asWGawJCmhMSKJbhfwjvPPSGyQvkTOGa7iztz92oNON4WeUfrkrS1g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@comunica/bus-merge-bindings-context": "^5.2.0",
+				"@comunica/bus-query-source-dereference-link": "^5.2.0",
+				"@comunica/bus-query-source-identify": "^5.2.0",
+				"@comunica/bus-rdf-metadata-accumulate": "^5.2.0",
+				"@comunica/bus-rdf-resolve-hypermedia-links": "^5.2.0",
+				"@comunica/bus-rdf-resolve-hypermedia-links-queue": "^5.2.0",
+				"@comunica/context-entries": "^5.2.0",
+				"@comunica/core": "^5.2.0",
+				"@comunica/types": "^5.2.0",
+				"@comunica/utils-algebra": "^5.2.0",
+				"@comunica/utils-bindings-factory": "^5.2.0",
+				"@comunica/utils-metadata": "^5.2.0",
 				"@rdfjs/types": "*",
 				"asynciterator": "^3.10.0",
 				"lru-cache": "^11.2.2"
@@ -3116,20 +3160,20 @@
 			}
 		},
 		"node_modules/@comunica/actor-query-source-identify-hypermedia-none": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-query-source-identify-hypermedia-none/-/actor-query-source-identify-hypermedia-none-5.1.3.tgz",
-			"integrity": "sha512-W+hP4Wnibb1zr4Y2XbpTs0sdjfkhWTjZOWNVV9dPAra5Ypaxjtje2LQQoupon4oJE4lIWLGIykHer2HuF+9tgg==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-query-source-identify-hypermedia-none/-/actor-query-source-identify-hypermedia-none-5.2.0.tgz",
+			"integrity": "sha512-phBaVA+NZv+u+Y8U6U0d8hH/KzyNPEL2NQD8WA1hYPTklSXYxYjNYd3doIEdTai6tXTjU/OQaf7L4LsiiTD2mw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/actor-query-source-identify-rdfjs": "^5.1.3",
-				"@comunica/bus-merge-bindings-context": "^5.1.3",
-				"@comunica/bus-query-source-identify-hypermedia": "^5.1.3",
-				"@comunica/context-entries": "^5.1.3",
-				"@comunica/core": "^5.1.3",
-				"@comunica/types": "^5.1.3",
-				"@comunica/utils-bindings-factory": "^5.1.3",
-				"rdf-store-stream": "^3.0.0"
+				"@comunica/actor-query-source-identify-rdfjs": "^5.2.0",
+				"@comunica/bus-merge-bindings-context": "^5.2.0",
+				"@comunica/bus-query-source-identify-hypermedia": "^5.2.0",
+				"@comunica/context-entries": "^5.2.0",
+				"@comunica/core": "^5.2.0",
+				"@comunica/utils-bindings-factory": "^5.2.0",
+				"@rdfjs/types": "*",
+				"rdf-stores": "^2.2.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -3137,25 +3181,25 @@
 			}
 		},
 		"node_modules/@comunica/actor-query-source-identify-hypermedia-qpf": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-query-source-identify-hypermedia-qpf/-/actor-query-source-identify-hypermedia-qpf-5.1.3.tgz",
-			"integrity": "sha512-yT1+okZnkG9AfBWGOUAkIJsj2qHoATka5u7+/ALmigq6WThh9G86f36tBXg4aCwiw2BmPQrNcBwDFSPk+vGFDw==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-query-source-identify-hypermedia-qpf/-/actor-query-source-identify-hypermedia-qpf-5.2.0.tgz",
+			"integrity": "sha512-c/Ce6XrznHOnoRtACkZXT46IPkd6x13PvGq6o8yhZK2KZebOKVo7B646tX51+y7Wz+ml9OAgFrtgVeOBRsSsVg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/actor-rdf-metadata-extract-hydra-controls": "^5.1.3",
-				"@comunica/bus-dereference-rdf": "^5.1.3",
-				"@comunica/bus-merge-bindings-context": "^5.1.3",
-				"@comunica/bus-query-source-identify": "^5.1.3",
-				"@comunica/bus-query-source-identify-hypermedia": "^5.1.3",
-				"@comunica/bus-rdf-metadata": "^5.1.3",
-				"@comunica/bus-rdf-metadata-extract": "^5.1.3",
-				"@comunica/context-entries": "^5.1.3",
-				"@comunica/core": "^5.1.3",
-				"@comunica/types": "^5.1.3",
-				"@comunica/utils-algebra": "^5.1.3",
-				"@comunica/utils-bindings-factory": "^5.1.3",
-				"@comunica/utils-metadata": "^5.1.3",
+				"@comunica/actor-rdf-metadata-extract-hydra-controls": "^5.2.0",
+				"@comunica/bus-dereference-rdf": "^5.2.0",
+				"@comunica/bus-merge-bindings-context": "^5.2.0",
+				"@comunica/bus-query-source-identify": "^5.2.0",
+				"@comunica/bus-query-source-identify-hypermedia": "^5.2.0",
+				"@comunica/bus-rdf-metadata": "^5.2.0",
+				"@comunica/bus-rdf-metadata-extract": "^5.2.0",
+				"@comunica/context-entries": "^5.2.0",
+				"@comunica/core": "^5.2.0",
+				"@comunica/types": "^5.2.0",
+				"@comunica/utils-algebra": "^5.2.0",
+				"@comunica/utils-bindings-factory": "^5.2.0",
+				"@comunica/utils-metadata": "^5.2.0",
 				"@rdfjs/types": "*",
 				"asynciterator": "^3.10.0",
 				"rdf-string": "^2.0.1",
@@ -3168,23 +3212,23 @@
 			}
 		},
 		"node_modules/@comunica/actor-query-source-identify-hypermedia-sparql": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-query-source-identify-hypermedia-sparql/-/actor-query-source-identify-hypermedia-sparql-5.1.3.tgz",
-			"integrity": "sha512-guNj+Hs2E45T6og+8HjIPYvLyYVX9WWuuQf038LfQlO/4w2WzewH/8VKqmc+jr8Kqml/ehTU7d/AOflkYIZWVg==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-query-source-identify-hypermedia-sparql/-/actor-query-source-identify-hypermedia-sparql-5.2.0.tgz",
+			"integrity": "sha512-thYMIXWfO6gRdeTihARyZVdQmmIpJbpZfFIJ+oMhm8z4nfmRdd9GSBTnpi1xcQPgoD85OtYWm2N1oUOP2aNtyA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-http": "^5.1.3",
-				"@comunica/bus-merge-bindings-context": "^5.1.3",
-				"@comunica/bus-query-serialize": "^5.1.3",
-				"@comunica/bus-query-source-identify-hypermedia": "^5.1.3",
-				"@comunica/context-entries": "^5.1.3",
-				"@comunica/core": "^5.1.3",
-				"@comunica/types": "^5.1.3",
-				"@comunica/utils-algebra": "^5.1.3",
-				"@comunica/utils-bindings-factory": "^5.1.3",
-				"@comunica/utils-metadata": "^5.1.3",
-				"@comunica/utils-query-operation": "^5.1.3",
+				"@comunica/bus-http": "^5.2.0",
+				"@comunica/bus-merge-bindings-context": "^5.2.0",
+				"@comunica/bus-query-serialize": "^5.2.0",
+				"@comunica/bus-query-source-identify-hypermedia": "^5.2.0",
+				"@comunica/context-entries": "^5.2.0",
+				"@comunica/core": "^5.2.0",
+				"@comunica/types": "^5.2.0",
+				"@comunica/utils-algebra": "^5.2.0",
+				"@comunica/utils-bindings-factory": "^5.2.0",
+				"@comunica/utils-metadata": "^5.2.0",
+				"@comunica/utils-query-operation": "^5.2.0",
 				"@rdfjs/types": "*",
 				"asynciterator": "^3.10.0",
 				"fetch-sparql-endpoint": "^7.1.0",
@@ -3197,20 +3241,20 @@
 			}
 		},
 		"node_modules/@comunica/actor-query-source-identify-rdfjs": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-query-source-identify-rdfjs/-/actor-query-source-identify-rdfjs-5.1.3.tgz",
-			"integrity": "sha512-LgB3va2e8Cw4/ia5luPirf5NTLdaeToVVp8O9uU6gAEzXgqpDWrLO0l6bvO9CQXJB/wIF5lTr/w0S/yWaUFDVw==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-query-source-identify-rdfjs/-/actor-query-source-identify-rdfjs-5.2.0.tgz",
+			"integrity": "sha512-UL0bq+oCVPWK5xJpmwa1+LMEv8lLhluSkIX2hFSqKaRWU3Ak4dYrZAgydrTbtMsL6La2HEC2JK1W72doTakOHg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-merge-bindings-context": "^5.1.3",
-				"@comunica/bus-query-source-identify": "^5.1.3",
-				"@comunica/context-entries": "^5.1.3",
-				"@comunica/core": "^5.1.3",
-				"@comunica/types": "^5.1.3",
-				"@comunica/utils-algebra": "^5.1.3",
-				"@comunica/utils-bindings-factory": "^5.1.3",
-				"@comunica/utils-metadata": "^5.1.3",
+				"@comunica/bus-merge-bindings-context": "^5.2.0",
+				"@comunica/bus-query-source-identify": "^5.2.0",
+				"@comunica/context-entries": "^5.2.0",
+				"@comunica/core": "^5.2.0",
+				"@comunica/types": "^5.2.0",
+				"@comunica/utils-algebra": "^5.2.0",
+				"@comunica/utils-bindings-factory": "^5.2.0",
+				"@comunica/utils-metadata": "^5.2.0",
 				"@rdfjs/types": "*",
 				"asynciterator": "^3.10.0",
 				"rdf-terms": "^2.0.0"
@@ -3221,16 +3265,16 @@
 			}
 		},
 		"node_modules/@comunica/actor-query-source-identify-serialized": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-query-source-identify-serialized/-/actor-query-source-identify-serialized-5.1.3.tgz",
-			"integrity": "sha512-/GaopV3GGiNbTwJ4aS5tu4ZXDu2pvYVcLRhh4XouA6SACFynJQYd5XwkrcZU0L8zM+GMLy8wbMcYKcSQYCrsIw==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-query-source-identify-serialized/-/actor-query-source-identify-serialized-5.2.0.tgz",
+			"integrity": "sha512-mBASve7EPwlIe3pyIxP4LClVOJDTaLhbxiMZZ4a0E6gXFvDTmVvM2Kje54pOkBYvJvf/zd0pRUHxI/pVbKpElw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-query-source-identify": "^5.1.3",
-				"@comunica/bus-rdf-parse": "^5.1.3",
-				"@comunica/core": "^5.1.3",
-				"@comunica/types": "^5.1.3",
+				"@comunica/bus-query-source-identify": "^5.2.0",
+				"@comunica/bus-rdf-parse": "^5.2.0",
+				"@comunica/core": "^5.2.0",
+				"@comunica/types": "^5.2.0",
 				"@rdfjs/types": "*",
 				"rdf-store-stream": "^3.0.0",
 				"readable-stream": "^4.7.0"
@@ -3241,14 +3285,14 @@
 			}
 		},
 		"node_modules/@comunica/actor-rdf-join-entries-sort-cardinality": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-entries-sort-cardinality/-/actor-rdf-join-entries-sort-cardinality-5.1.3.tgz",
-			"integrity": "sha512-XLYyk/gap6cD1wDN1KsbaA18J+iMzPdWBH2r7WxmCLy08UY2pigxl8EU5BT08s5XxYPWLDEUL/U+qy2IGzeKRg==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-entries-sort-cardinality/-/actor-rdf-join-entries-sort-cardinality-5.2.0.tgz",
+			"integrity": "sha512-H5CZy/lVn+LTFt2H2b/kPrxLKp6oxjbvzQlAlaEh4c+WJymjLwhHIVVKAnPjvc1TZn4Pd57fr3NAJl8tHgL5lQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-rdf-join-entries-sort": "^5.1.3",
-				"@comunica/core": "^5.1.3"
+				"@comunica/bus-rdf-join-entries-sort": "^5.2.0",
+				"@comunica/core": "^5.2.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -3256,16 +3300,16 @@
 			}
 		},
 		"node_modules/@comunica/actor-rdf-join-entries-sort-selectivity": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-entries-sort-selectivity/-/actor-rdf-join-entries-sort-selectivity-5.1.3.tgz",
-			"integrity": "sha512-U82yb1QT37dF7gebEYmtIWygbvxxgmcETsQl0QS+t7oHEPs5wKrq++Y62Tha67MGztr+2mVFaZYobGS34Ef/Xw==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-entries-sort-selectivity/-/actor-rdf-join-entries-sort-selectivity-5.2.0.tgz",
+			"integrity": "sha512-ncvBGyq9Rut6nLLc3O6QbvCkQtqmiNf168BMf+xUFbZZ2pD5x9Ud4HNBaCLueYUwdsqb5VGqzlSEcO1cH2g3EQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-rdf-join-entries-sort": "^5.1.3",
-				"@comunica/bus-rdf-join-selectivity": "^5.1.3",
-				"@comunica/core": "^5.1.3",
-				"@comunica/types": "^5.1.3"
+				"@comunica/bus-rdf-join-entries-sort": "^5.2.0",
+				"@comunica/bus-rdf-join-selectivity": "^5.2.0",
+				"@comunica/core": "^5.2.0",
+				"@comunica/types": "^5.2.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -3273,18 +3317,18 @@
 			}
 		},
 		"node_modules/@comunica/actor-rdf-join-inner-hash": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-inner-hash/-/actor-rdf-join-inner-hash-5.1.3.tgz",
-			"integrity": "sha512-NjA8dF4JLf0RxR0fDxvlC5wDna47NUdkjCOecZxolqa4XScZMcSu3Sa0P+POirrj57Tkp8P0C4qcjJ8kjOZQ7A==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-inner-hash/-/actor-rdf-join-inner-hash-5.2.0.tgz",
+			"integrity": "sha512-umoBMg/fdbjL8K26KUEso82tkB6slAhXkQgCpVcBppHx3U2ZxYnfpOq5lur7zpukfs4Gdx23Mk2uo5yYVqh49g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-hash-bindings": "^5.1.3",
-				"@comunica/bus-rdf-join": "^5.1.3",
-				"@comunica/core": "^5.1.3",
-				"@comunica/mediatortype-join-coefficients": "^5.1.3",
-				"@comunica/types": "^5.1.3",
-				"@comunica/utils-bindings-index": "^5.1.3",
+				"@comunica/bus-hash-bindings": "^5.2.0",
+				"@comunica/bus-rdf-join": "^5.2.0",
+				"@comunica/core": "^5.2.0",
+				"@comunica/mediatortype-join-coefficients": "^5.2.0",
+				"@comunica/types": "^5.2.0",
+				"@comunica/utils-bindings-index": "^5.2.0",
 				"@comunica/utils-iterator": "^5.0.0",
 				"asynciterator": "^3.10.0",
 				"asyncjoin": "^1.2.4",
@@ -3296,23 +3340,23 @@
 			}
 		},
 		"node_modules/@comunica/actor-rdf-join-inner-multi-bind": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-inner-multi-bind/-/actor-rdf-join-inner-multi-bind-5.1.3.tgz",
-			"integrity": "sha512-m8HRDNcAxtbBnNVxZIoTGIXyIpJKxl3IuVoAEFifB5tXC0YBUc/M457X+IWBAB0MzBYxoj+Gw372Mn/u/fyJcg==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-inner-multi-bind/-/actor-rdf-join-inner-multi-bind-5.2.0.tgz",
+			"integrity": "sha512-dhwLCG3smmI7SqihrL44Kwq6lgDsKMiF8l3VhZbpnDDKGVg4P/gz8CSubahXldPI189s2Rm6TJHjASoUwXh/Hw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-merge-bindings-context": "^5.1.3",
-				"@comunica/bus-query-operation": "^5.1.3",
-				"@comunica/bus-rdf-join": "^5.1.3",
-				"@comunica/bus-rdf-join-entries-sort": "^5.1.3",
-				"@comunica/context-entries": "^5.1.3",
-				"@comunica/core": "^5.1.3",
-				"@comunica/mediatortype-join-coefficients": "^5.1.3",
-				"@comunica/types": "^5.1.3",
-				"@comunica/utils-algebra": "^5.1.3",
-				"@comunica/utils-bindings-factory": "^5.1.3",
-				"@comunica/utils-query-operation": "^5.1.3",
+				"@comunica/bus-merge-bindings-context": "^5.2.0",
+				"@comunica/bus-query-operation": "^5.2.0",
+				"@comunica/bus-rdf-join": "^5.2.0",
+				"@comunica/bus-rdf-join-entries-sort": "^5.2.0",
+				"@comunica/context-entries": "^5.2.0",
+				"@comunica/core": "^5.2.0",
+				"@comunica/mediatortype-join-coefficients": "^5.2.0",
+				"@comunica/types": "^5.2.0",
+				"@comunica/utils-algebra": "^5.2.0",
+				"@comunica/utils-bindings-factory": "^5.2.0",
+				"@comunica/utils-query-operation": "^5.2.0",
 				"asynciterator": "^3.10.0"
 			},
 			"funding": {
@@ -3321,21 +3365,21 @@
 			}
 		},
 		"node_modules/@comunica/actor-rdf-join-inner-multi-bind-source": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-inner-multi-bind-source/-/actor-rdf-join-inner-multi-bind-source-5.1.3.tgz",
-			"integrity": "sha512-SDjKNoyCTti30M08EtWet8uIRFd7bMv057bu5Kk+7kUEJq699KLmalIAqvQxeS9Zx4lmbCCPLPcQqwKjc9HbPg==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-inner-multi-bind-source/-/actor-rdf-join-inner-multi-bind-source-5.2.0.tgz",
+			"integrity": "sha512-wbyPXa2RKD/krr5XZ1gOD8/t+NGQ8Bv2Vmdb6Yq2J+g5yRn7k1x2WBLYUpff3eNsm+THN5TKlae6YrU7ayVtCQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-rdf-join": "^5.1.3",
-				"@comunica/bus-rdf-join-entries-sort": "^5.1.3",
-				"@comunica/context-entries": "^5.1.3",
-				"@comunica/core": "^5.1.3",
-				"@comunica/mediatortype-join-coefficients": "^5.1.3",
-				"@comunica/types": "^5.1.3",
-				"@comunica/utils-algebra": "^5.1.3",
+				"@comunica/bus-rdf-join": "^5.2.0",
+				"@comunica/bus-rdf-join-entries-sort": "^5.2.0",
+				"@comunica/context-entries": "^5.2.0",
+				"@comunica/core": "^5.2.0",
+				"@comunica/mediatortype-join-coefficients": "^5.2.0",
+				"@comunica/types": "^5.2.0",
+				"@comunica/utils-algebra": "^5.2.0",
 				"@comunica/utils-iterator": "^5.0.0",
-				"@comunica/utils-query-operation": "^5.1.3",
+				"@comunica/utils-query-operation": "^5.2.0",
 				"asynciterator": "^3.10.0"
 			},
 			"funding": {
@@ -3344,18 +3388,18 @@
 			}
 		},
 		"node_modules/@comunica/actor-rdf-join-inner-multi-empty": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-inner-multi-empty/-/actor-rdf-join-inner-multi-empty-5.1.3.tgz",
-			"integrity": "sha512-UuqK4yDiFmUetJU4hMac7j0ZfCU+sGlPcTzEbwf1tgUrdDU1vlXaoSsRTsN4hbsPsUtjC1rQt3ZojVITl8hEfA==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-inner-multi-empty/-/actor-rdf-join-inner-multi-empty-5.2.0.tgz",
+			"integrity": "sha512-GH8iCKeGolIq+7NsquBMPkxaW2tMMQmjmZbGW+XrC12NnP9oiaTM+BJv4NZz8bfVpAyBUSyTB9vi0Yhmaivr1w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-rdf-join": "^5.1.3",
-				"@comunica/context-entries": "^5.1.3",
-				"@comunica/core": "^5.1.3",
-				"@comunica/mediatortype-join-coefficients": "^5.1.3",
-				"@comunica/types": "^5.1.3",
-				"@comunica/utils-metadata": "^5.1.3",
+				"@comunica/bus-rdf-join": "^5.2.0",
+				"@comunica/context-entries": "^5.2.0",
+				"@comunica/core": "^5.2.0",
+				"@comunica/mediatortype-join-coefficients": "^5.2.0",
+				"@comunica/types": "^5.2.0",
+				"@comunica/utils-metadata": "^5.2.0",
 				"@rdfjs/types": "*",
 				"asynciterator": "^3.10.0"
 			},
@@ -3365,20 +3409,20 @@
 			}
 		},
 		"node_modules/@comunica/actor-rdf-join-inner-multi-smallest": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-inner-multi-smallest/-/actor-rdf-join-inner-multi-smallest-5.1.3.tgz",
-			"integrity": "sha512-jZNq6mDzU4+GKY3ccYdmYJdeKzXvpHQiRcZlWCNifGAH3CC3k72Tvfh1GVChVE06Ek9EMCT/OU5QtlgjPRCLwg==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-inner-multi-smallest/-/actor-rdf-join-inner-multi-smallest-5.2.0.tgz",
+			"integrity": "sha512-375hXPLmB7Pxt+w7BfJVnsfS3W5DuPUiTuwvsDRqoalGNiv968QkB47hS4136/u6EvTW2HMdhXqY8m4Y2+Z34A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-rdf-join": "^5.1.3",
-				"@comunica/bus-rdf-join-entries-sort": "^5.1.3",
-				"@comunica/context-entries": "^5.1.3",
-				"@comunica/core": "^5.1.3",
-				"@comunica/mediatortype-join-coefficients": "^5.1.3",
-				"@comunica/types": "^5.1.3",
-				"@comunica/utils-algebra": "^5.1.3",
-				"@comunica/utils-query-operation": "^5.1.3"
+				"@comunica/bus-rdf-join": "^5.2.0",
+				"@comunica/bus-rdf-join-entries-sort": "^5.2.0",
+				"@comunica/context-entries": "^5.2.0",
+				"@comunica/core": "^5.2.0",
+				"@comunica/mediatortype-join-coefficients": "^5.2.0",
+				"@comunica/types": "^5.2.0",
+				"@comunica/utils-algebra": "^5.2.0",
+				"@comunica/utils-query-operation": "^5.2.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -3386,22 +3430,22 @@
 			}
 		},
 		"node_modules/@comunica/actor-rdf-join-inner-multi-smallest-filter-bindings": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-inner-multi-smallest-filter-bindings/-/actor-rdf-join-inner-multi-smallest-filter-bindings-5.1.3.tgz",
-			"integrity": "sha512-gbXAm7Wdtcn0ed2q4L70XPhEsr1+fiCGnIgRU0ap5eqhgoFGATw4G2VK2lQ9ueJ/ZCAE3QSnVMMnPn5PLxGNBQ==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-inner-multi-smallest-filter-bindings/-/actor-rdf-join-inner-multi-smallest-filter-bindings-5.2.0.tgz",
+			"integrity": "sha512-yDQbM+7xDbVRuv2i6rwSwIcFbMFQcjd6dSs+Z5fkID+J2S6TKlc5GfGU03KsbMrOfI7KBTIuAqX5AwpF+OILZg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-rdf-join": "^5.1.3",
-				"@comunica/bus-rdf-join-entries-sort": "^5.1.3",
-				"@comunica/context-entries": "^5.1.3",
-				"@comunica/core": "^5.1.3",
-				"@comunica/mediatortype-join-coefficients": "^5.1.3",
-				"@comunica/types": "^5.1.3",
-				"@comunica/utils-algebra": "^5.1.3",
-				"@comunica/utils-bindings-factory": "^5.1.3",
+				"@comunica/bus-rdf-join": "^5.2.0",
+				"@comunica/bus-rdf-join-entries-sort": "^5.2.0",
+				"@comunica/context-entries": "^5.2.0",
+				"@comunica/core": "^5.2.0",
+				"@comunica/mediatortype-join-coefficients": "^5.2.0",
+				"@comunica/types": "^5.2.0",
+				"@comunica/utils-algebra": "^5.2.0",
+				"@comunica/utils-bindings-factory": "^5.2.0",
 				"@comunica/utils-iterator": "^5.0.0",
-				"@comunica/utils-query-operation": "^5.1.3",
+				"@comunica/utils-query-operation": "^5.2.0",
 				"asynciterator": "^3.10.0"
 			},
 			"funding": {
@@ -3410,15 +3454,15 @@
 			}
 		},
 		"node_modules/@comunica/actor-rdf-join-inner-nestedloop": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-inner-nestedloop/-/actor-rdf-join-inner-nestedloop-5.1.3.tgz",
-			"integrity": "sha512-8NNxv7FMIWdkJcWZim8muhUNFDGH+kz0ye38XhVhhCwie10bOu67ON+j+R5WuvuFbb5Z8CKvM+5xl6ieHgsW/g==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-inner-nestedloop/-/actor-rdf-join-inner-nestedloop-5.2.0.tgz",
+			"integrity": "sha512-UWm9TGCqt04XyfSPXLrEHOyP0hoE38LQzW3PqCjDry1YrOvw3HYLOPsvzl61IqapNI5Iz5v2+7AP0bjw63+iDw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-rdf-join": "^5.1.3",
-				"@comunica/core": "^5.1.3",
-				"@comunica/mediatortype-join-coefficients": "^5.1.3",
+				"@comunica/bus-rdf-join": "^5.2.0",
+				"@comunica/core": "^5.2.0",
+				"@comunica/mediatortype-join-coefficients": "^5.2.0",
 				"asyncjoin": "^1.2.4"
 			},
 			"funding": {
@@ -3427,20 +3471,20 @@
 			}
 		},
 		"node_modules/@comunica/actor-rdf-join-inner-none": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-inner-none/-/actor-rdf-join-inner-none-5.1.3.tgz",
-			"integrity": "sha512-tkpT8vz2cjMA/jzNoWqtZxdKDby1JAb6jKfLW/bsMVq6H2/80OXB5bF1t120IR7+eFR/f7mde6D3Xqf7IX898w==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-inner-none/-/actor-rdf-join-inner-none-5.2.0.tgz",
+			"integrity": "sha512-XcoIVQUj7ln8Zwlzg2S8hp5oHyeAHXX+Z9n5Z0A6yBy+QIVhq3nkcMB+MPWIMHlpQRScjH2sYoi1huUf9tFQ0w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-merge-bindings-context": "^5.1.3",
-				"@comunica/bus-rdf-join": "^5.1.3",
-				"@comunica/context-entries": "^5.1.3",
-				"@comunica/core": "^5.1.3",
-				"@comunica/mediatortype-join-coefficients": "^5.1.3",
-				"@comunica/types": "^5.1.3",
-				"@comunica/utils-bindings-factory": "^5.1.3",
-				"@comunica/utils-metadata": "^5.1.3",
+				"@comunica/bus-merge-bindings-context": "^5.2.0",
+				"@comunica/bus-rdf-join": "^5.2.0",
+				"@comunica/context-entries": "^5.2.0",
+				"@comunica/core": "^5.2.0",
+				"@comunica/mediatortype-join-coefficients": "^5.2.0",
+				"@comunica/types": "^5.2.0",
+				"@comunica/utils-bindings-factory": "^5.2.0",
+				"@comunica/utils-metadata": "^5.2.0",
 				"@rdfjs/types": "*",
 				"asynciterator": "^3.10.0"
 			},
@@ -3450,15 +3494,15 @@
 			}
 		},
 		"node_modules/@comunica/actor-rdf-join-inner-single": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-inner-single/-/actor-rdf-join-inner-single-5.1.3.tgz",
-			"integrity": "sha512-k27OLJ0Bg2aoCW/zBxAvmZNjk+kqibx843wAaQdOY1qxlsf3XK59HOROYeHAk+ydnYP6lWwMjuDco2jTI9Uvzw==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-inner-single/-/actor-rdf-join-inner-single-5.2.0.tgz",
+			"integrity": "sha512-lXvrvWEyVNmJAYt2axVIr2x70JE0e3mK/dZ/S7UFBysWn40BFhCtyvalCbP2227JBy9gLLCmpLtiB30D0/yEkg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-rdf-join": "^5.1.3",
-				"@comunica/core": "^5.1.3",
-				"@comunica/mediatortype-join-coefficients": "^5.1.3"
+				"@comunica/bus-rdf-join": "^5.2.0",
+				"@comunica/core": "^5.2.0",
+				"@comunica/mediatortype-join-coefficients": "^5.2.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -3466,16 +3510,16 @@
 			}
 		},
 		"node_modules/@comunica/actor-rdf-join-inner-symmetrichash": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-inner-symmetrichash/-/actor-rdf-join-inner-symmetrichash-5.1.3.tgz",
-			"integrity": "sha512-U41j1sziGCIM04kejE8Vf/w3bf+fXI+xPc/JAEfikFZcq3GufGHp6+6x4/WI/mI+D2/0vI3w0PxngZ+1EAuFkw==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-inner-symmetrichash/-/actor-rdf-join-inner-symmetrichash-5.2.0.tgz",
+			"integrity": "sha512-sDNJ49e0MQACIP3gy1knHPbMlYOnl72pp2FyIUMLZixLtm9sHBigxaaTyNS2PQt809lZv/6/R71Xbs+2gD6aRA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-hash-bindings": "^5.1.3",
-				"@comunica/bus-rdf-join": "^5.1.3",
-				"@comunica/core": "^5.1.3",
-				"@comunica/mediatortype-join-coefficients": "^5.1.3",
+				"@comunica/bus-hash-bindings": "^5.2.0",
+				"@comunica/bus-rdf-join": "^5.2.0",
+				"@comunica/core": "^5.2.0",
+				"@comunica/mediatortype-join-coefficients": "^5.2.0",
 				"asyncjoin": "^1.2.4"
 			},
 			"funding": {
@@ -3484,18 +3528,18 @@
 			}
 		},
 		"node_modules/@comunica/actor-rdf-join-minus-hash": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-minus-hash/-/actor-rdf-join-minus-hash-5.1.3.tgz",
-			"integrity": "sha512-vFcWRkqjalJUJm5mTKP/VAYK0hP01mwf5fF23qeXeSW3tjP7ePn34+NA0N+Igf/XPQVtRmd+b92woFuHm6ydfw==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-minus-hash/-/actor-rdf-join-minus-hash-5.2.0.tgz",
+			"integrity": "sha512-7T6TZCxGCjzjnCPR4vUPeYx1jkeAVxiIllO/iNF7jq1Cfhh7jVs7ADHggqnZtnpPucotECJr8rh/eOPfVVVQmg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-rdf-join": "^5.1.3",
-				"@comunica/core": "^5.1.3",
-				"@comunica/mediatortype-join-coefficients": "^5.1.3",
-				"@comunica/types": "^5.1.3",
-				"@comunica/utils-bindings-factory": "^5.1.3",
-				"@comunica/utils-bindings-index": "^5.1.3",
+				"@comunica/bus-rdf-join": "^5.2.0",
+				"@comunica/core": "^5.2.0",
+				"@comunica/mediatortype-join-coefficients": "^5.2.0",
+				"@comunica/types": "^5.2.0",
+				"@comunica/utils-bindings-factory": "^5.2.0",
+				"@comunica/utils-bindings-index": "^5.2.0",
 				"@comunica/utils-iterator": "^5.0.0",
 				"@rdfjs/types": "*",
 				"rdf-string": "^2.0.1"
@@ -3506,23 +3550,23 @@
 			}
 		},
 		"node_modules/@comunica/actor-rdf-join-optional-bind": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-optional-bind/-/actor-rdf-join-optional-bind-5.1.3.tgz",
-			"integrity": "sha512-1PJHdLjCNa4mQjaNVZKO2BovL9abB2wfa0ch1AQlMIA1uCpX3jj3iLXMB1GIDNe6aeArkuyL+cKUHQH6RqXLBg==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-optional-bind/-/actor-rdf-join-optional-bind-5.2.0.tgz",
+			"integrity": "sha512-JwTBpD1dy+K9vrH1IemF1O1ePIbKXDSpdRNPkTk/zp4xN/7c1sU2jViQLifT4427dGUemW45JppFerWj0pi8Pg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/actor-rdf-join-inner-multi-bind": "^5.1.3",
-				"@comunica/bus-merge-bindings-context": "^5.1.3",
-				"@comunica/bus-query-operation": "^5.1.3",
-				"@comunica/bus-rdf-join": "^5.1.3",
-				"@comunica/context-entries": "^5.1.3",
-				"@comunica/core": "^5.1.3",
-				"@comunica/mediatortype-join-coefficients": "^5.1.3",
-				"@comunica/types": "^5.1.3",
-				"@comunica/utils-algebra": "^5.1.3",
-				"@comunica/utils-bindings-factory": "^5.1.3",
-				"@comunica/utils-query-operation": "^5.1.3"
+				"@comunica/actor-rdf-join-inner-multi-bind": "^5.2.0",
+				"@comunica/bus-merge-bindings-context": "^5.2.0",
+				"@comunica/bus-query-operation": "^5.2.0",
+				"@comunica/bus-rdf-join": "^5.2.0",
+				"@comunica/context-entries": "^5.2.0",
+				"@comunica/core": "^5.2.0",
+				"@comunica/mediatortype-join-coefficients": "^5.2.0",
+				"@comunica/types": "^5.2.0",
+				"@comunica/utils-algebra": "^5.2.0",
+				"@comunica/utils-bindings-factory": "^5.2.0",
+				"@comunica/utils-query-operation": "^5.2.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -3530,18 +3574,18 @@
 			}
 		},
 		"node_modules/@comunica/actor-rdf-join-optional-hash": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-optional-hash/-/actor-rdf-join-optional-hash-5.1.3.tgz",
-			"integrity": "sha512-XgJzTvWAPh3qwsmK8BxGvezB+IRsYGS9jwvIcQeXnZ6Q+8Br9S9wRtZk5fU22t6B0Ra1bIuLrH3PVMAlJHFTJg==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-optional-hash/-/actor-rdf-join-optional-hash-5.2.0.tgz",
+			"integrity": "sha512-DlBSsHxUK5WncQHmu6HLK7jHj7tu/welm+U9CPp346nA5bX/xcgZALsuvyskrDGCoUpBGMzrw100DUB+wHXWHw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-rdf-join": "^5.1.3",
-				"@comunica/core": "^5.1.3",
-				"@comunica/mediatortype-join-coefficients": "^5.1.3",
-				"@comunica/types": "^5.1.3",
-				"@comunica/utils-bindings-factory": "^5.1.3",
-				"@comunica/utils-bindings-index": "^5.1.3",
+				"@comunica/bus-rdf-join": "^5.2.0",
+				"@comunica/core": "^5.2.0",
+				"@comunica/mediatortype-join-coefficients": "^5.2.0",
+				"@comunica/types": "^5.2.0",
+				"@comunica/utils-bindings-factory": "^5.2.0",
+				"@comunica/utils-bindings-index": "^5.2.0",
 				"@comunica/utils-iterator": "^5.0.0",
 				"asynciterator": "^3.10.0",
 				"rdf-string": "^2.0.1"
@@ -3552,15 +3596,15 @@
 			}
 		},
 		"node_modules/@comunica/actor-rdf-join-optional-nestedloop": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-optional-nestedloop/-/actor-rdf-join-optional-nestedloop-5.1.3.tgz",
-			"integrity": "sha512-prsgzCT+JqKUXN0Xg7NxPEUfzR9XCPz/Xbk+QCjJr2sKmObU+TQQx2X6nDudx5tGVCr1JhrYSG7UUJkVoLf8Kw==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-optional-nestedloop/-/actor-rdf-join-optional-nestedloop-5.2.0.tgz",
+			"integrity": "sha512-5wfVtGiXro1Fjg6W8XPUrd+Q6VEn6+nkM9KekoWIFweyrODGww9VrHBVsgFwOqwhoNQ1SI+1p0Fj+40DYbcCTA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-rdf-join": "^5.1.3",
-				"@comunica/core": "^5.1.3",
-				"@comunica/mediatortype-join-coefficients": "^5.1.3",
+				"@comunica/bus-rdf-join": "^5.2.0",
+				"@comunica/core": "^5.2.0",
+				"@comunica/mediatortype-join-coefficients": "^5.2.0",
 				"asyncjoin": "^1.2.4"
 			},
 			"funding": {
@@ -3569,16 +3613,16 @@
 			}
 		},
 		"node_modules/@comunica/actor-rdf-join-selectivity-variable-counting": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-selectivity-variable-counting/-/actor-rdf-join-selectivity-variable-counting-5.1.3.tgz",
-			"integrity": "sha512-LViPdsDoPQNycgs82yjXP/CFUn+B/UmCOLF40EwzJ54KvMqlVkQH+eSXAMOZ+VAVUyDFf4haRNi6YQjAfWBC1w==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-selectivity-variable-counting/-/actor-rdf-join-selectivity-variable-counting-5.2.0.tgz",
+			"integrity": "sha512-bceQyoiHx16s6OgayYnub69Od3LB8jFcWfhwKAanbrbJepnJ9swRJ6hGOwFZWSqkpNM6HPcFX/4lclMSgm79rg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-rdf-join-selectivity": "^5.1.3",
-				"@comunica/core": "^5.1.3",
-				"@comunica/mediatortype-accuracy": "^5.1.3",
-				"@comunica/utils-algebra": "^5.1.3"
+				"@comunica/bus-rdf-join-selectivity": "^5.2.0",
+				"@comunica/core": "^5.2.0",
+				"@comunica/mediatortype-accuracy": "^5.2.0",
+				"@comunica/utils-algebra": "^5.2.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -3586,15 +3630,15 @@
 			}
 		},
 		"node_modules/@comunica/actor-rdf-metadata-accumulate-cardinality": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-accumulate-cardinality/-/actor-rdf-metadata-accumulate-cardinality-5.1.3.tgz",
-			"integrity": "sha512-Vwby9Ye6uvxZraX0+GGkQzRNIQyj4eC2x0odZAd9UIfKek1yxz7f23y4Dh/UgOt8NwLa8XKcTzEFSH7m5DeiDg==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-accumulate-cardinality/-/actor-rdf-metadata-accumulate-cardinality-5.2.0.tgz",
+			"integrity": "sha512-hQHwh091qarW1RfHil67vjCAHBSZR+IriC7Tka5BuRn577OMhOHM8Beo0lkbBDgQFMrWn5So74u0hufTLDM8hQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-rdf-metadata-accumulate": "^5.1.3",
-				"@comunica/core": "^5.1.3",
-				"@comunica/types": "^5.1.3"
+				"@comunica/bus-rdf-metadata-accumulate": "^5.2.0",
+				"@comunica/core": "^5.2.0",
+				"@comunica/types": "^5.2.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -3602,14 +3646,14 @@
 			}
 		},
 		"node_modules/@comunica/actor-rdf-metadata-accumulate-pagesize": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-accumulate-pagesize/-/actor-rdf-metadata-accumulate-pagesize-5.1.3.tgz",
-			"integrity": "sha512-+UdaqRlyOHkkSoKd+W1xSCf7IrMVlHoeDov6y1tzzYbnFLnyjEVx+0XW6f8S6FTyQ8uYZOMISqgEEh0CXfKHXg==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-accumulate-pagesize/-/actor-rdf-metadata-accumulate-pagesize-5.2.0.tgz",
+			"integrity": "sha512-sQP6FAEpTPJF7dfAjKApzh6ZooiRZHD/Hkd+I0/RQzaQ5EnFYdmp4Pr+cOwImNueKMFbrO+L70s+zFrnJ50cAg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-rdf-metadata-accumulate": "^5.1.3",
-				"@comunica/core": "^5.1.3"
+				"@comunica/bus-rdf-metadata-accumulate": "^5.2.0",
+				"@comunica/core": "^5.2.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -3617,14 +3661,14 @@
 			}
 		},
 		"node_modules/@comunica/actor-rdf-metadata-accumulate-requesttime": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-accumulate-requesttime/-/actor-rdf-metadata-accumulate-requesttime-5.1.3.tgz",
-			"integrity": "sha512-O4a/oBTu3E58mfZ5oCxXibanBHsCX0db0B0eeWJtuWswQN1vRlj66xpjGNcC+wSz4i04KjmDkAyZTyisj8nIwA==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-accumulate-requesttime/-/actor-rdf-metadata-accumulate-requesttime-5.2.0.tgz",
+			"integrity": "sha512-wwdCE6W/gV5WMB/0RCM2BLnJZ2yZob+nOeMuFra6KyGI3b9j1DL/kc/qbhJ4uffC04hiCyYc84F+ErItYorn1A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-rdf-metadata-accumulate": "^5.1.3",
-				"@comunica/core": "^5.1.3"
+				"@comunica/bus-rdf-metadata-accumulate": "^5.2.0",
+				"@comunica/core": "^5.2.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -3632,14 +3676,14 @@
 			}
 		},
 		"node_modules/@comunica/actor-rdf-metadata-all": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-all/-/actor-rdf-metadata-all-5.1.3.tgz",
-			"integrity": "sha512-SiwMp96+pe726PUau785pceIhmmUh35p2lUWmGFAafTtLzMvdb/4yw0vU8J9XGEFmz/njzYT1PfgwM1K0CUqYQ==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-all/-/actor-rdf-metadata-all-5.2.0.tgz",
+			"integrity": "sha512-RZX307EAFVfb+7iydqH7JQF3Fbg+VcZqYGPAK24PCwMxRqtqejKV/0W955Z7wQ8QyCooK/FfiH5pmtOfaBjj5g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-rdf-metadata": "^5.1.3",
-				"@comunica/core": "^5.1.3",
+				"@comunica/bus-rdf-metadata": "^5.2.0",
+				"@comunica/core": "^5.2.0",
 				"readable-stream": "^4.7.0"
 			},
 			"funding": {
@@ -3648,14 +3692,14 @@
 			}
 		},
 		"node_modules/@comunica/actor-rdf-metadata-extract-allow-http-methods": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-extract-allow-http-methods/-/actor-rdf-metadata-extract-allow-http-methods-5.1.3.tgz",
-			"integrity": "sha512-fMB7iG4LYt2cTGmZ44o1Z6lZyN/4zF8xqomqEJrr28wA9Gqbso12ZODj0QphJGY6t3VPeoX6Fpmjhc/seMgqHA==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-extract-allow-http-methods/-/actor-rdf-metadata-extract-allow-http-methods-5.2.0.tgz",
+			"integrity": "sha512-YuJT3evvol/y6fErIwKK23MXvtauxDbe/g2ytZUDgDbBxLi92W02XhDh6cGqzq6FmJ29DIrK17q9VMyKnIliYA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-rdf-metadata-extract": "^5.1.3",
-				"@comunica/core": "^5.1.3"
+				"@comunica/bus-rdf-metadata-extract": "^5.2.0",
+				"@comunica/core": "^5.2.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -3663,14 +3707,14 @@
 			}
 		},
 		"node_modules/@comunica/actor-rdf-metadata-extract-hydra-controls": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-extract-hydra-controls/-/actor-rdf-metadata-extract-hydra-controls-5.1.3.tgz",
-			"integrity": "sha512-wdB9AcfQL/bl7KRxW9cT911wJadeRwDvkeNut8k5SRAq//ahXSkO2MdIglGiS9pgr8BTUwtF4tKEvQsGc6yCkw==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-extract-hydra-controls/-/actor-rdf-metadata-extract-hydra-controls-5.2.0.tgz",
+			"integrity": "sha512-d4+iilqjQJ2SGjKedpB9B7/QpHf3fsEPnWcoqEyBLFyYM2mdPNV3KpN2916NY18AqWv9REBI/H40y+/K6Te9Mw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-rdf-metadata-extract": "^5.1.3",
-				"@comunica/core": "^5.1.3",
+				"@comunica/bus-rdf-metadata-extract": "^5.2.0",
+				"@comunica/core": "^5.2.0",
 				"@rdfjs/types": "*",
 				"@types/uritemplate": "^0.3.4",
 				"uritemplate": "0.3.4"
@@ -3681,14 +3725,14 @@
 			}
 		},
 		"node_modules/@comunica/actor-rdf-metadata-extract-hydra-count": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-extract-hydra-count/-/actor-rdf-metadata-extract-hydra-count-5.1.3.tgz",
-			"integrity": "sha512-75pBxALDnQmTUCmDvbT6ctZyNvMJEUmc1SHBcGCkpeobX1k8gl2+1jrbOta+mG2Hp/dfk1e9h+ZqfUk34cF5OQ==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-extract-hydra-count/-/actor-rdf-metadata-extract-hydra-count-5.2.0.tgz",
+			"integrity": "sha512-GGvU5LUOi+lmYiLaWd2oAyiUSo+PGZ4dDNQt8LBVXqORK/Ws3Rqcx052KcjzR9ihZR4Ljf20UYz3bXBcGJQnRA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-rdf-metadata-extract": "^5.1.3",
-				"@comunica/core": "^5.1.3"
+				"@comunica/bus-rdf-metadata-extract": "^5.2.0",
+				"@comunica/core": "^5.2.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -3696,14 +3740,14 @@
 			}
 		},
 		"node_modules/@comunica/actor-rdf-metadata-extract-hydra-pagesize": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-extract-hydra-pagesize/-/actor-rdf-metadata-extract-hydra-pagesize-5.1.3.tgz",
-			"integrity": "sha512-v066/WKTGVtE2if0Qf22N11Cvy9koMpmDvRd+JL3H4J9P/0SIELM2Qg6a62DD570K3AMBlwtAwA9iKyJEu//ng==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-extract-hydra-pagesize/-/actor-rdf-metadata-extract-hydra-pagesize-5.2.0.tgz",
+			"integrity": "sha512-3Pna95OiVVAFsUqOFFJ0Ly0SjXcXobZztoc3Hf4IzFyH30F8oIqf9WCYfFBC+LfOvzG5gJKWEFnz53CSh5rekw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-rdf-metadata-extract": "^5.1.3",
-				"@comunica/core": "^5.1.3"
+				"@comunica/bus-rdf-metadata-extract": "^5.2.0",
+				"@comunica/core": "^5.2.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -3711,14 +3755,14 @@
 			}
 		},
 		"node_modules/@comunica/actor-rdf-metadata-extract-patch-sparql-update": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-extract-patch-sparql-update/-/actor-rdf-metadata-extract-patch-sparql-update-5.1.3.tgz",
-			"integrity": "sha512-rCUY07vdDKpdY9B2cmCoZFFdPXY1zZ5NNRf151JEUPzeHO6MIHe0MFlW+3pXF0a5c+gBqUc7nv2TMTuSFY6P5A==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-extract-patch-sparql-update/-/actor-rdf-metadata-extract-patch-sparql-update-5.2.0.tgz",
+			"integrity": "sha512-fjiTZ3K4XYGuPhdyDCaKBf5Y0Gndy7kztzDe8Dh5KXbR0HuHejYtIT9OKzJ5CgBn2VwP/cGY3+dia2pPF/c1aw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-rdf-metadata-extract": "^5.1.3",
-				"@comunica/core": "^5.1.3"
+				"@comunica/bus-rdf-metadata-extract": "^5.2.0",
+				"@comunica/core": "^5.2.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -3726,14 +3770,14 @@
 			}
 		},
 		"node_modules/@comunica/actor-rdf-metadata-extract-post-accepted": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-extract-post-accepted/-/actor-rdf-metadata-extract-post-accepted-5.1.3.tgz",
-			"integrity": "sha512-ReDpvtoKhi0MUqX3JtBbv/55IsuzQh2h58h7iXhMudwpYhmP3SblIuvp8YiqItNz+k0GpAygtwogeArVgI59Ww==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-extract-post-accepted/-/actor-rdf-metadata-extract-post-accepted-5.2.0.tgz",
+			"integrity": "sha512-jLtZ5fwRHURmgF1cfKR5lXmjFS2QBuMEnFjRUy9wWbNB/eF7fpEmVRZ6gDC5HKPf1bx0Lh7TA7wArasE5/2Orw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-rdf-metadata-extract": "^5.1.3",
-				"@comunica/core": "^5.1.3"
+				"@comunica/bus-rdf-metadata-extract": "^5.2.0",
+				"@comunica/core": "^5.2.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -3741,14 +3785,14 @@
 			}
 		},
 		"node_modules/@comunica/actor-rdf-metadata-extract-put-accepted": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-extract-put-accepted/-/actor-rdf-metadata-extract-put-accepted-5.1.3.tgz",
-			"integrity": "sha512-iqP5VBGJgsaqOmrx4Rciwh89kyDc4sID+Gml81WX+qNK7xvn8cZxnKNM2JISNRK7Q4kP7xzObMwn20T/7LAUhg==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-extract-put-accepted/-/actor-rdf-metadata-extract-put-accepted-5.2.0.tgz",
+			"integrity": "sha512-5MSokKEJDxqwCLc2+hq2y9wvrIbm0xHCGlDaQ45XvK3Yfjy/tbu0RCwjJNEKog6qfRBIkEl6ABFS4B0q+mqv5Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-rdf-metadata-extract": "^5.1.3",
-				"@comunica/core": "^5.1.3"
+				"@comunica/bus-rdf-metadata-extract": "^5.2.0",
+				"@comunica/core": "^5.2.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -3756,14 +3800,29 @@
 			}
 		},
 		"node_modules/@comunica/actor-rdf-metadata-extract-request-time": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-extract-request-time/-/actor-rdf-metadata-extract-request-time-5.1.3.tgz",
-			"integrity": "sha512-urfSfwy0Z2IM6SvsJWtg5bi4DuCEU0A9JNR/2d4LLZh0srjPREk2SS7av0cX1Vkq85FBOG5cTjgbSlM0trP93g==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-extract-request-time/-/actor-rdf-metadata-extract-request-time-5.2.0.tgz",
+			"integrity": "sha512-RE25jL2UQ1SYx+cosluLF5vOzr3ZY1KPZLskDC9Bel4iOM8Fi2sWcu8AXo8uSzfhBWu1Ug0h2QD6y7W30mRoug==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-rdf-metadata-extract": "^5.1.3",
-				"@comunica/core": "^5.1.3"
+				"@comunica/bus-rdf-metadata-extract": "^5.2.0",
+				"@comunica/core": "^5.2.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/comunica-association"
+			}
+		},
+		"node_modules/@comunica/actor-rdf-metadata-extract-server-software": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-extract-server-software/-/actor-rdf-metadata-extract-server-software-5.2.0.tgz",
+			"integrity": "sha512-T0OErS65c5PVMjtLgKCbdXupRYpLzohPrlKg9QdYBCPKpwHNJDYXGqJCg7Qo92aL/x+oLxIa4ZpHXOXamBqLdw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@comunica/bus-rdf-metadata-extract": "^5.2.0",
+				"@comunica/core": "^5.2.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -3771,14 +3830,14 @@
 			}
 		},
 		"node_modules/@comunica/actor-rdf-metadata-extract-sparql-service": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-extract-sparql-service/-/actor-rdf-metadata-extract-sparql-service-5.1.3.tgz",
-			"integrity": "sha512-gUKb///+/rTpq4iKZCHP4LiPSkk3ywCHxzFYWKisWEmi79HRh9PVsRhETIT3/6vNP8nC03EJP5/k3OD+uqLq/Q==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-extract-sparql-service/-/actor-rdf-metadata-extract-sparql-service-5.2.0.tgz",
+			"integrity": "sha512-yVel37Cj9LfkC/1/akqK3+Pfcru1xFV9bfJiA79ZQSmah2b+6lUIxNnZhRTYGzAmOb5oEayuKX31KzaNjdwi9A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-rdf-metadata-extract": "^5.1.3",
-				"@comunica/core": "^5.1.3",
+				"@comunica/bus-rdf-metadata-extract": "^5.2.0",
+				"@comunica/core": "^5.2.0",
 				"@rdfjs/types": "*",
 				"relative-to-absolute-iri": "^1.0.7"
 			},
@@ -3788,28 +3847,28 @@
 			}
 		},
 		"node_modules/@comunica/actor-rdf-metadata-extract-void": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-extract-void/-/actor-rdf-metadata-extract-void-5.1.3.tgz",
-			"integrity": "sha512-GSVasBKtKOEfsD7RYp3BfR3x+gGXbjt+ZZDQTwON8cZgWyZkU7DhxJ0DLKrJJgte/LbJWdufObHj6tel1TNmOw==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-extract-void/-/actor-rdf-metadata-extract-void-5.2.0.tgz",
+			"integrity": "sha512-dMG8Oi4IuBtqpCC6wTFPM5SSvtK//e4hepbn8jCGAqry0Z+1M6AX0aWP4TFMbQ/vUcmfLVcRrMh6QLl8EDsWkg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-rdf-metadata-extract": "^5.1.3",
-				"@comunica/core": "^5.1.3",
-				"@comunica/types": "^5.1.3",
-				"@comunica/utils-algebra": "^5.1.3",
+				"@comunica/bus-rdf-metadata-extract": "^5.2.0",
+				"@comunica/core": "^5.2.0",
+				"@comunica/types": "^5.2.0",
+				"@comunica/utils-algebra": "^5.2.0",
 				"@rdfjs/types": "*"
 			}
 		},
 		"node_modules/@comunica/actor-rdf-metadata-primary-topic": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-primary-topic/-/actor-rdf-metadata-primary-topic-5.1.3.tgz",
-			"integrity": "sha512-AV2RTwp4Innv0JL3aOfFhPunbdtETkBpKtGh6dMed/JyoQnnIvV/RJo+k7jSF/weGygZxJlH0PwULEpyKQDdPw==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-primary-topic/-/actor-rdf-metadata-primary-topic-5.2.0.tgz",
+			"integrity": "sha512-FQz+7wWcXR5sBG5cX9THSb8AKxN/baZMNvHHFZ6bAviwE01QPCgsg7cNCY1Uzcm+xtWC8kO6MC5dHai4E06pfw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-rdf-metadata": "^5.1.3",
-				"@comunica/core": "^5.1.3",
+				"@comunica/bus-rdf-metadata": "^5.2.0",
+				"@comunica/core": "^5.2.0",
 				"@rdfjs/types": "*",
 				"readable-stream": "^4.7.0"
 			},
@@ -3819,16 +3878,16 @@
 			}
 		},
 		"node_modules/@comunica/actor-rdf-parse-html": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-html/-/actor-rdf-parse-html-5.1.3.tgz",
-			"integrity": "sha512-YfyXKpJtcX3RHhpdr68wtHbDTREtanUGB+KrQLHRzkCIbQyQ76CmWcBZVZnrsxIb2Lv/kSWJjwhoAdw0qYGkwQ==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-html/-/actor-rdf-parse-html-5.2.0.tgz",
+			"integrity": "sha512-EcP1dq4+e75SxvPU/YmwbQiupc8I6CI8XW+RKulSt1XSL+uF9LwCZmFseSL5lFIN+XVfMjDe6RdqJHMRwJXMEg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-rdf-parse": "^5.1.3",
-				"@comunica/bus-rdf-parse-html": "^5.1.3",
-				"@comunica/core": "^5.1.3",
-				"@comunica/types": "^5.1.3",
+				"@comunica/bus-rdf-parse": "^5.2.0",
+				"@comunica/bus-rdf-parse-html": "^5.2.0",
+				"@comunica/core": "^5.2.0",
+				"@comunica/types": "^5.2.0",
 				"@rdfjs/types": "*",
 				"htmlparser2": "^10.0.0",
 				"readable-stream": "^4.7.0"
@@ -3839,16 +3898,16 @@
 			}
 		},
 		"node_modules/@comunica/actor-rdf-parse-html-microdata": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-html-microdata/-/actor-rdf-parse-html-microdata-5.1.3.tgz",
-			"integrity": "sha512-A+9vfMgp5aAArWgKZcJxeRpolNn6OL9EU5IGFB9AhfOiMWKqgaxBIFrrn+Bd2S4yi5AE4XA0BDSCKw9hjOD/Ng==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-html-microdata/-/actor-rdf-parse-html-microdata-5.2.0.tgz",
+			"integrity": "sha512-k48MXHmxoZiN28wfBN1RykKf3lBbI2KxLd6iivtKYS9PQx5F9FPv2B4E8OF0fsuyXkFK+u/+du+l7L0DrF6dyw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-rdf-parse-html": "^5.1.3",
-				"@comunica/context-entries": "^5.1.3",
-				"@comunica/core": "^5.1.3",
-				"@comunica/types": "^5.1.3",
+				"@comunica/bus-rdf-parse-html": "^5.2.0",
+				"@comunica/context-entries": "^5.2.0",
+				"@comunica/core": "^5.2.0",
+				"@comunica/types": "^5.2.0",
 				"microdata-rdf-streaming-parser": "^3.0.0"
 			},
 			"funding": {
@@ -3857,16 +3916,16 @@
 			}
 		},
 		"node_modules/@comunica/actor-rdf-parse-html-rdfa": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-html-rdfa/-/actor-rdf-parse-html-rdfa-5.1.3.tgz",
-			"integrity": "sha512-YT8DRCrVz6gSD7Nz8NI3/KHSnrI+uJKhUHvF7l1GPR0HCxXVRxd3Ck9L/iAgsXv9Ilv6oXLOPum5U0kG9N4Fkg==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-html-rdfa/-/actor-rdf-parse-html-rdfa-5.2.0.tgz",
+			"integrity": "sha512-2UsUqtZQqGVixBdkAiXl6c+aPJZ1/wH1t14EuywSlhWe4bdDkH8tD4/hfDqPIPabR/oDnGgxMtMumDM4PXHPbQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-rdf-parse-html": "^5.1.3",
-				"@comunica/context-entries": "^5.1.3",
-				"@comunica/core": "^5.1.3",
-				"@comunica/types": "^5.1.3",
+				"@comunica/bus-rdf-parse-html": "^5.2.0",
+				"@comunica/context-entries": "^5.2.0",
+				"@comunica/core": "^5.2.0",
+				"@comunica/types": "^5.2.0",
 				"rdfa-streaming-parser": "^3.0.2"
 			},
 			"funding": {
@@ -3875,17 +3934,17 @@
 			}
 		},
 		"node_modules/@comunica/actor-rdf-parse-html-script": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-html-script/-/actor-rdf-parse-html-script-5.1.3.tgz",
-			"integrity": "sha512-lq9xJMMntoD8EDcQl+idsvhON9gdk5gVID8ltMIo6t31n3OFOUiWowow5zRsVBwj+JVsKimR/X0hz/yl+2tuPQ==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-html-script/-/actor-rdf-parse-html-script-5.2.0.tgz",
+			"integrity": "sha512-IEHdR5YIJbDtlMvDe3iE+MkxJ4eeo3jvQHyFrNVRACNKhfqt6arxWHMJnTcDq3AS31x11dKWMZgHUK2Ujc4dTA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-rdf-parse": "^5.1.3",
-				"@comunica/bus-rdf-parse-html": "^5.1.3",
-				"@comunica/context-entries": "^5.1.3",
-				"@comunica/core": "^5.1.3",
-				"@comunica/types": "^5.1.3",
+				"@comunica/bus-rdf-parse": "^5.2.0",
+				"@comunica/bus-rdf-parse-html": "^5.2.0",
+				"@comunica/context-entries": "^5.2.0",
+				"@comunica/core": "^5.2.0",
+				"@comunica/types": "^5.2.0",
 				"@rdfjs/types": "*",
 				"readable-stream": "^4.7.0",
 				"relative-to-absolute-iri": "^1.0.7"
@@ -3896,18 +3955,18 @@
 			}
 		},
 		"node_modules/@comunica/actor-rdf-parse-jsonld": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-jsonld/-/actor-rdf-parse-jsonld-5.1.3.tgz",
-			"integrity": "sha512-5s+EK1JiwzntFLqB4J1DNAbhjtM1v5sdK4c078Q3QuBv3+IUzXzSyAqfloCGyRo8ZMaNck3XM8kXbst5/3vzgg==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-jsonld/-/actor-rdf-parse-jsonld-5.2.0.tgz",
+			"integrity": "sha512-adTe3LcTTFetmTQwu+14jKPU6n/9fvFXDIiEAM0UmiHpyaQcd8Pjw+UtjljhhMlDcxzctYAL0RokZnAadMpLeQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-http": "^5.1.3",
-				"@comunica/bus-http-invalidate": "^5.1.3",
-				"@comunica/bus-rdf-parse": "^5.1.3",
-				"@comunica/context-entries": "^5.1.3",
-				"@comunica/core": "^5.1.3",
-				"@comunica/types": "^5.1.3",
+				"@comunica/bus-http": "^5.2.0",
+				"@comunica/bus-http-invalidate": "^5.2.0",
+				"@comunica/bus-rdf-parse": "^5.2.0",
+				"@comunica/context-entries": "^5.2.0",
+				"@comunica/core": "^5.2.0",
+				"@comunica/types": "^5.2.0",
 				"@jeswr/stream-to-string": "^2.0.0",
 				"jsonld-context-parser": "^2.2.2",
 				"jsonld-streaming-parser": "^5.0.0",
@@ -3919,27 +3978,27 @@
 			}
 		},
 		"node_modules/@comunica/actor-rdf-parse-n3": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-n3/-/actor-rdf-parse-n3-5.1.3.tgz",
-			"integrity": "sha512-OJZGclYq299rI0LfeHBu+2nabXUoSXnilJRUBUdOruvSsCBT3Y85cmGxzP4iFE25WSuS1cvdH48tbZItvXXsgQ==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-n3/-/actor-rdf-parse-n3-5.2.0.tgz",
+			"integrity": "sha512-eOwTTMRG84lHTMvFxb/bme/CwTrD8BQqdRZY1STUQLk7qeZykPTVbDReU86RcDGcTPoJYTkLJLEOfXmAhVTw8Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-rdf-parse": "^5.1.3",
-				"@comunica/context-entries": "^5.1.3",
-				"@comunica/types": "^5.1.3",
+				"@comunica/bus-rdf-parse": "^5.2.0",
+				"@comunica/context-entries": "^5.2.0",
+				"@comunica/types": "^5.2.0",
 				"n3": "^2.0.0"
 			}
 		},
 		"node_modules/@comunica/actor-rdf-parse-rdfxml": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-rdfxml/-/actor-rdf-parse-rdfxml-5.1.3.tgz",
-			"integrity": "sha512-6oHHEk85KmwQ7ildTO0yVlulNoXXXdDuCQW5a3o9E9gxJoHg52pdswbuuMO7+VybzxPcrZPUvKpwEuIPRQ2bMQ==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-rdfxml/-/actor-rdf-parse-rdfxml-5.2.0.tgz",
+			"integrity": "sha512-EXtFmwUzBVzHS/Hben/iRx8+DD/QxfsYpT9+jQZSCsHH7q2JwUCbxptK7uD65ZuJq/rcSOOQWgjPmt+hv1//hQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-rdf-parse": "^5.1.3",
-				"@comunica/context-entries": "^5.1.3",
+				"@comunica/bus-rdf-parse": "^5.2.0",
+				"@comunica/context-entries": "^5.2.0",
 				"rdfxml-streaming-parser": "^3.2.0"
 			},
 			"funding": {
@@ -3948,14 +4007,14 @@
 			}
 		},
 		"node_modules/@comunica/actor-rdf-parse-shaclc": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-shaclc/-/actor-rdf-parse-shaclc-5.1.3.tgz",
-			"integrity": "sha512-dWZnxwKgb2cGKEcWA7adIUeijDSfA3rXqAiSi6I3NZUZmJDvmj5Ze+D1DB6/RO7lxm5iHRTCKECElJiwyqgbpw==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-shaclc/-/actor-rdf-parse-shaclc-5.2.0.tgz",
+			"integrity": "sha512-RyrzErn19/ySxrtbqLuRVLVB/leqvWvXbLRETRpT05PoUrSDe4ZXW00jMntY0S3RihQyPVzYeICJchMdYs+Q1w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-rdf-parse": "^5.1.3",
-				"@comunica/types": "^5.1.3",
+				"@comunica/bus-rdf-parse": "^5.2.0",
+				"@comunica/types": "^5.2.0",
 				"@jeswr/stream-to-string": "^2.0.0",
 				"@rdfjs/types": "*",
 				"asynciterator": "^3.10.0",
@@ -3968,15 +4027,15 @@
 			}
 		},
 		"node_modules/@comunica/actor-rdf-parse-xml-rdfa": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-xml-rdfa/-/actor-rdf-parse-xml-rdfa-5.1.3.tgz",
-			"integrity": "sha512-eGioGo58dMjt/FzBPjNFeRf9wDspDHTFt6ZWXSxdeJjHuuvFQvnZEJq/3d4Oe9unHzImCRUEOcLApKbZfFbxVw==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-xml-rdfa/-/actor-rdf-parse-xml-rdfa-5.2.0.tgz",
+			"integrity": "sha512-pNkj+AYnBEYGXtGibf6cNdtoxacniZbTD8oNyFlafBopS8SOjTdlPDJpAYa5CeTNHxJ6EYrXNlb2lTWy0WSvDQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-rdf-parse": "^5.1.3",
-				"@comunica/context-entries": "^5.1.3",
-				"@comunica/types": "^5.1.3",
+				"@comunica/bus-rdf-parse": "^5.2.0",
+				"@comunica/context-entries": "^5.2.0",
+				"@comunica/types": "^5.2.0",
 				"rdfa-streaming-parser": "^3.0.2"
 			},
 			"funding": {
@@ -3985,14 +4044,14 @@
 			}
 		},
 		"node_modules/@comunica/actor-rdf-resolve-hypermedia-links-next": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-hypermedia-links-next/-/actor-rdf-resolve-hypermedia-links-next-5.1.3.tgz",
-			"integrity": "sha512-64xtAg8J6LoSgSpnttCmBMvLInxGtn3Mq1w0h/dIzalTZ+LX+xmaBsaYdkNmo0K6JmVot35/M1rNVHbkJmHr9w==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-hypermedia-links-next/-/actor-rdf-resolve-hypermedia-links-next-5.2.0.tgz",
+			"integrity": "sha512-zpoE5YkLpuWW//vPdJOv/mr3gvRc6eRSAy6Lb6U0RHAVsdKnGVfjmIrvALPb59nL+z//VMBwRF/kD0Fbaugg4Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-rdf-resolve-hypermedia-links": "^5.1.3",
-				"@comunica/core": "^5.1.3"
+				"@comunica/bus-rdf-resolve-hypermedia-links": "^5.2.0",
+				"@comunica/core": "^5.2.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -4000,15 +4059,15 @@
 			}
 		},
 		"node_modules/@comunica/actor-rdf-resolve-hypermedia-links-queue-fifo": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-hypermedia-links-queue-fifo/-/actor-rdf-resolve-hypermedia-links-queue-fifo-5.1.3.tgz",
-			"integrity": "sha512-zJWMRyoW8Q3cOcQoMZtDaWBJoTkuAaqkvcP6V8SfK8yqG+ARH0JMJoWwbcYHi7hi/xbxAEJgWaZmlgzpz5jxrw==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-hypermedia-links-queue-fifo/-/actor-rdf-resolve-hypermedia-links-queue-fifo-5.2.0.tgz",
+			"integrity": "sha512-9vYn7Uub0PzCEN6DcvuTF/YkdxcmkRds8UeB4bDTS1vIviaNiyjMv6JdggCxlacpXT3bjQ2y9sSI2hspH4AZnA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-rdf-resolve-hypermedia-links-queue": "^5.1.3",
-				"@comunica/core": "^5.1.3",
-				"@comunica/types": "^5.1.3"
+				"@comunica/bus-rdf-resolve-hypermedia-links-queue": "^5.2.0",
+				"@comunica/core": "^5.2.0",
+				"@comunica/types": "^5.2.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -4016,14 +4075,14 @@
 			}
 		},
 		"node_modules/@comunica/actor-rdf-serialize-jsonld": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-rdf-serialize-jsonld/-/actor-rdf-serialize-jsonld-5.1.3.tgz",
-			"integrity": "sha512-QqfsVclU5rF28cNkO1EZoOm+zT/70s3y2ljnDx2v9zLvImE4iwdLwMYe4ueXPqXRdmwI85/qqsLkNcMtMKEMtg==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-rdf-serialize-jsonld/-/actor-rdf-serialize-jsonld-5.2.0.tgz",
+			"integrity": "sha512-68l13KG9NZOKssdLg/ueQme3fD2aNDdouWkOswtx0reHGfbyQLrcVXd0yNkOkdUfzHJwxiNeAoDK5mq4c/Aeug==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-rdf-serialize": "^5.1.3",
-				"@comunica/types": "^5.1.3",
+				"@comunica/bus-rdf-serialize": "^5.2.0",
+				"@comunica/types": "^5.2.0",
 				"jsonld-streaming-serializer": "^4.0.0"
 			},
 			"funding": {
@@ -4032,25 +4091,25 @@
 			}
 		},
 		"node_modules/@comunica/actor-rdf-serialize-n3": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-rdf-serialize-n3/-/actor-rdf-serialize-n3-5.1.3.tgz",
-			"integrity": "sha512-tH9lNJZLTSsk9CqANHeV+W4kTI2k3wGbcSa0H5D72rI7CbjDcQf97YDAcbdnpvbavS66TB3mibjV9ekeMqVOfg==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-rdf-serialize-n3/-/actor-rdf-serialize-n3-5.2.0.tgz",
+			"integrity": "sha512-Yn90qZUBrsQaFSh+jd6Sokm1R7GopnE5dVEvqkyY76DhQqw+Ph1lXwJTW7Vtwsb5fUG0gLyW2rEpRwdCOFBL6g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-rdf-serialize": "^5.1.3",
-				"@comunica/context-entries": "^5.1.3",
+				"@comunica/bus-rdf-serialize": "^5.2.0",
+				"@comunica/context-entries": "^5.2.0",
 				"n3": "^2.0.0"
 			}
 		},
 		"node_modules/@comunica/actor-rdf-serialize-shaclc": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-rdf-serialize-shaclc/-/actor-rdf-serialize-shaclc-5.1.3.tgz",
-			"integrity": "sha512-KgcgtfzWl8HMgXP7B+DcycV6Neiv/GWfnt2tZ0rUY81xkf2Pb6HjYAprK9nhkUEnz6hWPBGCU8SGF77+dJakLA==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-rdf-serialize-shaclc/-/actor-rdf-serialize-shaclc-5.2.0.tgz",
+			"integrity": "sha512-meHUhRqf+1JlPTl7Ys2VGE9x6x6tH24BLexWoNhtQtESZKgwqwTCpELJYwABFPkIaW4sd30oIdJc8+z1CA5baA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-rdf-serialize": "^5.1.3",
+				"@comunica/bus-rdf-serialize": "^5.2.0",
 				"arrayify-stream": "^2.0.1",
 				"readable-stream": "^4.7.0",
 				"shaclc-write": "^1.6.0"
@@ -4061,17 +4120,17 @@
 			}
 		},
 		"node_modules/@comunica/actor-rdf-update-hypermedia-patch-sparql-update": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-rdf-update-hypermedia-patch-sparql-update/-/actor-rdf-update-hypermedia-patch-sparql-update-5.1.3.tgz",
-			"integrity": "sha512-1AabrIU2pntk5zycY2ISX4YC+K9d21ZwLaTVO5c29zzzK2YSnFBXFt2Rm2lLZ+dl127kEC67O+UYfxXw8K01xw==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-rdf-update-hypermedia-patch-sparql-update/-/actor-rdf-update-hypermedia-patch-sparql-update-5.2.0.tgz",
+			"integrity": "sha512-+YjUIC0sGeWRIj1l/VQW4i3P/OQMOS5lRSLMRIDUOWrkv/RBwvyYyfrvShZVylD8v3Cd+EHvfMlXCUfjEG2ssA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-http": "^5.1.3",
-				"@comunica/bus-rdf-update-hypermedia": "^5.1.3",
-				"@comunica/bus-rdf-update-quads": "^5.1.3",
-				"@comunica/core": "^5.1.3",
-				"@comunica/types": "^5.1.3",
+				"@comunica/bus-http": "^5.2.0",
+				"@comunica/bus-rdf-update-hypermedia": "^5.2.0",
+				"@comunica/bus-rdf-update-quads": "^5.2.0",
+				"@comunica/core": "^5.2.0",
+				"@comunica/types": "^5.2.0",
 				"@rdfjs/types": "*",
 				"asynciterator": "^3.10.0",
 				"rdf-string-ttl": "^2.0.1",
@@ -4083,18 +4142,18 @@
 			}
 		},
 		"node_modules/@comunica/actor-rdf-update-hypermedia-put-ldp": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-rdf-update-hypermedia-put-ldp/-/actor-rdf-update-hypermedia-put-ldp-5.1.3.tgz",
-			"integrity": "sha512-nTgEDGwyb5WRGrHSB/mXyEmx6fggX6/lpXLf3kiqz8DTEDvFyswPVii/8CWDRynuKFaBvA3iuEIk6VAaBKS7AQ==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-rdf-update-hypermedia-put-ldp/-/actor-rdf-update-hypermedia-put-ldp-5.2.0.tgz",
+			"integrity": "sha512-/ODakixSIvGDOdZH1mvPeca7sy3YQb2EobVseGqDXf3cAdAqLqEgLUROGMn3rgjsBs5RB8Xb5989fJnaPocB8A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-http": "^5.1.3",
-				"@comunica/bus-rdf-serialize": "^5.1.3",
-				"@comunica/bus-rdf-update-hypermedia": "^5.1.3",
-				"@comunica/bus-rdf-update-quads": "^5.1.3",
-				"@comunica/core": "^5.1.3",
-				"@comunica/types": "^5.1.3",
+				"@comunica/bus-http": "^5.2.0",
+				"@comunica/bus-rdf-serialize": "^5.2.0",
+				"@comunica/bus-rdf-update-hypermedia": "^5.2.0",
+				"@comunica/bus-rdf-update-quads": "^5.2.0",
+				"@comunica/core": "^5.2.0",
+				"@comunica/types": "^5.2.0",
 				"@rdfjs/types": "*",
 				"asynciterator": "^3.10.0"
 			},
@@ -4104,18 +4163,18 @@
 			}
 		},
 		"node_modules/@comunica/actor-rdf-update-hypermedia-sparql": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-rdf-update-hypermedia-sparql/-/actor-rdf-update-hypermedia-sparql-5.1.3.tgz",
-			"integrity": "sha512-5OA9HzNRDroIGx94KEL/jhzvErNpmlaKrJieC+MOfKtTzlEmCCfcugIAZXwt4Neaaqw2ER3mFsdUEa4PRNMBPQ==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-rdf-update-hypermedia-sparql/-/actor-rdf-update-hypermedia-sparql-5.2.0.tgz",
+			"integrity": "sha512-f6yCjl/kemVfuuNJ9fReAbKGOg9QVx12T4xz5luIAh3IKEU4ElvAoARW/m8AsrxA9998mMtMCcSZ4Zjqw+hjTw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-http": "^5.1.3",
-				"@comunica/bus-rdf-update-hypermedia": "^5.1.3",
-				"@comunica/bus-rdf-update-quads": "^5.1.3",
-				"@comunica/context-entries": "^5.1.3",
-				"@comunica/core": "^5.1.3",
-				"@comunica/types": "^5.1.3",
+				"@comunica/bus-http": "^5.2.0",
+				"@comunica/bus-rdf-update-hypermedia": "^5.2.0",
+				"@comunica/bus-rdf-update-quads": "^5.2.0",
+				"@comunica/context-entries": "^5.2.0",
+				"@comunica/core": "^5.2.0",
+				"@comunica/types": "^5.2.0",
 				"@jeswr/stream-to-string": "^2.0.0",
 				"@rdfjs/types": "*",
 				"asynciterator": "^3.10.0",
@@ -4128,22 +4187,22 @@
 			}
 		},
 		"node_modules/@comunica/actor-rdf-update-quads-hypermedia": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-rdf-update-quads-hypermedia/-/actor-rdf-update-quads-hypermedia-5.1.3.tgz",
-			"integrity": "sha512-dKIRysQrv0fH7835WzxfXYgjP6U+PF/QPtEjuaueyB0tY/H6AcrScCkg8AcahKR1UPm6qNXtkkwPVxPDYROepw==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-rdf-update-quads-hypermedia/-/actor-rdf-update-quads-hypermedia-5.2.0.tgz",
+			"integrity": "sha512-2lkApfoiq9ZpvKv+y9HSP3aBM7XhvQ5xKoh7+XO5PouEhhXNy4RdHLCvOP8u1rP+3jcRrs5Uoq59XxLQ60aXhA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-dereference": "^5.1.3",
-				"@comunica/bus-dereference-rdf": "^5.1.3",
-				"@comunica/bus-http-invalidate": "^5.1.3",
-				"@comunica/bus-rdf-metadata": "^5.1.3",
-				"@comunica/bus-rdf-metadata-extract": "^5.1.3",
-				"@comunica/bus-rdf-update-hypermedia": "^5.1.3",
-				"@comunica/bus-rdf-update-quads": "^5.1.3",
-				"@comunica/core": "^5.1.3",
-				"@comunica/types": "^5.1.3",
-				"@comunica/utils-query-operation": "^5.1.3",
+				"@comunica/bus-dereference": "^5.2.0",
+				"@comunica/bus-dereference-rdf": "^5.2.0",
+				"@comunica/bus-http-invalidate": "^5.2.0",
+				"@comunica/bus-rdf-metadata": "^5.2.0",
+				"@comunica/bus-rdf-metadata-extract": "^5.2.0",
+				"@comunica/bus-rdf-update-hypermedia": "^5.2.0",
+				"@comunica/bus-rdf-update-quads": "^5.2.0",
+				"@comunica/core": "^5.2.0",
+				"@comunica/types": "^5.2.0",
+				"@comunica/utils-query-operation": "^5.2.0",
 				"lru-cache": "^11.2.2"
 			},
 			"funding": {
@@ -4152,17 +4211,17 @@
 			}
 		},
 		"node_modules/@comunica/actor-rdf-update-quads-rdfjs-store": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-rdf-update-quads-rdfjs-store/-/actor-rdf-update-quads-rdfjs-store-5.1.3.tgz",
-			"integrity": "sha512-MTbUNNkJsj8HZRYNm6CicPSpqKydeZTwdFJbu/jame0PEk1Hu+UixbSO6a/xKqQ+E/pAS7NZygqJDscXy+UTTA==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-rdf-update-quads-rdfjs-store/-/actor-rdf-update-quads-rdfjs-store-5.2.0.tgz",
+			"integrity": "sha512-a3a3HTQWP367TUi9+O7g/bMgtXg3S+VzlNlwa2D6HH2bMCiVh8fG1yehLWAztwEUjCCsmJWtiR0zvwc2OVg2og==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-rdf-update-quads": "^5.1.3",
-				"@comunica/context-entries": "^5.1.3",
-				"@comunica/core": "^5.1.3",
-				"@comunica/types": "^5.1.3",
-				"@comunica/utils-query-operation": "^5.1.3",
+				"@comunica/bus-rdf-update-quads": "^5.2.0",
+				"@comunica/context-entries": "^5.2.0",
+				"@comunica/core": "^5.2.0",
+				"@comunica/types": "^5.2.0",
+				"@comunica/utils-query-operation": "^5.2.0",
 				"@rdfjs/types": "*",
 				"asynciterator": "^3.10.0",
 				"event-emitter-promisify": "^1.1.0",
@@ -4174,48 +4233,48 @@
 			}
 		},
 		"node_modules/@comunica/actor-term-comparator-factory-expression-evaluator": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/actor-term-comparator-factory-expression-evaluator/-/actor-term-comparator-factory-expression-evaluator-5.1.3.tgz",
-			"integrity": "sha512-0kwd4QpPClN0VUJZ34iiOBYlCkzPFi90NwL254lNalHT8cBrXfGImoE80jfPwpvRYYYjuHNwqIT3ck4wPCTi9g==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/actor-term-comparator-factory-expression-evaluator/-/actor-term-comparator-factory-expression-evaluator-5.2.0.tgz",
+			"integrity": "sha512-j46X2m+NB54FPI0v4hPuDLXDs7X+wlKdjlsvLZ/4crI/4pjQrgrH32/8j9XGLdt6QlSHRQ2NnIr82A+Di7Y8eA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/actor-expression-evaluator-factory-default": "^5.1.3",
-				"@comunica/bus-function-factory": "^5.1.3",
-				"@comunica/bus-term-comparator-factory": "^5.1.3",
-				"@comunica/context-entries": "^5.1.3",
-				"@comunica/core": "^5.1.3",
-				"@comunica/utils-bindings-factory": "^5.1.3",
-				"@comunica/utils-expression-evaluator": "^5.1.3",
+				"@comunica/actor-expression-evaluator-factory-default": "^5.2.0",
+				"@comunica/bus-function-factory": "^5.2.0",
+				"@comunica/bus-term-comparator-factory": "^5.2.0",
+				"@comunica/context-entries": "^5.2.0",
+				"@comunica/core": "^5.2.0",
+				"@comunica/utils-bindings-factory": "^5.2.0",
+				"@comunica/utils-expression-evaluator": "^5.2.0",
 				"@rdfjs/types": "*"
 			}
 		},
 		"node_modules/@comunica/bus-bindings-aggregator-factory": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/bus-bindings-aggregator-factory/-/bus-bindings-aggregator-factory-5.1.3.tgz",
-			"integrity": "sha512-COtwhyFPgirx2OpC1m7wObZzcNIWTNGEt7Z01Bx69i3kvsvsHkJwznLhnFzOq71sR7DoyVDZlQ3kwqgo5u/hCA==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/bus-bindings-aggregator-factory/-/bus-bindings-aggregator-factory-5.2.0.tgz",
+			"integrity": "sha512-FmkBvmJCz5YPdeqanhTvPY3fzzVYvHnkIJV/6mft+dNNCmhAo7JGQSSy3OvSdREXgTyalrecB8wushIpRbg1zQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-expression-evaluator-factory": "^5.1.3",
-				"@comunica/context-entries": "^5.1.3",
-				"@comunica/core": "^5.1.3",
-				"@comunica/types": "^5.1.3",
-				"@comunica/utils-algebra": "^5.1.3",
-				"@comunica/utils-expression-evaluator": "^5.1.3",
+				"@comunica/bus-expression-evaluator-factory": "^5.2.0",
+				"@comunica/context-entries": "^5.2.0",
+				"@comunica/core": "^5.2.0",
+				"@comunica/types": "^5.2.0",
+				"@comunica/utils-algebra": "^5.2.0",
+				"@comunica/utils-expression-evaluator": "^5.2.0",
 				"@rdfjs/types": "*",
 				"rdf-string": "^2.0.1"
 			}
 		},
 		"node_modules/@comunica/bus-context-preprocess": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/bus-context-preprocess/-/bus-context-preprocess-5.1.3.tgz",
-			"integrity": "sha512-y5LkWP2FklsJViOnzNClNl6LaDuyI3T0Y+rWnH9Kbw5/fzAGI01adAM7Tu6UlwAMshV2MnDsnuM2llFvGbi2KQ==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/bus-context-preprocess/-/bus-context-preprocess-5.2.0.tgz",
+			"integrity": "sha512-24LMc7jAAkkyqAnE56QZypEB06VU87k0sVgogBgIxj9YSZGW54VWtIhAbtqdFwijpAx4xBE5Gjw3BRz0gpOJ2w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/core": "^5.1.3",
-				"@comunica/types": "^5.1.3"
+				"@comunica/core": "^5.2.0",
+				"@comunica/types": "^5.2.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -4223,17 +4282,17 @@
 			}
 		},
 		"node_modules/@comunica/bus-dereference": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/bus-dereference/-/bus-dereference-5.1.3.tgz",
-			"integrity": "sha512-BeR3K0zzpg883tDO22PdjXBt1nVsS4Qz/rzvZ7TtfMMcPySVgTScOpmQAHWhV569aSi+ytU5dWEgzW58OIc/Xg==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/bus-dereference/-/bus-dereference-5.2.0.tgz",
+			"integrity": "sha512-9U2TyHFxzexuu/sa2yPElYcFoM5JnzlPpnJ4BMYg880MIAZDK5X683dMnItrtgiB0nMawyEqqZJmKu5hFzg5vw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/actor-abstract-mediatyped": "^5.1.3",
-				"@comunica/actor-abstract-parse": "^5.1.3",
-				"@comunica/context-entries": "^5.1.3",
-				"@comunica/core": "^5.1.3",
-				"@comunica/types": "^5.1.3",
+				"@comunica/actor-abstract-mediatyped": "^5.2.0",
+				"@comunica/actor-abstract-parse": "^5.2.0",
+				"@comunica/context-entries": "^5.2.0",
+				"@comunica/core": "^5.2.0",
+				"@comunica/types": "^5.2.0",
 				"readable-stream": "^4.7.0"
 			},
 			"funding": {
@@ -4242,15 +4301,15 @@
 			}
 		},
 		"node_modules/@comunica/bus-dereference-rdf": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/bus-dereference-rdf/-/bus-dereference-rdf-5.1.3.tgz",
-			"integrity": "sha512-Rqfyf3/NaUxSl31o59zDfQLJrQ+erHbuks/lHG9TBgEzGOattwv0k9IK5MJS2xboIyrajOGff6cn7XidyGtw+g==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/bus-dereference-rdf/-/bus-dereference-rdf-5.2.0.tgz",
+			"integrity": "sha512-VIDqpO6g0DOSgdftT5iLzykRyd70SbGGwEnaZ/e6DVL+4rkDv8ob3yKJ3S3bQXcR0c5/Z3Jts6MtDjri7ybMPw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-dereference": "^5.1.3",
-				"@comunica/bus-rdf-parse": "^5.1.3",
-				"@comunica/core": "^5.1.3",
+				"@comunica/bus-dereference": "^5.2.0",
+				"@comunica/bus-rdf-parse": "^5.2.0",
+				"@comunica/core": "^5.2.0",
 				"@rdfjs/types": "*"
 			},
 			"funding": {
@@ -4259,43 +4318,43 @@
 			}
 		},
 		"node_modules/@comunica/bus-expression-evaluator-factory": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/bus-expression-evaluator-factory/-/bus-expression-evaluator-factory-5.1.3.tgz",
-			"integrity": "sha512-Zq+iWYjOQ5WE5UnGzT6sd3ZR4plwTUgsbbSIKv2YkMAd6czoaT2WNtNcJL19GVcdhtKMG0eVOlYCfsu0RCq2/g==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/bus-expression-evaluator-factory/-/bus-expression-evaluator-factory-5.2.0.tgz",
+			"integrity": "sha512-i6UlMg2HO5Vyd8jCCS9KBHjrXhWqgyPbHz0ze7JhQFI5kCmSrpMSbfLOrgWL7D6UVhKBxicytqgm0YSywGbYiw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-function-factory": "^5.1.3",
-				"@comunica/bus-merge-bindings-context": "^5.1.3",
-				"@comunica/bus-query-operation": "^5.1.3",
-				"@comunica/core": "^5.1.3",
-				"@comunica/types": "^5.1.3",
-				"@comunica/utils-algebra": "^5.1.3"
+				"@comunica/bus-function-factory": "^5.2.0",
+				"@comunica/bus-merge-bindings-context": "^5.2.0",
+				"@comunica/bus-query-operation": "^5.2.0",
+				"@comunica/core": "^5.2.0",
+				"@comunica/types": "^5.2.0",
+				"@comunica/utils-algebra": "^5.2.0"
 			}
 		},
 		"node_modules/@comunica/bus-function-factory": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/bus-function-factory/-/bus-function-factory-5.1.3.tgz",
-			"integrity": "sha512-PhPIYnQXSPxi/vYjOToyjBHPFukXhg/1/q3zh0z0QHikUZaT8uhW36kBWYmc2t3wwtyzUw9FDG7VCDqXhOsC0g==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/bus-function-factory/-/bus-function-factory-5.2.0.tgz",
+			"integrity": "sha512-i9kGtN4iOUwnHAvdPXdNbnLXHifJtgt7gOMUz53hYPQHSgSWgDQj9vGhi+74D2bfMt75rv8EX5/ESqRXIMJ7iA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/context-entries": "^5.1.3",
-				"@comunica/core": "^5.1.3",
-				"@comunica/types": "^5.1.3",
-				"@comunica/utils-algebra": "^5.1.3",
-				"@comunica/utils-expression-evaluator": "^5.1.3"
+				"@comunica/context-entries": "^5.2.0",
+				"@comunica/core": "^5.2.0",
+				"@comunica/types": "^5.2.0",
+				"@comunica/utils-algebra": "^5.2.0",
+				"@comunica/utils-expression-evaluator": "^5.2.0"
 			}
 		},
 		"node_modules/@comunica/bus-hash-bindings": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/bus-hash-bindings/-/bus-hash-bindings-5.1.3.tgz",
-			"integrity": "sha512-bE5RkrwGpfjXEp8pxF3dbHopG4hyni+QB4D5sTfz5Wk4iMsfG0Mq/Og4zLY9tfz4KvPxtVE8b1w0BtNrySdTIA==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/bus-hash-bindings/-/bus-hash-bindings-5.2.0.tgz",
+			"integrity": "sha512-8b0/7WPBwrIBEmYElczh2d3CIik+Cd5PLeY1Pp20KkIVcOzD86XwidalozTimdOLm4/7wFTnHMmJhpGDWM4TZA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/core": "^5.1.3",
-				"@comunica/types": "^5.1.3",
+				"@comunica/core": "^5.2.0",
+				"@comunica/types": "^5.2.0",
 				"@rdfjs/types": "*"
 			},
 			"funding": {
@@ -4304,13 +4363,13 @@
 			}
 		},
 		"node_modules/@comunica/bus-hash-quads": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/bus-hash-quads/-/bus-hash-quads-5.1.3.tgz",
-			"integrity": "sha512-8bBUQSL1GO1d8+xEw1lU3OW17Y0W00hsmc6R6hgxym6zcIbQMnK/p+UnTAUo/3mn6e3mxVD2GEKh9PUYfZKVQA==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/bus-hash-quads/-/bus-hash-quads-5.2.0.tgz",
+			"integrity": "sha512-I1NRTCoK7fPkzgiDN0XnL067y3i9U7lK0ppzg3s6uZvyfEGBjB4XIo1nskbU16fYI6Odp35cyPxQVZkFKmoi8A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/core": "^5.1.3",
+				"@comunica/core": "^5.2.0",
 				"rdf-data-factory": "^2.0.0"
 			},
 			"funding": {
@@ -4319,14 +4378,14 @@
 			}
 		},
 		"node_modules/@comunica/bus-http": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/bus-http/-/bus-http-5.1.3.tgz",
-			"integrity": "sha512-UQAYlWHCIneRafcSy2yCJyGoZwtDYr5qdpF71SXE8Jwm8rFyjQLTSC4JKK3F02WxuJ7fMkMXZhg/anaT580QCg==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/bus-http/-/bus-http-5.2.0.tgz",
+			"integrity": "sha512-XFxVaYel88V7tCDSLXgjxxmDbMiefPzqF2yTWW1AeJym6giHViU1pLC4PbvcX/Pa8gBmDFOdyHnLKrHU6rlGdA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/core": "^5.1.3",
-				"@comunica/types": "^5.1.3",
+				"@comunica/core": "^5.2.0",
+				"@comunica/types": "^5.2.0",
 				"@jeswr/stream-to-string": "^2.0.0",
 				"is-stream": "^2.0.1",
 				"readable-from-web": "^1.0.0",
@@ -4338,13 +4397,13 @@
 			}
 		},
 		"node_modules/@comunica/bus-http-invalidate": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/bus-http-invalidate/-/bus-http-invalidate-5.1.3.tgz",
-			"integrity": "sha512-A97g7OA9QVNn5j4mhOEoy8QORR1ILvctTRVwUNV6faIezKYifiZBack5aXotv7lNZGFA/dSdArcbXJKkEq6Tvw==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/bus-http-invalidate/-/bus-http-invalidate-5.2.0.tgz",
+			"integrity": "sha512-u4W5j5uxm6A6e6Mvfty+dJUqhv6es3qU5ITVEiFGhf/YZghxBVJvtViiARsc/8dHH8VB4grkHO8XMZKYvGe3zA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/core": "^5.1.3"
+				"@comunica/core": "^5.2.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -4352,13 +4411,13 @@
 			}
 		},
 		"node_modules/@comunica/bus-init": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/bus-init/-/bus-init-5.1.3.tgz",
-			"integrity": "sha512-x8MQhPIZgQWmbG/5YCPIhMe0lhX2bTuwTAVX8EF8PlnnG3tkXOlV9fR8DOASvWhTVEiZJy/582UM0ZNGe9Di3w==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/bus-init/-/bus-init-5.2.0.tgz",
+			"integrity": "sha512-Srs9COoBV6g0DJ7BSMREjfPKmr/ukYCt9qAVtzLo6YtdL5/sYOT3xPdhH/PQ0L++1qqggDSZRD5EtiBBRdEv+w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/core": "^5.1.3",
+				"@comunica/core": "^5.2.0",
 				"readable-stream": "^4.7.0"
 			},
 			"funding": {
@@ -4367,14 +4426,14 @@
 			}
 		},
 		"node_modules/@comunica/bus-merge-bindings-context": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/bus-merge-bindings-context/-/bus-merge-bindings-context-5.1.3.tgz",
-			"integrity": "sha512-AH0QhlhTHPJSD0IG5qIinHO3R05fVz8Z7GpBQJN9O43BzDZIwuSdJ1bVOcRITEPoSEhGeTTUGLzKGvz9xgbkyg==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/bus-merge-bindings-context/-/bus-merge-bindings-context-5.2.0.tgz",
+			"integrity": "sha512-/bHF0bO3qhpNK1MuyCA7LAxq0jsKqVI5WVuBO6e9X6V7ocLc31CMdDhRbPcogVl7Z5L0Ibp5NhZf40364FHHZg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/core": "^5.1.3",
-				"@comunica/types": "^5.1.3"
+				"@comunica/core": "^5.2.0",
+				"@comunica/types": "^5.2.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -4382,15 +4441,15 @@
 			}
 		},
 		"node_modules/@comunica/bus-optimize-query-operation": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/bus-optimize-query-operation/-/bus-optimize-query-operation-5.1.3.tgz",
-			"integrity": "sha512-vyenOYrNZ0e6eg4R3u6tVquc5m4Cb22WneujZhRto9MgQJaPYFAK7WiL4BM9uZSEmFGtHd8qErvu5J0pys9lvg==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/bus-optimize-query-operation/-/bus-optimize-query-operation-5.2.0.tgz",
+			"integrity": "sha512-x9CgAq54dljNhmYc6TosD/wjJE7EpJ9PL84ZMlhf1RUKZ0WnOfCWVtcVLCTRJkg1m7dqG46nkAdCZjaTWlU8AQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/core": "^5.1.3",
-				"@comunica/types": "^5.1.3",
-				"@comunica/utils-algebra": "^5.1.3"
+				"@comunica/core": "^5.2.0",
+				"@comunica/types": "^5.2.0",
+				"@comunica/utils-algebra": "^5.2.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -4398,17 +4457,17 @@
 			}
 		},
 		"node_modules/@comunica/bus-query-operation": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/bus-query-operation/-/bus-query-operation-5.1.3.tgz",
-			"integrity": "sha512-040bKjCxHeFiGu89QUB7Hi92q1ziV1PG5Fsb6c35LAZvvoWYb/bu9tOntTKKmkleUN4uhxsxeqCw61SsOp49Pw==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/bus-query-operation/-/bus-query-operation-5.2.0.tgz",
+			"integrity": "sha512-4idAykaNFGiUWuXO057AFbOgdvCAPYsBLlLrvyUKX4RfNUznkX/ssqVL+Jsgsx6RbcWPyVAR6lv7Jc4AF0F0HA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/context-entries": "^5.1.3",
-				"@comunica/core": "^5.1.3",
-				"@comunica/types": "^5.1.3",
-				"@comunica/utils-algebra": "^5.1.3",
-				"@comunica/utils-metadata": "^5.1.3",
+				"@comunica/context-entries": "^5.2.0",
+				"@comunica/core": "^5.2.0",
+				"@comunica/types": "^5.2.0",
+				"@comunica/utils-algebra": "^5.2.0",
+				"@comunica/utils-metadata": "^5.2.0",
 				"@rdfjs/types": "*"
 			},
 			"funding": {
@@ -4417,14 +4476,14 @@
 			}
 		},
 		"node_modules/@comunica/bus-query-parse": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/bus-query-parse/-/bus-query-parse-5.1.3.tgz",
-			"integrity": "sha512-vsHQyuVcL7U9HStLBf4WMt77CYKD6QC5oXmOclx6/dKyGc+bCw0Cl5Ltb2yipbAosTwM9rqEbICfNnGADazgkQ==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/bus-query-parse/-/bus-query-parse-5.2.0.tgz",
+			"integrity": "sha512-Irc0+OWoWiSp2xxQZJcvJD9U01h7n3Afr9wbLMOS4XA/mNsIE4CSgGCtc/3IIb/xQWqDjJzfHaAb0rL1YzrpMw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/core": "^5.1.3",
-				"@comunica/utils-algebra": "^5.1.3",
+				"@comunica/core": "^5.2.0",
+				"@comunica/utils-algebra": "^5.2.0",
 				"@rdfjs/types": "*"
 			},
 			"funding": {
@@ -4433,15 +4492,15 @@
 			}
 		},
 		"node_modules/@comunica/bus-query-process": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/bus-query-process/-/bus-query-process-5.1.3.tgz",
-			"integrity": "sha512-36WthzjsEuNQkgr5l0J04EeT1y+chV0IQr/kKpAVypux2yf/o3qc3GdwRVfILHMxb+uD52EqOYDuJHWnQbY3Ag==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/bus-query-process/-/bus-query-process-5.2.0.tgz",
+			"integrity": "sha512-mn8ssD0S1LvAdnYBt9S0wCj1hL0xYbKe6CuxAmRvU1n7920OCMRcesJL839kCl1tO9KoZ0UorJsZsq6Dg8pcgw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/core": "^5.1.3",
-				"@comunica/types": "^5.1.3",
-				"@comunica/utils-algebra": "^5.1.3"
+				"@comunica/core": "^5.2.0",
+				"@comunica/types": "^5.2.0",
+				"@comunica/utils-algebra": "^5.2.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -4449,15 +4508,15 @@
 			}
 		},
 		"node_modules/@comunica/bus-query-result-serialize": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/bus-query-result-serialize/-/bus-query-result-serialize-5.1.3.tgz",
-			"integrity": "sha512-NQ1Qe0/rQjSDJOuDA2GpDnIZjejM1Tp1savFVVtqRZs7BxVWfCpQ4aCdiZ20eLDgE9MK1HspKlUfV1c1amGtSA==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/bus-query-result-serialize/-/bus-query-result-serialize-5.2.0.tgz",
+			"integrity": "sha512-1mT9Nb2oEaLkb0DLfDEwvcWi+0RUZ3x80CbXNrPVYorseAdAl21DhJpHEOUVwqcUzFuQimsUsFTRAs/QGvrxQw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/actor-abstract-mediatyped": "^5.1.3",
-				"@comunica/core": "^5.1.3",
-				"@comunica/types": "^5.1.3"
+				"@comunica/actor-abstract-mediatyped": "^5.2.0",
+				"@comunica/core": "^5.2.0",
+				"@comunica/types": "^5.2.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -4465,14 +4524,14 @@
 			}
 		},
 		"node_modules/@comunica/bus-query-serialize": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/bus-query-serialize/-/bus-query-serialize-5.1.3.tgz",
-			"integrity": "sha512-n3atX87lj49UqpXNSJ/o+FIf0ZUgKvLasIf7SoigW13xcb/z4GyVACa78RLGYP577qJINs9RGkMvcxZk1VjQYg==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/bus-query-serialize/-/bus-query-serialize-5.2.0.tgz",
+			"integrity": "sha512-R/tzintGgKydZka0AOuFAIAdll5QidsiWhIgdcY/qLBHkeky2sPno+FvU7H8QNuDys3N0Hg3ohepDAzIyxdG9g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/core": "^5.1.3",
-				"@comunica/utils-algebra": "^5.1.3",
+				"@comunica/core": "^5.2.0",
+				"@comunica/utils-algebra": "^5.2.0",
 				"@rdfjs/types": "*"
 			},
 			"funding": {
@@ -4481,14 +4540,14 @@
 			}
 		},
 		"node_modules/@comunica/bus-query-source-dereference-link": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/bus-query-source-dereference-link/-/bus-query-source-dereference-link-5.1.3.tgz",
-			"integrity": "sha512-u9/wqYbk46QCb/MNX3hoEe/LLKjSYXqVYD3zSGq3mtnlxYlpOZMoZSLu6JttZKP4nPKXOwVj61XZK8XjkKb6KA==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/bus-query-source-dereference-link/-/bus-query-source-dereference-link-5.2.0.tgz",
+			"integrity": "sha512-AQHPMnE+84w59nZLZpIDiwu/pVm0Vgp6XydI6FvoEiw6H7TEka1euBddnZEmmI/qdbHcnDkSGjd2Hw3U0XGZ8w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/core": "^5.1.3",
-				"@comunica/types": "^5.1.3"
+				"@comunica/core": "^5.2.0",
+				"@comunica/types": "^5.2.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -4496,18 +4555,18 @@
 			}
 		},
 		"node_modules/@comunica/bus-query-source-identify": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/bus-query-source-identify/-/bus-query-source-identify-5.1.3.tgz",
-			"integrity": "sha512-3lqmDg4ftBpgFuHRa6OltSEOLqMfq9YLDZN9VQuOqoNP+tMqLw0HruHqYD2LJCS3nH7hS2m+pXfnkXNh2vYCKw==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/bus-query-source-identify/-/bus-query-source-identify-5.2.0.tgz",
+			"integrity": "sha512-pleheP81xO659+QI/Hei83+GXd5JZ4I0J2Q62ro6Clr7pFTGBxk5PRQD02Wv69mMwQu84j0uzrKFKLPzbtzs1Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/core": "^5.1.3",
-				"@comunica/types": "^5.1.3",
-				"@comunica/utils-algebra": "^5.1.3",
-				"@comunica/utils-bindings-factory": "^5.1.3",
+				"@comunica/core": "^5.2.0",
+				"@comunica/types": "^5.2.0",
+				"@comunica/utils-algebra": "^5.2.0",
+				"@comunica/utils-bindings-factory": "^5.2.0",
 				"@comunica/utils-iterator": "^5.0.0",
-				"@comunica/utils-metadata": "^5.1.3",
+				"@comunica/utils-metadata": "^5.2.0",
 				"@rdfjs/types": "*",
 				"asynciterator": "^3.10.0",
 				"rdf-string": "^2.0.1",
@@ -4519,14 +4578,14 @@
 			}
 		},
 		"node_modules/@comunica/bus-query-source-identify-hypermedia": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/bus-query-source-identify-hypermedia/-/bus-query-source-identify-hypermedia-5.1.3.tgz",
-			"integrity": "sha512-VpDMqXCwl3Kfa9QjpP6pR++A1Ser9QV7FlMFUvSlgD09XDBPr2T8auS3Q/5kBYmcjwh5s1woXy2nm053WzZDwA==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/bus-query-source-identify-hypermedia/-/bus-query-source-identify-hypermedia-5.2.0.tgz",
+			"integrity": "sha512-R/jt/BD5KiIWyBp8ZLW9EoOYcexRH8hGRKfCfS17I55Vww+tyUDz5f1AqT9+fzN2PqIUaEEbR+NyksW8Fb8iwg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/core": "^5.1.3",
-				"@comunica/types": "^5.1.3",
+				"@comunica/core": "^5.2.0",
+				"@comunica/types": "^5.2.0",
 				"@rdfjs/types": "*"
 			},
 			"funding": {
@@ -4535,20 +4594,20 @@
 			}
 		},
 		"node_modules/@comunica/bus-rdf-join": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/bus-rdf-join/-/bus-rdf-join-5.1.3.tgz",
-			"integrity": "sha512-z4IfUfRHosSAWRGwNIc3hIhYU5JsdSF4SNIoA+vgGDlB/P9Rn1Bo/KCoKq35BLOXAp6Xo7mkNQCiN9u88L5RPg==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/bus-rdf-join/-/bus-rdf-join-5.2.0.tgz",
+			"integrity": "sha512-6yBJ7PwcVNeEeFIaBomkhk8+r1XDLCKq/7nUJL1HuqC/igf8fdUsYMqbt0Bz/cRspOx4iJuzH4gzm74Yd5SYDQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-rdf-join-entries-sort": "^5.1.3",
-				"@comunica/bus-rdf-join-selectivity": "^5.1.3",
-				"@comunica/context-entries": "^5.1.3",
-				"@comunica/core": "^5.1.3",
-				"@comunica/mediatortype-join-coefficients": "^5.1.3",
-				"@comunica/types": "^5.1.3",
+				"@comunica/bus-rdf-join-entries-sort": "^5.2.0",
+				"@comunica/bus-rdf-join-selectivity": "^5.2.0",
+				"@comunica/context-entries": "^5.2.0",
+				"@comunica/core": "^5.2.0",
+				"@comunica/mediatortype-join-coefficients": "^5.2.0",
+				"@comunica/types": "^5.2.0",
 				"@comunica/utils-iterator": "^5.0.0",
-				"@comunica/utils-metadata": "^5.1.3",
+				"@comunica/utils-metadata": "^5.2.0",
 				"@rdfjs/types": "*"
 			},
 			"funding": {
@@ -4557,14 +4616,14 @@
 			}
 		},
 		"node_modules/@comunica/bus-rdf-join-entries-sort": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/bus-rdf-join-entries-sort/-/bus-rdf-join-entries-sort-5.1.3.tgz",
-			"integrity": "sha512-+JRQ+PX5p124BiCapPBmDzH0bbML1NUYyzhV0xpizKU5KFwv++sZBpTetHR4PUhz3UnGsz4H+U7MQbkgmno+ig==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/bus-rdf-join-entries-sort/-/bus-rdf-join-entries-sort-5.2.0.tgz",
+			"integrity": "sha512-2BJ9j9Z2NNLWPZEYKrwNMEZ1L0ZsNnDz7LFuhaRFon7HXn10CkgCLhOMohVab1ko3ilQiPANdlSF8NfvsNAq9Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/core": "^5.1.3",
-				"@comunica/types": "^5.1.3"
+				"@comunica/core": "^5.2.0",
+				"@comunica/types": "^5.2.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -4572,15 +4631,15 @@
 			}
 		},
 		"node_modules/@comunica/bus-rdf-join-selectivity": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/bus-rdf-join-selectivity/-/bus-rdf-join-selectivity-5.1.3.tgz",
-			"integrity": "sha512-MFr0iazkZtWFiTBKFTt9ZqKXdUic9dUg4cLdsoiMzV+hyK3il5xcICzLVTkTbGyJe9dJjjvc3ZvWbmS4GYxcsA==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/bus-rdf-join-selectivity/-/bus-rdf-join-selectivity-5.2.0.tgz",
+			"integrity": "sha512-doMANgVCPy3yVZl8eMKXDhx23VLsWFIH33DzRKuiOkJH9YZU354pyyKyAJQKvY+hGklKJlJdAwI0u9SpYnAfXw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/core": "^5.1.3",
-				"@comunica/mediatortype-accuracy": "^5.1.3",
-				"@comunica/types": "^5.1.3"
+				"@comunica/core": "^5.2.0",
+				"@comunica/mediatortype-accuracy": "^5.2.0",
+				"@comunica/types": "^5.2.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -4588,13 +4647,13 @@
 			}
 		},
 		"node_modules/@comunica/bus-rdf-metadata": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/bus-rdf-metadata/-/bus-rdf-metadata-5.1.3.tgz",
-			"integrity": "sha512-MC2cQtjT+ZTKfyJbgfY41cAmZ+4/xmWm+i5E7Ip7Ldipc2IRNrBRvYmAu4FRmhj6+J4Ps/JH7iOR/QczCG+Rng==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/bus-rdf-metadata/-/bus-rdf-metadata-5.2.0.tgz",
+			"integrity": "sha512-3R3COaxkFIwT3VsVmCd0W55HMw7N57UtsmudC/NvJ1ixeIApjafBHpO3Hrs5tfiVRwkRG035waNtW8YGclosUw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/core": "^5.1.3",
+				"@comunica/core": "^5.2.0",
 				"@rdfjs/types": "*"
 			},
 			"funding": {
@@ -4603,14 +4662,14 @@
 			}
 		},
 		"node_modules/@comunica/bus-rdf-metadata-accumulate": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/bus-rdf-metadata-accumulate/-/bus-rdf-metadata-accumulate-5.1.3.tgz",
-			"integrity": "sha512-1sz/pkwFXYWL5M/BfDddpnGr8o/b0mG2HHOwF9ujb3RKHj54Qj3PiGfAAbOXd6yKgpOaHeKpCKuxfdCZYqr1vw==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/bus-rdf-metadata-accumulate/-/bus-rdf-metadata-accumulate-5.2.0.tgz",
+			"integrity": "sha512-RGIqoXjiF036vKfdKrfiSZ6zMwtwf5YUFW3DuFoshQSPtjRnVm1NPgdSsJbm2uVjGGPL4VCallarVysldQNuGw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/core": "^5.1.3",
-				"@comunica/types": "^5.1.3"
+				"@comunica/core": "^5.2.0",
+				"@comunica/types": "^5.2.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -4618,13 +4677,13 @@
 			}
 		},
 		"node_modules/@comunica/bus-rdf-metadata-extract": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/bus-rdf-metadata-extract/-/bus-rdf-metadata-extract-5.1.3.tgz",
-			"integrity": "sha512-lGDVcgcBdP6mCjDrKJjAwR4p11wbCTgIl+dqYwfTBVVUOrKX72UNOpq0cBLKdq+j5Y+FZC4fzYuVgvXpo38jTg==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/bus-rdf-metadata-extract/-/bus-rdf-metadata-extract-5.2.0.tgz",
+			"integrity": "sha512-n1niW1oE8Kl7Bis1tBPP1SN7kX+gDNxpgsNhf49h73ExegW3tsgcWXTg9ZlGrVdNn7hmME0uNcFWOH9BwFs6oQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/core": "^5.1.3",
+				"@comunica/core": "^5.2.0",
 				"@rdfjs/types": "*"
 			},
 			"funding": {
@@ -4633,15 +4692,15 @@
 			}
 		},
 		"node_modules/@comunica/bus-rdf-parse": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/bus-rdf-parse/-/bus-rdf-parse-5.1.3.tgz",
-			"integrity": "sha512-K0tt2+5sbjnndYvuwsZGqNecm/IbywGqqUquRlyVvW3pzMEPOG3IMmYleeUSZqkJJ4gwdm5cBHA0Hykro30UeA==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/bus-rdf-parse/-/bus-rdf-parse-5.2.0.tgz",
+			"integrity": "sha512-wf4oyC7d1+rn75W+EcLnZYHPFmB0eNdFC5epscqh5LpplSSiB0QC68hQ4dyVeSr0klTcLKgiymBmdnK5LkcYoA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/actor-abstract-mediatyped": "^5.1.3",
-				"@comunica/actor-abstract-parse": "^5.1.3",
-				"@comunica/core": "^5.1.3",
+				"@comunica/actor-abstract-mediatyped": "^5.2.0",
+				"@comunica/actor-abstract-parse": "^5.2.0",
+				"@comunica/core": "^5.2.0",
 				"@rdfjs/types": "*"
 			},
 			"funding": {
@@ -4650,13 +4709,13 @@
 			}
 		},
 		"node_modules/@comunica/bus-rdf-parse-html": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/bus-rdf-parse-html/-/bus-rdf-parse-html-5.1.3.tgz",
-			"integrity": "sha512-iIPVdLVzQt25SclAPjPbEgq4ZWupkQSnq6LO0rxAxto7p9Md6dGy/Vm3r28KvicK9qOorQiyW3TGqWB+PhFupQ==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/bus-rdf-parse-html/-/bus-rdf-parse-html-5.2.0.tgz",
+			"integrity": "sha512-rcka8Pi3FZWuvLT/MlrPfv47D3FCJLsbRQM+IyukvKrM+vBqp7pORlMgEYM7kxcpZ9iwOWKGXxur/NBhysaUqg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/core": "^5.1.3",
+				"@comunica/core": "^5.2.0",
 				"@rdfjs/types": "*"
 			},
 			"funding": {
@@ -4665,14 +4724,14 @@
 			}
 		},
 		"node_modules/@comunica/bus-rdf-resolve-hypermedia-links": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/bus-rdf-resolve-hypermedia-links/-/bus-rdf-resolve-hypermedia-links-5.1.3.tgz",
-			"integrity": "sha512-QH6p1G205mKGCJtqcp9OSKw2A/th6zmpHi+IlSZd4jT7RcFhs5dVpywPvW7ZlCsuR6X9vBmzVIVhd/hsppGUsw==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/bus-rdf-resolve-hypermedia-links/-/bus-rdf-resolve-hypermedia-links-5.2.0.tgz",
+			"integrity": "sha512-SJcTYP+rPnDHAVe4UBKJwqjQysZVF8kQ5R0Evjgwrg3VTtjXLU5ADE+MS7j8B3GosK3IIXoLF/Mrp3uBmECYHw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/core": "^5.1.3",
-				"@comunica/types": "^5.1.3"
+				"@comunica/core": "^5.2.0",
+				"@comunica/types": "^5.2.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -4680,14 +4739,14 @@
 			}
 		},
 		"node_modules/@comunica/bus-rdf-resolve-hypermedia-links-queue": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/bus-rdf-resolve-hypermedia-links-queue/-/bus-rdf-resolve-hypermedia-links-queue-5.1.3.tgz",
-			"integrity": "sha512-wEQU06dAb38BgK+1OTnmsTNaZctz79cEgxd/DZnke/FykxoqRM5wEqgE2dI/j3tzV+8XGbe5IS94iS2F0dvmew==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/bus-rdf-resolve-hypermedia-links-queue/-/bus-rdf-resolve-hypermedia-links-queue-5.2.0.tgz",
+			"integrity": "sha512-r/YjkgQSYRKhaGdB41HoVtzbtwRsvYmNipKvoeGF6eRXt8ys0LALvCAQZvUg1/vEC6aU8nCpJrM/OrXnfzmPQw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/core": "^5.1.3",
-				"@comunica/types": "^5.1.3"
+				"@comunica/core": "^5.2.0",
+				"@comunica/types": "^5.2.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -4695,14 +4754,14 @@
 			}
 		},
 		"node_modules/@comunica/bus-rdf-serialize": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/bus-rdf-serialize/-/bus-rdf-serialize-5.1.3.tgz",
-			"integrity": "sha512-wKOsPFYw9QM6fw0kBzup0HvUDkx6Y2SZGV0jFx9va3T2OuwkXD/UPHL61M+JZ82qHzQndS8cMaUE5VJjqWnJDg==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/bus-rdf-serialize/-/bus-rdf-serialize-5.2.0.tgz",
+			"integrity": "sha512-+cXwsyGxYl0BkQYiJxZLHHsooBFscdaMB4xgHcVhMT7110PqEY+ffzUpbnJfKSGdkUs6xENR7rUn5+7tLp+F3g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/actor-abstract-mediatyped": "^5.1.3",
-				"@comunica/core": "^5.1.3",
+				"@comunica/actor-abstract-mediatyped": "^5.2.0",
+				"@comunica/core": "^5.2.0",
 				"@rdfjs/types": "*"
 			},
 			"funding": {
@@ -4711,14 +4770,14 @@
 			}
 		},
 		"node_modules/@comunica/bus-rdf-update-hypermedia": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/bus-rdf-update-hypermedia/-/bus-rdf-update-hypermedia-5.1.3.tgz",
-			"integrity": "sha512-6axnYhDYSB6zjhLttCCbsXuN9V8ufAZv9UpZTjXchWqFyHOOI/Za2/n6i/UHGNgJ2OuuUlnQNSRLFXQ9i38lMw==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/bus-rdf-update-hypermedia/-/bus-rdf-update-hypermedia-5.2.0.tgz",
+			"integrity": "sha512-A/gf5ymoukVbjV8TCOTUbN08Fz28z95BlxfFK6yyP34ooFufFXy7zVxKINlGgefE3H7GSRxtCgin8keZfNp2OA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-rdf-update-quads": "^5.1.3",
-				"@comunica/core": "^5.1.3"
+				"@comunica/bus-rdf-update-quads": "^5.2.0",
+				"@comunica/core": "^5.2.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -4726,16 +4785,16 @@
 			}
 		},
 		"node_modules/@comunica/bus-rdf-update-quads": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/bus-rdf-update-quads/-/bus-rdf-update-quads-5.1.3.tgz",
-			"integrity": "sha512-jZMw/JgZYHU6e/p9/8QCxNdDhLvqI2KtHlWSBpaL0tTjtbsdWNTaxcBAmbbcxXRL877C8yWA0g89NzuTI+pS0g==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/bus-rdf-update-quads/-/bus-rdf-update-quads-5.2.0.tgz",
+			"integrity": "sha512-1QqLQ/w6AsXu4chkQAvzAj8lF5CeOdSwM4Uj6AKG7FehdZmPDrHDMIFOizKfuWoEmdDThyabSgpQ7y0/JztNLQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/actor-optimize-query-operation-query-source-skolemize": "^5.1.3",
-				"@comunica/context-entries": "^5.1.3",
-				"@comunica/core": "^5.1.3",
-				"@comunica/types": "^5.1.3",
+				"@comunica/actor-optimize-query-operation-query-source-skolemize": "^5.2.0",
+				"@comunica/context-entries": "^5.2.0",
+				"@comunica/core": "^5.2.0",
+				"@comunica/types": "^5.2.0",
 				"@rdfjs/types": "*",
 				"asynciterator": "^3.10.0"
 			},
@@ -4745,23 +4804,23 @@
 			}
 		},
 		"node_modules/@comunica/bus-term-comparator-factory": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/bus-term-comparator-factory/-/bus-term-comparator-factory-5.1.3.tgz",
-			"integrity": "sha512-BMQlV/H5593DZMdvskpvn0d8vh3NKS+Xhe+vEbugoF19sk5a9cOmfA7fZZmPIVfIh4Zlo6itQfZwdHdKjvMzng==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/bus-term-comparator-factory/-/bus-term-comparator-factory-5.2.0.tgz",
+			"integrity": "sha512-L79G7RRgk1VjQEevwIr6fWPCEY3QjNN7nr2v/AdowYD6FtUHdJ9k77KTOJOlx+VI8fGqhMs5cW1veSziFxmyRQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-function-factory": "^5.1.3",
-				"@comunica/bus-merge-bindings-context": "^5.1.3",
-				"@comunica/bus-query-operation": "^5.1.3",
-				"@comunica/core": "^5.1.3",
+				"@comunica/bus-function-factory": "^5.2.0",
+				"@comunica/bus-merge-bindings-context": "^5.2.0",
+				"@comunica/bus-query-operation": "^5.2.0",
+				"@comunica/core": "^5.2.0",
 				"@rdfjs/types": "*"
 			}
 		},
 		"node_modules/@comunica/config-query-sparql": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/@comunica/config-query-sparql/-/config-query-sparql-5.0.0.tgz",
-			"integrity": "sha512-vS6Ik0Lbm9InWPrqnLeOFM7M2SKj+KLqGVwmOaX6N/+3TjOdOhGQJRLZCGXkiwYUDg/Jn3Z++9bQIR9/Bhj4GA==",
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/@comunica/config-query-sparql/-/config-query-sparql-5.2.1.tgz",
+			"integrity": "sha512-zCfogBq5IK+GrgX/mBEltzdVDWLOBnyzpUXBLQdd6LTgfjRVYjAQjbZEAtUZ36mh6EDG5QGUbE4SnedQFvRMVg==",
 			"dev": true,
 			"license": "MIT",
 			"funding": {
@@ -4770,15 +4829,15 @@
 			}
 		},
 		"node_modules/@comunica/context-entries": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/context-entries/-/context-entries-5.1.3.tgz",
-			"integrity": "sha512-7LMYo7l/3a3BLOYfaMXR6Jh/QIIcz77a1rEMXPxtLE6io+m/4l72EZG6WGeUbyHFablt0fzaeBA/6afufrVNqg==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/context-entries/-/context-entries-5.2.0.tgz",
+			"integrity": "sha512-jyqjPWOeDACgFY7vUa9wVeOZOlEbr3DXJWoe1veElxQVdx65qF/Ppg/7l6rqEzxcUvoyZ1FrZBUUXpvnCcUs9A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/core": "^5.1.3",
-				"@comunica/types": "^5.1.3",
-				"@comunica/utils-algebra": "^5.1.3",
+				"@comunica/core": "^5.2.0",
+				"@comunica/types": "^5.2.0",
+				"@comunica/utils-algebra": "^5.2.0",
 				"@rdfjs/types": "*",
 				"jsonld-context-parser": "^2.2.2"
 			},
@@ -4788,13 +4847,13 @@
 			}
 		},
 		"node_modules/@comunica/core": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/core/-/core-5.1.3.tgz",
-			"integrity": "sha512-j0m+iJ3jAs06BeDlAIqqLj3rAf0vbj/oONIMPzzPE13aVvtd4q1NlhV4sGUQCwqD9IKi/16HpliMie618dQ/iw==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/core/-/core-5.2.0.tgz",
+			"integrity": "sha512-YnTVTF3CXxuCZo56VBEFN6cs/pOFNEzjuDqKlGyCaTSGJJHSGm3fHXHuVm2KOzDO2lkI9N/cgO3+ICzNOZA6Zg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/types": "^5.1.3",
+				"@comunica/types": "^5.2.0",
 				"immutable": "^5.1.3"
 			},
 			"engines": {
@@ -4806,13 +4865,13 @@
 			}
 		},
 		"node_modules/@comunica/logger-pretty": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/logger-pretty/-/logger-pretty-5.1.3.tgz",
-			"integrity": "sha512-HrZPwAtFqZ/t9m/rFT4W1+dySBAQ4mZs2kowoInjY7sm26ivbF+SqUKPryQFzYB4QsQnrQstSnlo6168a6xHMA==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/logger-pretty/-/logger-pretty-5.2.0.tgz",
+			"integrity": "sha512-t0jcru3fOYwrkATQVdalXGgRE2XEY8nc1j0G0ccdYXQfsCIed+i1/hS7QdECO1VaDGrKYRGAyGmuiS5TmD8JZQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/types": "^5.1.3",
+				"@comunica/types": "^5.2.0",
 				"object-inspect": "^1.12.2",
 				"process": "^0.11.10"
 			},
@@ -4822,13 +4881,13 @@
 			}
 		},
 		"node_modules/@comunica/logger-void": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/logger-void/-/logger-void-5.1.3.tgz",
-			"integrity": "sha512-HQvRB0tMWabPfHBDCjeUC7DnXsBdtbrnU7RUQdfpJ9rtehtxf5spi/ba+vbWxEtfsb+eXHAurlSEHU2mNK1m2Q==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/logger-void/-/logger-void-5.2.0.tgz",
+			"integrity": "sha512-6rNY4cfCUl1w0MJIJDR5uOsP29RvzKTN+4h4Gk2H82pvgPA6IHfFGSQE/ptIGuhZcatWyXYxMew8sO2RVl8ZQA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/types": "^5.1.3"
+				"@comunica/types": "^5.2.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -4836,13 +4895,13 @@
 			}
 		},
 		"node_modules/@comunica/mediator-all": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/mediator-all/-/mediator-all-5.1.3.tgz",
-			"integrity": "sha512-A/oV5mngV5JEN757NRR7UZhfNkJKaC2iyqbwoavdtHtLOlgQe4BYSsyD2QM9gSswm4DwfUZvi5CwGr3ppON7vw==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/mediator-all/-/mediator-all-5.2.0.tgz",
+			"integrity": "sha512-Zce4KZBmU1w/QfY6i5DnVvWpvaMxcjFuNzu5NpsFDeGHSJiiRoKNmqJbNe6yBEDiSPNYD1osFyySl50fhfMTaw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/core": "^5.1.3"
+				"@comunica/core": "^5.2.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -4850,14 +4909,14 @@
 			}
 		},
 		"node_modules/@comunica/mediator-combine-pipeline": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/mediator-combine-pipeline/-/mediator-combine-pipeline-5.1.3.tgz",
-			"integrity": "sha512-OR9z0Bkep/22ARDf2P/ZxAMgQ/lCarSp6XNE2DmjsenQR+N2+75LqSSqwvZZWNiaSukB/wsm2FnA7+i+O/Dttg==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/mediator-combine-pipeline/-/mediator-combine-pipeline-5.2.0.tgz",
+			"integrity": "sha512-Tet43+YYG4rcHkOQDhqQB4/aO0r2vvBpzvn/8VXLPdXMJ/mRCu6a39T5JlFVeRbDwnxV+hDF4/etIGR0r7jAIQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/core": "^5.1.3",
-				"@comunica/types": "^5.1.3"
+				"@comunica/core": "^5.2.0",
+				"@comunica/types": "^5.2.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -4865,13 +4924,13 @@
 			}
 		},
 		"node_modules/@comunica/mediator-combine-union": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/mediator-combine-union/-/mediator-combine-union-5.1.3.tgz",
-			"integrity": "sha512-hvSIR6Ddu456bauJULrnXeFiobGXuqABYhGFdEPlXoyl4DKVew3TbIR843JcVttefS5dMT4IRqulMKBWNw+CWw==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/mediator-combine-union/-/mediator-combine-union-5.2.0.tgz",
+			"integrity": "sha512-TjUYosD+yxAvZslrf5xpKh9mY7g7PU0iBhrEpmhHoUP3UOHGTPrCrxzfEIEUUi/jWaK9rvHlmAh/IemCRppJGQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/core": "^5.1.3"
+				"@comunica/core": "^5.2.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -4879,17 +4938,17 @@
 			}
 		},
 		"node_modules/@comunica/mediator-join-coefficients-fixed": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/mediator-join-coefficients-fixed/-/mediator-join-coefficients-fixed-5.1.3.tgz",
-			"integrity": "sha512-3VBBQQwnu/oKQQiu+XGbUS8SwLeAfXUoWY09fnEYwKUHIcxi8+i8jvicOzXnWVs3D5hscX8ViAR+aEJzc8TOUQ==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/mediator-join-coefficients-fixed/-/mediator-join-coefficients-fixed-5.2.0.tgz",
+			"integrity": "sha512-fxzWMs5TMjcD5tWV/VXsnvqgZMaURcjgotu0DgPsbQWAV5BPoITUq8EGzju7AXh1PiuI+T4tQmlwA/34L/dkcg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-rdf-join": "^5.1.3",
-				"@comunica/context-entries": "^5.1.3",
-				"@comunica/core": "^5.1.3",
-				"@comunica/mediatortype-join-coefficients": "^5.1.3",
-				"@comunica/types": "^5.1.3"
+				"@comunica/bus-rdf-join": "^5.2.0",
+				"@comunica/context-entries": "^5.2.0",
+				"@comunica/core": "^5.2.0",
+				"@comunica/mediatortype-join-coefficients": "^5.2.0",
+				"@comunica/types": "^5.2.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -4897,13 +4956,13 @@
 			}
 		},
 		"node_modules/@comunica/mediator-number": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/mediator-number/-/mediator-number-5.1.3.tgz",
-			"integrity": "sha512-w2yHLjI5ROdAw5L5rN/iWgH0Unc5D79QeFFl6FfmpPZirbP9W1nSXHZT4HP71hk4m8EEZN70gSzCcu5+QBGgpQ==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/mediator-number/-/mediator-number-5.2.0.tgz",
+			"integrity": "sha512-ghu6doDd43iPmo4Kb2HqZmCvt1rSQFq6aHuyLW9U9RnpVNhXntgVIxE7S2d8WJ/QoOm/vBwIweB/14GfGcerxw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/core": "^5.1.3"
+				"@comunica/core": "^5.2.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -4911,13 +4970,13 @@
 			}
 		},
 		"node_modules/@comunica/mediator-race": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/mediator-race/-/mediator-race-5.1.3.tgz",
-			"integrity": "sha512-MbODudHH8poLfUVpWaNarajF/1f9m2MTEtECweE26hit/9TzRDj55/Af2tYpiD4B/TFZQuFheWZ7fzL169Hq9A==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/mediator-race/-/mediator-race-5.2.0.tgz",
+			"integrity": "sha512-DfGshtcvy1vll5aMiaywkPLOpL7ANAtKmj+ENQcEuX7QOQ0/tcJDdG2UcvHen+vX5v0bFpVxYy6qgx5OWfoXbw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/core": "^5.1.3"
+				"@comunica/core": "^5.2.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -4925,13 +4984,13 @@
 			}
 		},
 		"node_modules/@comunica/mediatortype-accuracy": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/mediatortype-accuracy/-/mediatortype-accuracy-5.1.3.tgz",
-			"integrity": "sha512-n5rcZMlyeueyy4dxfHuV0QbjAh6Cc1gBM7hxx3GzSzijmhpTHiGayIdUgN6kdiLHMqmDk2ZHDYHTF4ZRtJR15A==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/mediatortype-accuracy/-/mediatortype-accuracy-5.2.0.tgz",
+			"integrity": "sha512-g1jpKbvDZfeicPWujZLzbBlOwdu5oyz1IPsoF9DceECD92PIclg6Uiuhy2ON39hu4NgwC10qNCFfPihpH2j2iQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/core": "^5.1.3"
+				"@comunica/core": "^5.2.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -4939,13 +4998,13 @@
 			}
 		},
 		"node_modules/@comunica/mediatortype-join-coefficients": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/mediatortype-join-coefficients/-/mediatortype-join-coefficients-5.1.3.tgz",
-			"integrity": "sha512-y7l+kFO5qML8ul0DoPCT08ENIpceBHcVABvIvMl1J1gkySkAK2STQn3YZPt2fNtDxHFLUbDJTulr3K/JU+7eKA==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/mediatortype-join-coefficients/-/mediatortype-join-coefficients-5.2.0.tgz",
+			"integrity": "sha512-AnidCrb+SCC3HojQdUJM6RNo+r4KXuwPQ49hJgyvFOncl+ke4GrdXj5mCxeACann/o7UWnqz3ZNiKQaJr+uEMQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/core": "^5.1.3",
+				"@comunica/core": "^5.2.0",
 				"@rdfjs/types": "*"
 			},
 			"funding": {
@@ -4954,13 +5013,13 @@
 			}
 		},
 		"node_modules/@comunica/mediatortype-time": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/mediatortype-time/-/mediatortype-time-5.1.3.tgz",
-			"integrity": "sha512-qvvekxezMO+r8lonfTY+Yo7CNm5oABfg420M9ZgPlTDECd53GGhwjWLQqp4lk285ZOCrEkOYiy7AW1LZysLvIQ==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/mediatortype-time/-/mediatortype-time-5.2.0.tgz",
+			"integrity": "sha512-ugUnGEGmD2BqljIndJ5C8q+XrcKEfks3JULw/y94Tnu/KcHBC5uWuG3A1m39xbxLq+6Ov2dyHqXDp+vQwTs9wA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/core": "^5.1.3"
+				"@comunica/core": "^5.2.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -4968,265 +5027,271 @@
 			}
 		},
 		"node_modules/@comunica/query-sparql": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/query-sparql/-/query-sparql-5.1.3.tgz",
-			"integrity": "sha512-vKleNL3i4d/QJwy6gfz1orblRY9wyOK8MlP9Dou7YbsdqAxMD6SsSE2Yn6++Adza9q8exVVL2vFBZ4mTAgIVig==",
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/@comunica/query-sparql/-/query-sparql-5.2.1.tgz",
+			"integrity": "sha512-vaV/doKBwTn0fQnAIaMVQfB9/Vbfi6JIb50cm0OktXXP2CeQQaildDzjSFOxEKgxdoNhVyLb0QEEfJUH4IQjVQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/actor-bindings-aggregator-factory-average": "^5.1.3",
-				"@comunica/actor-bindings-aggregator-factory-count": "^5.1.3",
-				"@comunica/actor-bindings-aggregator-factory-group-concat": "^5.1.3",
-				"@comunica/actor-bindings-aggregator-factory-max": "^5.1.3",
-				"@comunica/actor-bindings-aggregator-factory-min": "^5.1.3",
-				"@comunica/actor-bindings-aggregator-factory-sample": "^5.1.3",
-				"@comunica/actor-bindings-aggregator-factory-sum": "^5.1.3",
-				"@comunica/actor-bindings-aggregator-factory-wildcard-count": "^5.1.3",
-				"@comunica/actor-context-preprocess-convert-shortcuts": "^5.1.3",
-				"@comunica/actor-context-preprocess-set-defaults": "^5.1.3",
-				"@comunica/actor-context-preprocess-source-to-destination": "^5.1.3",
-				"@comunica/actor-dereference-fallback": "^5.1.3",
-				"@comunica/actor-dereference-http": "^5.1.3",
-				"@comunica/actor-dereference-rdf-parse": "^5.1.3",
-				"@comunica/actor-expression-evaluator-factory-default": "^5.1.3",
-				"@comunica/actor-function-factory-expression-bnode": "^5.1.3",
-				"@comunica/actor-function-factory-expression-bound": "^5.1.3",
-				"@comunica/actor-function-factory-expression-coalesce": "^5.1.3",
-				"@comunica/actor-function-factory-expression-concat": "^5.1.3",
-				"@comunica/actor-function-factory-expression-extensions": "^5.1.3",
-				"@comunica/actor-function-factory-expression-if": "^5.1.3",
-				"@comunica/actor-function-factory-expression-in": "^5.1.3",
-				"@comunica/actor-function-factory-expression-logical-and": "^5.1.3",
-				"@comunica/actor-function-factory-expression-logical-or": "^5.1.3",
-				"@comunica/actor-function-factory-expression-not-in": "^5.1.3",
-				"@comunica/actor-function-factory-expression-same-term": "^5.1.3",
-				"@comunica/actor-function-factory-term-abs": "^5.1.3",
-				"@comunica/actor-function-factory-term-addition": "^5.1.3",
-				"@comunica/actor-function-factory-term-ceil": "^5.1.3",
-				"@comunica/actor-function-factory-term-contains": "^5.1.3",
-				"@comunica/actor-function-factory-term-datatype": "^5.1.3",
-				"@comunica/actor-function-factory-term-day": "^5.1.3",
-				"@comunica/actor-function-factory-term-division": "^5.1.3",
-				"@comunica/actor-function-factory-term-encode-for-uri": "^5.1.3",
-				"@comunica/actor-function-factory-term-equality": "^5.1.3",
-				"@comunica/actor-function-factory-term-floor": "^5.1.3",
-				"@comunica/actor-function-factory-term-greater-than": "^5.1.3",
-				"@comunica/actor-function-factory-term-greater-than-equal": "^5.1.3",
-				"@comunica/actor-function-factory-term-has-lang": "^5.1.3",
-				"@comunica/actor-function-factory-term-has-langdir": "^5.1.3",
-				"@comunica/actor-function-factory-term-hours": "^5.1.3",
-				"@comunica/actor-function-factory-term-inequality": "^5.1.3",
-				"@comunica/actor-function-factory-term-iri": "^5.1.3",
-				"@comunica/actor-function-factory-term-is-blank": "^5.1.3",
-				"@comunica/actor-function-factory-term-is-iri": "^5.1.3",
-				"@comunica/actor-function-factory-term-is-literal": "^5.1.3",
-				"@comunica/actor-function-factory-term-is-numeric": "^5.1.3",
-				"@comunica/actor-function-factory-term-is-triple": "^5.1.3",
-				"@comunica/actor-function-factory-term-lang": "^5.1.3",
-				"@comunica/actor-function-factory-term-langdir": "^5.1.3",
-				"@comunica/actor-function-factory-term-langmatches": "^5.1.3",
-				"@comunica/actor-function-factory-term-lcase": "^5.1.3",
-				"@comunica/actor-function-factory-term-lesser-than": "^5.1.3",
-				"@comunica/actor-function-factory-term-lesser-than-equal": "^5.1.3",
-				"@comunica/actor-function-factory-term-md5": "^5.1.3",
-				"@comunica/actor-function-factory-term-minutes": "^5.1.3",
-				"@comunica/actor-function-factory-term-month": "^5.1.3",
-				"@comunica/actor-function-factory-term-multiplication": "^5.1.3",
-				"@comunica/actor-function-factory-term-not": "^5.1.3",
-				"@comunica/actor-function-factory-term-now": "^5.1.3",
-				"@comunica/actor-function-factory-term-object": "^5.1.3",
-				"@comunica/actor-function-factory-term-predicate": "^5.1.3",
-				"@comunica/actor-function-factory-term-rand": "^5.1.3",
-				"@comunica/actor-function-factory-term-regex": "^5.1.3",
-				"@comunica/actor-function-factory-term-replace": "^5.1.3",
-				"@comunica/actor-function-factory-term-round": "^5.1.3",
-				"@comunica/actor-function-factory-term-seconds": "^5.1.3",
-				"@comunica/actor-function-factory-term-sha1": "^5.1.3",
-				"@comunica/actor-function-factory-term-sha256": "^5.1.3",
-				"@comunica/actor-function-factory-term-sha384": "^5.1.3",
-				"@comunica/actor-function-factory-term-sha512": "^5.1.3",
-				"@comunica/actor-function-factory-term-str": "^5.1.3",
-				"@comunica/actor-function-factory-term-str-after": "^5.1.3",
-				"@comunica/actor-function-factory-term-str-before": "^5.1.3",
-				"@comunica/actor-function-factory-term-str-dt": "^5.1.3",
-				"@comunica/actor-function-factory-term-str-ends": "^5.1.3",
-				"@comunica/actor-function-factory-term-str-lang": "^5.1.3",
-				"@comunica/actor-function-factory-term-str-langdir": "^5.1.3",
-				"@comunica/actor-function-factory-term-str-len": "^5.1.3",
-				"@comunica/actor-function-factory-term-str-starts": "^5.1.3",
-				"@comunica/actor-function-factory-term-str-uuid": "^5.1.3",
-				"@comunica/actor-function-factory-term-sub-str": "^5.1.3",
-				"@comunica/actor-function-factory-term-subject": "^5.1.3",
-				"@comunica/actor-function-factory-term-subtraction": "^5.1.3",
-				"@comunica/actor-function-factory-term-timezone": "^5.1.3",
-				"@comunica/actor-function-factory-term-triple": "^5.1.3",
-				"@comunica/actor-function-factory-term-tz": "^5.1.3",
-				"@comunica/actor-function-factory-term-ucase": "^5.1.3",
-				"@comunica/actor-function-factory-term-unary-minus": "^5.1.3",
-				"@comunica/actor-function-factory-term-unary-plus": "^5.1.3",
-				"@comunica/actor-function-factory-term-uuid": "^5.1.3",
-				"@comunica/actor-function-factory-term-xsd-to-boolean": "^5.1.3",
-				"@comunica/actor-function-factory-term-xsd-to-date": "^5.1.3",
-				"@comunica/actor-function-factory-term-xsd-to-datetime": "^5.1.3",
-				"@comunica/actor-function-factory-term-xsd-to-day-time-duration": "^5.1.3",
-				"@comunica/actor-function-factory-term-xsd-to-decimal": "^5.1.3",
-				"@comunica/actor-function-factory-term-xsd-to-double": "^5.1.3",
-				"@comunica/actor-function-factory-term-xsd-to-duration": "^5.1.3",
-				"@comunica/actor-function-factory-term-xsd-to-float": "^5.1.3",
-				"@comunica/actor-function-factory-term-xsd-to-integer": "^5.1.3",
-				"@comunica/actor-function-factory-term-xsd-to-string": "^5.1.3",
-				"@comunica/actor-function-factory-term-xsd-to-time": "^5.1.3",
-				"@comunica/actor-function-factory-term-xsd-to-year-month-duration": "^5.1.3",
-				"@comunica/actor-function-factory-term-year": "^5.1.3",
-				"@comunica/actor-hash-bindings-murmur": "^5.1.3",
-				"@comunica/actor-hash-quads-murmur": "^5.1.3",
-				"@comunica/actor-http-fetch": "^5.1.3",
-				"@comunica/actor-http-limit-rate": "^5.1.3",
-				"@comunica/actor-http-proxy": "^5.1.3",
-				"@comunica/actor-http-retry": "^5.1.3",
-				"@comunica/actor-http-wayback": "^5.1.3",
-				"@comunica/actor-init-query": "^5.1.3",
-				"@comunica/actor-optimize-query-operation-assign-sources-exhaustive": "^5.1.3",
-				"@comunica/actor-optimize-query-operation-bgp-to-join": "^5.1.3",
-				"@comunica/actor-optimize-query-operation-construct-distinct": "^5.1.3",
-				"@comunica/actor-optimize-query-operation-describe-to-constructs-subject": "^5.1.3",
-				"@comunica/actor-optimize-query-operation-filter-pushdown": "^5.1.3",
-				"@comunica/actor-optimize-query-operation-group-sources": "^5.1.3",
-				"@comunica/actor-optimize-query-operation-join-bgp": "^5.1.3",
-				"@comunica/actor-optimize-query-operation-join-connected": "^5.1.3",
-				"@comunica/actor-optimize-query-operation-leftjoin-expression-pushdown": "^5.1.3",
-				"@comunica/actor-optimize-query-operation-prune-empty-source-operations": "^5.1.3",
-				"@comunica/actor-optimize-query-operation-query-source-identify": "^5.1.3",
-				"@comunica/actor-optimize-query-operation-query-source-skolemize": "^5.1.3",
-				"@comunica/actor-optimize-query-operation-rewrite-add": "^5.1.3",
-				"@comunica/actor-optimize-query-operation-rewrite-copy": "^5.1.3",
-				"@comunica/actor-optimize-query-operation-rewrite-move": "^5.1.3",
-				"@comunica/actor-query-operation-ask": "^5.1.3",
-				"@comunica/actor-query-operation-bgp-join": "^5.1.3",
-				"@comunica/actor-query-operation-construct": "^5.1.3",
-				"@comunica/actor-query-operation-distinct-identity": "^5.1.3",
-				"@comunica/actor-query-operation-extend": "^5.1.3",
-				"@comunica/actor-query-operation-filter": "^5.1.3",
-				"@comunica/actor-query-operation-from-quad": "^5.1.3",
-				"@comunica/actor-query-operation-group": "^5.1.3",
-				"@comunica/actor-query-operation-join": "^5.1.3",
-				"@comunica/actor-query-operation-leftjoin": "^5.1.3",
-				"@comunica/actor-query-operation-minus": "^5.1.3",
-				"@comunica/actor-query-operation-nop": "^5.1.3",
-				"@comunica/actor-query-operation-orderby": "^5.1.3",
-				"@comunica/actor-query-operation-path-alt": "^5.1.3",
-				"@comunica/actor-query-operation-path-inv": "^5.1.3",
-				"@comunica/actor-query-operation-path-link": "^5.1.3",
-				"@comunica/actor-query-operation-path-nps": "^5.1.3",
-				"@comunica/actor-query-operation-path-one-or-more": "^5.1.3",
-				"@comunica/actor-query-operation-path-seq": "^5.1.3",
-				"@comunica/actor-query-operation-path-zero-or-more": "^5.1.3",
-				"@comunica/actor-query-operation-path-zero-or-one": "^5.1.3",
-				"@comunica/actor-query-operation-project": "^5.1.3",
-				"@comunica/actor-query-operation-reduced-hash": "^5.1.3",
-				"@comunica/actor-query-operation-slice": "^5.1.3",
-				"@comunica/actor-query-operation-source": "^5.1.3",
-				"@comunica/actor-query-operation-union": "^5.1.3",
-				"@comunica/actor-query-operation-update-clear": "^5.1.3",
-				"@comunica/actor-query-operation-update-compositeupdate": "^5.1.3",
-				"@comunica/actor-query-operation-update-create": "^5.1.3",
-				"@comunica/actor-query-operation-update-deleteinsert": "^5.1.3",
-				"@comunica/actor-query-operation-update-drop": "^5.1.3",
-				"@comunica/actor-query-operation-update-load": "^5.1.3",
-				"@comunica/actor-query-operation-values": "^5.1.3",
-				"@comunica/actor-query-parse-graphql": "^5.1.3",
-				"@comunica/actor-query-parse-sparql": "^5.1.3",
-				"@comunica/actor-query-process-explain-logical": "^5.1.3",
-				"@comunica/actor-query-process-explain-parsed": "^5.1.3",
-				"@comunica/actor-query-process-explain-physical": "^5.1.3",
-				"@comunica/actor-query-process-explain-query": "^5.1.3",
-				"@comunica/actor-query-process-sequential": "^5.1.3",
-				"@comunica/actor-query-result-serialize-json": "^5.1.3",
-				"@comunica/actor-query-result-serialize-rdf": "^5.1.3",
-				"@comunica/actor-query-result-serialize-simple": "^5.1.3",
-				"@comunica/actor-query-result-serialize-sparql-csv": "^5.1.3",
-				"@comunica/actor-query-result-serialize-sparql-json": "^5.1.3",
-				"@comunica/actor-query-result-serialize-sparql-tsv": "^5.1.3",
-				"@comunica/actor-query-result-serialize-sparql-xml": "^5.1.3",
-				"@comunica/actor-query-result-serialize-stats": "^5.1.3",
-				"@comunica/actor-query-result-serialize-table": "^5.1.3",
-				"@comunica/actor-query-result-serialize-tree": "^5.1.3",
-				"@comunica/actor-query-serialize-sparql": "^5.1.3",
-				"@comunica/actor-query-source-dereference-link-force-sparql": "^5.1.3",
-				"@comunica/actor-query-source-dereference-link-hypermedia": "^5.1.3",
-				"@comunica/actor-query-source-identify-hypermedia": "^5.1.3",
-				"@comunica/actor-query-source-identify-hypermedia-none": "^5.1.3",
-				"@comunica/actor-query-source-identify-hypermedia-qpf": "^5.1.3",
-				"@comunica/actor-query-source-identify-hypermedia-sparql": "^5.1.3",
-				"@comunica/actor-query-source-identify-rdfjs": "^5.1.3",
-				"@comunica/actor-query-source-identify-serialized": "^5.1.3",
-				"@comunica/actor-rdf-join-entries-sort-cardinality": "^5.1.3",
-				"@comunica/actor-rdf-join-entries-sort-selectivity": "^5.1.3",
-				"@comunica/actor-rdf-join-inner-hash": "^5.1.3",
-				"@comunica/actor-rdf-join-inner-multi-bind": "^5.1.3",
-				"@comunica/actor-rdf-join-inner-multi-bind-source": "^5.1.3",
-				"@comunica/actor-rdf-join-inner-multi-empty": "^5.1.3",
-				"@comunica/actor-rdf-join-inner-multi-smallest": "^5.1.3",
-				"@comunica/actor-rdf-join-inner-multi-smallest-filter-bindings": "^5.1.3",
-				"@comunica/actor-rdf-join-inner-nestedloop": "^5.1.3",
-				"@comunica/actor-rdf-join-inner-none": "^5.1.3",
-				"@comunica/actor-rdf-join-inner-single": "^5.1.3",
-				"@comunica/actor-rdf-join-inner-symmetrichash": "^5.1.3",
-				"@comunica/actor-rdf-join-minus-hash": "^5.1.3",
-				"@comunica/actor-rdf-join-optional-bind": "^5.1.3",
-				"@comunica/actor-rdf-join-optional-hash": "^5.1.3",
-				"@comunica/actor-rdf-join-optional-nestedloop": "^5.1.3",
-				"@comunica/actor-rdf-join-selectivity-variable-counting": "^5.1.3",
-				"@comunica/actor-rdf-metadata-accumulate-cardinality": "^5.1.3",
-				"@comunica/actor-rdf-metadata-accumulate-pagesize": "^5.1.3",
-				"@comunica/actor-rdf-metadata-accumulate-requesttime": "^5.1.3",
-				"@comunica/actor-rdf-metadata-all": "^5.1.3",
-				"@comunica/actor-rdf-metadata-extract-allow-http-methods": "^5.1.3",
-				"@comunica/actor-rdf-metadata-extract-hydra-controls": "^5.1.3",
-				"@comunica/actor-rdf-metadata-extract-hydra-count": "^5.1.3",
-				"@comunica/actor-rdf-metadata-extract-hydra-pagesize": "^5.1.3",
-				"@comunica/actor-rdf-metadata-extract-patch-sparql-update": "^5.1.3",
-				"@comunica/actor-rdf-metadata-extract-post-accepted": "^5.1.3",
-				"@comunica/actor-rdf-metadata-extract-put-accepted": "^5.1.3",
-				"@comunica/actor-rdf-metadata-extract-request-time": "^5.1.3",
-				"@comunica/actor-rdf-metadata-extract-sparql-service": "^5.1.3",
-				"@comunica/actor-rdf-metadata-extract-void": "^5.1.3",
-				"@comunica/actor-rdf-metadata-primary-topic": "^5.1.3",
-				"@comunica/actor-rdf-parse-html": "^5.1.3",
-				"@comunica/actor-rdf-parse-html-microdata": "^5.1.3",
-				"@comunica/actor-rdf-parse-html-rdfa": "^5.1.3",
-				"@comunica/actor-rdf-parse-html-script": "^5.1.3",
-				"@comunica/actor-rdf-parse-jsonld": "^5.1.3",
-				"@comunica/actor-rdf-parse-n3": "^5.1.3",
-				"@comunica/actor-rdf-parse-rdfxml": "^5.1.3",
-				"@comunica/actor-rdf-parse-shaclc": "^5.1.3",
-				"@comunica/actor-rdf-parse-xml-rdfa": "^5.1.3",
-				"@comunica/actor-rdf-resolve-hypermedia-links-next": "^5.1.3",
-				"@comunica/actor-rdf-resolve-hypermedia-links-queue-fifo": "^5.1.3",
-				"@comunica/actor-rdf-serialize-jsonld": "^5.1.3",
-				"@comunica/actor-rdf-serialize-n3": "^5.1.3",
-				"@comunica/actor-rdf-serialize-shaclc": "^5.1.3",
-				"@comunica/actor-rdf-update-hypermedia-patch-sparql-update": "^5.1.3",
-				"@comunica/actor-rdf-update-hypermedia-put-ldp": "^5.1.3",
-				"@comunica/actor-rdf-update-hypermedia-sparql": "^5.1.3",
-				"@comunica/actor-rdf-update-quads-hypermedia": "^5.1.3",
-				"@comunica/actor-rdf-update-quads-rdfjs-store": "^5.1.3",
-				"@comunica/actor-term-comparator-factory-expression-evaluator": "^5.1.3",
-				"@comunica/bus-function-factory": "^5.1.3",
-				"@comunica/bus-http-invalidate": "^5.1.3",
-				"@comunica/bus-query-operation": "^5.1.3",
-				"@comunica/config-query-sparql": "^5.0.0",
-				"@comunica/core": "^5.1.3",
-				"@comunica/logger-void": "^5.1.3",
-				"@comunica/mediator-all": "^5.1.3",
-				"@comunica/mediator-combine-pipeline": "^5.1.3",
-				"@comunica/mediator-combine-union": "^5.1.3",
-				"@comunica/mediator-join-coefficients-fixed": "^5.1.3",
-				"@comunica/mediator-number": "^5.1.3",
-				"@comunica/mediator-race": "^5.1.3",
-				"@comunica/runner": "^5.1.3",
-				"@comunica/runner-cli": "^5.1.3",
-				"@comunica/types": "^5.1.3",
+				"@comunica/actor-bindings-aggregator-factory-average": "^5.2.0",
+				"@comunica/actor-bindings-aggregator-factory-count": "^5.2.0",
+				"@comunica/actor-bindings-aggregator-factory-group-concat": "^5.2.0",
+				"@comunica/actor-bindings-aggregator-factory-max": "^5.2.0",
+				"@comunica/actor-bindings-aggregator-factory-min": "^5.2.0",
+				"@comunica/actor-bindings-aggregator-factory-sample": "^5.2.0",
+				"@comunica/actor-bindings-aggregator-factory-sum": "^5.2.0",
+				"@comunica/actor-bindings-aggregator-factory-wildcard-count": "^5.2.0",
+				"@comunica/actor-context-preprocess-convert-shortcuts": "^5.2.0",
+				"@comunica/actor-context-preprocess-set-defaults": "^5.2.0",
+				"@comunica/actor-context-preprocess-source-to-destination": "^5.2.0",
+				"@comunica/actor-dereference-fallback": "^5.2.0",
+				"@comunica/actor-dereference-http": "^5.2.0",
+				"@comunica/actor-dereference-rdf-parse": "^5.2.0",
+				"@comunica/actor-expression-evaluator-factory-default": "^5.2.0",
+				"@comunica/actor-function-factory-expression-bnode": "^5.2.0",
+				"@comunica/actor-function-factory-expression-bound": "^5.2.0",
+				"@comunica/actor-function-factory-expression-coalesce": "^5.2.0",
+				"@comunica/actor-function-factory-expression-concat": "^5.2.0",
+				"@comunica/actor-function-factory-expression-extensions": "^5.2.0",
+				"@comunica/actor-function-factory-expression-if": "^5.2.0",
+				"@comunica/actor-function-factory-expression-in": "^5.2.0",
+				"@comunica/actor-function-factory-expression-logical-and": "^5.2.0",
+				"@comunica/actor-function-factory-expression-logical-or": "^5.2.0",
+				"@comunica/actor-function-factory-expression-not-in": "^5.2.0",
+				"@comunica/actor-function-factory-expression-same-term": "^5.2.0",
+				"@comunica/actor-function-factory-term-abs": "^5.2.0",
+				"@comunica/actor-function-factory-term-addition": "^5.2.0",
+				"@comunica/actor-function-factory-term-ceil": "^5.2.0",
+				"@comunica/actor-function-factory-term-contains": "^5.2.0",
+				"@comunica/actor-function-factory-term-datatype": "^5.2.0",
+				"@comunica/actor-function-factory-term-day": "^5.2.0",
+				"@comunica/actor-function-factory-term-division": "^5.2.0",
+				"@comunica/actor-function-factory-term-encode-for-uri": "^5.2.0",
+				"@comunica/actor-function-factory-term-equality": "^5.2.0",
+				"@comunica/actor-function-factory-term-floor": "^5.2.0",
+				"@comunica/actor-function-factory-term-greater-than": "^5.2.0",
+				"@comunica/actor-function-factory-term-greater-than-equal": "^5.2.0",
+				"@comunica/actor-function-factory-term-has-lang": "^5.2.0",
+				"@comunica/actor-function-factory-term-has-langdir": "^5.2.0",
+				"@comunica/actor-function-factory-term-hours": "^5.2.0",
+				"@comunica/actor-function-factory-term-inequality": "^5.2.0",
+				"@comunica/actor-function-factory-term-iri": "^5.2.0",
+				"@comunica/actor-function-factory-term-is-blank": "^5.2.0",
+				"@comunica/actor-function-factory-term-is-iri": "^5.2.0",
+				"@comunica/actor-function-factory-term-is-literal": "^5.2.0",
+				"@comunica/actor-function-factory-term-is-numeric": "^5.2.0",
+				"@comunica/actor-function-factory-term-is-triple": "^5.2.0",
+				"@comunica/actor-function-factory-term-lang": "^5.2.0",
+				"@comunica/actor-function-factory-term-langdir": "^5.2.0",
+				"@comunica/actor-function-factory-term-langmatches": "^5.2.0",
+				"@comunica/actor-function-factory-term-lcase": "^5.2.0",
+				"@comunica/actor-function-factory-term-lesser-than": "^5.2.0",
+				"@comunica/actor-function-factory-term-lesser-than-equal": "^5.2.0",
+				"@comunica/actor-function-factory-term-md5": "^5.2.0",
+				"@comunica/actor-function-factory-term-minutes": "^5.2.0",
+				"@comunica/actor-function-factory-term-month": "^5.2.0",
+				"@comunica/actor-function-factory-term-multiplication": "^5.2.0",
+				"@comunica/actor-function-factory-term-not": "^5.2.0",
+				"@comunica/actor-function-factory-term-now": "^5.2.0",
+				"@comunica/actor-function-factory-term-object": "^5.2.0",
+				"@comunica/actor-function-factory-term-predicate": "^5.2.0",
+				"@comunica/actor-function-factory-term-rand": "^5.2.0",
+				"@comunica/actor-function-factory-term-regex": "^5.2.0",
+				"@comunica/actor-function-factory-term-replace": "^5.2.0",
+				"@comunica/actor-function-factory-term-round": "^5.2.0",
+				"@comunica/actor-function-factory-term-seconds": "^5.2.0",
+				"@comunica/actor-function-factory-term-sha1": "^5.2.0",
+				"@comunica/actor-function-factory-term-sha256": "^5.2.0",
+				"@comunica/actor-function-factory-term-sha384": "^5.2.0",
+				"@comunica/actor-function-factory-term-sha512": "^5.2.0",
+				"@comunica/actor-function-factory-term-str": "^5.2.0",
+				"@comunica/actor-function-factory-term-str-after": "^5.2.0",
+				"@comunica/actor-function-factory-term-str-before": "^5.2.0",
+				"@comunica/actor-function-factory-term-str-dt": "^5.2.0",
+				"@comunica/actor-function-factory-term-str-ends": "^5.2.0",
+				"@comunica/actor-function-factory-term-str-lang": "^5.2.0",
+				"@comunica/actor-function-factory-term-str-langdir": "^5.2.0",
+				"@comunica/actor-function-factory-term-str-len": "^5.2.0",
+				"@comunica/actor-function-factory-term-str-starts": "^5.2.0",
+				"@comunica/actor-function-factory-term-str-uuid": "^5.2.0",
+				"@comunica/actor-function-factory-term-sub-str": "^5.2.0",
+				"@comunica/actor-function-factory-term-subject": "^5.2.0",
+				"@comunica/actor-function-factory-term-subtraction": "^5.2.0",
+				"@comunica/actor-function-factory-term-timezone": "^5.2.0",
+				"@comunica/actor-function-factory-term-triple": "^5.2.0",
+				"@comunica/actor-function-factory-term-tz": "^5.2.0",
+				"@comunica/actor-function-factory-term-ucase": "^5.2.0",
+				"@comunica/actor-function-factory-term-unary-minus": "^5.2.0",
+				"@comunica/actor-function-factory-term-unary-plus": "^5.2.0",
+				"@comunica/actor-function-factory-term-uuid": "^5.2.0",
+				"@comunica/actor-function-factory-term-xsd-to-boolean": "^5.2.0",
+				"@comunica/actor-function-factory-term-xsd-to-date": "^5.2.0",
+				"@comunica/actor-function-factory-term-xsd-to-datetime": "^5.2.0",
+				"@comunica/actor-function-factory-term-xsd-to-day-time-duration": "^5.2.0",
+				"@comunica/actor-function-factory-term-xsd-to-decimal": "^5.2.0",
+				"@comunica/actor-function-factory-term-xsd-to-double": "^5.2.0",
+				"@comunica/actor-function-factory-term-xsd-to-duration": "^5.2.0",
+				"@comunica/actor-function-factory-term-xsd-to-float": "^5.2.0",
+				"@comunica/actor-function-factory-term-xsd-to-integer": "^5.2.0",
+				"@comunica/actor-function-factory-term-xsd-to-string": "^5.2.0",
+				"@comunica/actor-function-factory-term-xsd-to-time": "^5.2.0",
+				"@comunica/actor-function-factory-term-xsd-to-year-month-duration": "^5.2.0",
+				"@comunica/actor-function-factory-term-year": "^5.2.0",
+				"@comunica/actor-hash-bindings-murmur": "^5.2.0",
+				"@comunica/actor-hash-quads-murmur": "^5.2.0",
+				"@comunica/actor-http-fetch": "^5.2.0",
+				"@comunica/actor-http-limit-rate": "^5.2.0",
+				"@comunica/actor-http-proxy": "^5.2.0",
+				"@comunica/actor-http-retry": "^5.2.0",
+				"@comunica/actor-http-retry-body": "^5.2.0",
+				"@comunica/actor-http-wayback": "^5.2.0",
+				"@comunica/actor-init-query": "^5.2.0",
+				"@comunica/actor-optimize-query-operation-assign-sources-exhaustive": "^5.2.0",
+				"@comunica/actor-optimize-query-operation-bgp-to-join": "^5.2.0",
+				"@comunica/actor-optimize-query-operation-construct-distinct": "^5.2.0",
+				"@comunica/actor-optimize-query-operation-describe-to-constructs-subject": "^5.2.0",
+				"@comunica/actor-optimize-query-operation-distinct-terms-pushdown": "^5.2.0",
+				"@comunica/actor-optimize-query-operation-filter-pushdown": "^5.2.0",
+				"@comunica/actor-optimize-query-operation-group-file-sources": "^5.2.0",
+				"@comunica/actor-optimize-query-operation-group-sources": "^5.2.0",
+				"@comunica/actor-optimize-query-operation-join-bgp": "^5.2.0",
+				"@comunica/actor-optimize-query-operation-join-connected": "^5.2.0",
+				"@comunica/actor-optimize-query-operation-leftjoin-expression-pushdown": "^5.2.0",
+				"@comunica/actor-optimize-query-operation-prune-empty-source-operations": "^5.2.0",
+				"@comunica/actor-optimize-query-operation-query-source-identify": "^5.2.0",
+				"@comunica/actor-optimize-query-operation-query-source-skolemize": "^5.2.0",
+				"@comunica/actor-optimize-query-operation-rewrite-add": "^5.2.0",
+				"@comunica/actor-optimize-query-operation-rewrite-copy": "^5.2.0",
+				"@comunica/actor-optimize-query-operation-rewrite-move": "^5.2.0",
+				"@comunica/actor-query-operation-ask": "^5.2.0",
+				"@comunica/actor-query-operation-bgp-join": "^5.2.0",
+				"@comunica/actor-query-operation-construct": "^5.2.0",
+				"@comunica/actor-query-operation-distinct-identity": "^5.2.0",
+				"@comunica/actor-query-operation-extend": "^5.2.0",
+				"@comunica/actor-query-operation-filter": "^5.2.0",
+				"@comunica/actor-query-operation-from-quad": "^5.2.0",
+				"@comunica/actor-query-operation-group": "^5.2.0",
+				"@comunica/actor-query-operation-join": "^5.2.0",
+				"@comunica/actor-query-operation-leftjoin": "^5.2.0",
+				"@comunica/actor-query-operation-minus": "^5.2.0",
+				"@comunica/actor-query-operation-nodes": "^5.2.0",
+				"@comunica/actor-query-operation-nop": "^5.2.0",
+				"@comunica/actor-query-operation-orderby": "^5.2.0",
+				"@comunica/actor-query-operation-path-alt": "^5.2.0",
+				"@comunica/actor-query-operation-path-inv": "^5.2.0",
+				"@comunica/actor-query-operation-path-link": "^5.2.0",
+				"@comunica/actor-query-operation-path-nps": "^5.2.0",
+				"@comunica/actor-query-operation-path-one-or-more": "^5.2.0",
+				"@comunica/actor-query-operation-path-seq": "^5.2.0",
+				"@comunica/actor-query-operation-path-zero-or-more": "^5.2.0",
+				"@comunica/actor-query-operation-path-zero-or-one": "^5.2.0",
+				"@comunica/actor-query-operation-project": "^5.2.0",
+				"@comunica/actor-query-operation-reduced-hash": "^5.2.0",
+				"@comunica/actor-query-operation-slice": "^5.2.0",
+				"@comunica/actor-query-operation-source": "^5.2.0",
+				"@comunica/actor-query-operation-union": "^5.2.0",
+				"@comunica/actor-query-operation-update-clear": "^5.2.0",
+				"@comunica/actor-query-operation-update-compositeupdate": "^5.2.0",
+				"@comunica/actor-query-operation-update-create": "^5.2.0",
+				"@comunica/actor-query-operation-update-deleteinsert": "^5.2.0",
+				"@comunica/actor-query-operation-update-drop": "^5.2.0",
+				"@comunica/actor-query-operation-update-load": "^5.2.0",
+				"@comunica/actor-query-operation-values": "^5.2.0",
+				"@comunica/actor-query-parse-graphql": "^5.2.0",
+				"@comunica/actor-query-parse-sparql": "^5.2.0",
+				"@comunica/actor-query-process-explain-logical": "^5.2.0",
+				"@comunica/actor-query-process-explain-parsed": "^5.2.0",
+				"@comunica/actor-query-process-explain-physical": "^5.2.0",
+				"@comunica/actor-query-process-explain-query": "^5.2.0",
+				"@comunica/actor-query-process-sequential": "^5.2.0",
+				"@comunica/actor-query-result-serialize-json": "^5.2.0",
+				"@comunica/actor-query-result-serialize-rdf": "^5.2.0",
+				"@comunica/actor-query-result-serialize-simple": "^5.2.0",
+				"@comunica/actor-query-result-serialize-sparql-csv": "^5.2.0",
+				"@comunica/actor-query-result-serialize-sparql-json": "^5.2.0",
+				"@comunica/actor-query-result-serialize-sparql-tsv": "^5.2.0",
+				"@comunica/actor-query-result-serialize-sparql-xml": "^5.2.0",
+				"@comunica/actor-query-result-serialize-stats": "^5.2.0",
+				"@comunica/actor-query-result-serialize-table": "^5.2.0",
+				"@comunica/actor-query-result-serialize-tree": "^5.2.0",
+				"@comunica/actor-query-serialize-sparql": "^5.2.0",
+				"@comunica/actor-query-source-dereference-link-force-sparql": "^5.2.0",
+				"@comunica/actor-query-source-dereference-link-hypermedia": "^5.2.0",
+				"@comunica/actor-query-source-identify-compositefile": "^5.2.0",
+				"@comunica/actor-query-source-identify-hypermedia": "^5.2.0",
+				"@comunica/actor-query-source-identify-hypermedia-none": "^5.2.0",
+				"@comunica/actor-query-source-identify-hypermedia-qpf": "^5.2.0",
+				"@comunica/actor-query-source-identify-hypermedia-sparql": "^5.2.0",
+				"@comunica/actor-query-source-identify-rdfjs": "^5.2.0",
+				"@comunica/actor-query-source-identify-serialized": "^5.2.0",
+				"@comunica/actor-rdf-join-entries-sort-cardinality": "^5.2.0",
+				"@comunica/actor-rdf-join-entries-sort-selectivity": "^5.2.0",
+				"@comunica/actor-rdf-join-inner-hash": "^5.2.0",
+				"@comunica/actor-rdf-join-inner-multi-bind": "^5.2.0",
+				"@comunica/actor-rdf-join-inner-multi-bind-source": "^5.2.0",
+				"@comunica/actor-rdf-join-inner-multi-empty": "^5.2.0",
+				"@comunica/actor-rdf-join-inner-multi-smallest": "^5.2.0",
+				"@comunica/actor-rdf-join-inner-multi-smallest-filter-bindings": "^5.2.0",
+				"@comunica/actor-rdf-join-inner-nestedloop": "^5.2.0",
+				"@comunica/actor-rdf-join-inner-none": "^5.2.0",
+				"@comunica/actor-rdf-join-inner-single": "^5.2.0",
+				"@comunica/actor-rdf-join-inner-symmetrichash": "^5.2.0",
+				"@comunica/actor-rdf-join-minus-hash": "^5.2.0",
+				"@comunica/actor-rdf-join-optional-bind": "^5.2.0",
+				"@comunica/actor-rdf-join-optional-hash": "^5.2.0",
+				"@comunica/actor-rdf-join-optional-nestedloop": "^5.2.0",
+				"@comunica/actor-rdf-join-selectivity-variable-counting": "^5.2.0",
+				"@comunica/actor-rdf-metadata-accumulate-cardinality": "^5.2.0",
+				"@comunica/actor-rdf-metadata-accumulate-pagesize": "^5.2.0",
+				"@comunica/actor-rdf-metadata-accumulate-requesttime": "^5.2.0",
+				"@comunica/actor-rdf-metadata-all": "^5.2.0",
+				"@comunica/actor-rdf-metadata-extract-allow-http-methods": "^5.2.0",
+				"@comunica/actor-rdf-metadata-extract-hydra-controls": "^5.2.0",
+				"@comunica/actor-rdf-metadata-extract-hydra-count": "^5.2.0",
+				"@comunica/actor-rdf-metadata-extract-hydra-pagesize": "^5.2.0",
+				"@comunica/actor-rdf-metadata-extract-patch-sparql-update": "^5.2.0",
+				"@comunica/actor-rdf-metadata-extract-post-accepted": "^5.2.0",
+				"@comunica/actor-rdf-metadata-extract-put-accepted": "^5.2.0",
+				"@comunica/actor-rdf-metadata-extract-request-time": "^5.2.0",
+				"@comunica/actor-rdf-metadata-extract-server-software": "^5.2.0",
+				"@comunica/actor-rdf-metadata-extract-sparql-service": "^5.2.0",
+				"@comunica/actor-rdf-metadata-extract-void": "^5.2.0",
+				"@comunica/actor-rdf-metadata-primary-topic": "^5.2.0",
+				"@comunica/actor-rdf-parse-html": "^5.2.0",
+				"@comunica/actor-rdf-parse-html-microdata": "^5.2.0",
+				"@comunica/actor-rdf-parse-html-rdfa": "^5.2.0",
+				"@comunica/actor-rdf-parse-html-script": "^5.2.0",
+				"@comunica/actor-rdf-parse-jsonld": "^5.2.0",
+				"@comunica/actor-rdf-parse-n3": "^5.2.0",
+				"@comunica/actor-rdf-parse-rdfxml": "^5.2.0",
+				"@comunica/actor-rdf-parse-shaclc": "^5.2.0",
+				"@comunica/actor-rdf-parse-xml-rdfa": "^5.2.0",
+				"@comunica/actor-rdf-resolve-hypermedia-links-next": "^5.2.0",
+				"@comunica/actor-rdf-resolve-hypermedia-links-queue-fifo": "^5.2.0",
+				"@comunica/actor-rdf-serialize-jsonld": "^5.2.0",
+				"@comunica/actor-rdf-serialize-n3": "^5.2.0",
+				"@comunica/actor-rdf-serialize-shaclc": "^5.2.0",
+				"@comunica/actor-rdf-update-hypermedia-patch-sparql-update": "^5.2.0",
+				"@comunica/actor-rdf-update-hypermedia-put-ldp": "^5.2.0",
+				"@comunica/actor-rdf-update-hypermedia-sparql": "^5.2.0",
+				"@comunica/actor-rdf-update-quads-hypermedia": "^5.2.0",
+				"@comunica/actor-rdf-update-quads-rdfjs-store": "^5.2.0",
+				"@comunica/actor-term-comparator-factory-expression-evaluator": "^5.2.0",
+				"@comunica/bus-function-factory": "^5.2.0",
+				"@comunica/bus-http-invalidate": "^5.2.0",
+				"@comunica/bus-query-operation": "^5.2.0",
+				"@comunica/config-query-sparql": "^5.2.1",
+				"@comunica/core": "^5.2.0",
+				"@comunica/logger-void": "^5.2.0",
+				"@comunica/mediator-all": "^5.2.0",
+				"@comunica/mediator-combine-pipeline": "^5.2.0",
+				"@comunica/mediator-combine-union": "^5.2.0",
+				"@comunica/mediator-join-coefficients-fixed": "^5.2.0",
+				"@comunica/mediator-number": "^5.2.0",
+				"@comunica/mediator-race": "^5.2.0",
+				"@comunica/runner": "^5.2.0",
+				"@comunica/runner-cli": "^5.2.0",
+				"@comunica/types": "^5.2.0",
 				"process": "^0.11.10"
 			},
 			"bin": {
@@ -5240,14 +5305,14 @@
 			}
 		},
 		"node_modules/@comunica/runner": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/runner/-/runner-5.1.3.tgz",
-			"integrity": "sha512-SP84pTYFBdHED0KSua4h6r6Gry+3zNFSeiRsihf/s/wS9cs/J+juUteDBdiB9ObC/kg3wRMkMptmRO77CqsfoA==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/runner/-/runner-5.2.0.tgz",
+			"integrity": "sha512-OlsUQbJ6as7H8KoWFrQ7DLwbC/sYLe7U6MNno/a8JoGBtgAnYlueFm+5drpk53RcQANQ77rRExwzAJU2qGqlEQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-init": "^5.1.3",
-				"@comunica/core": "^5.1.3",
+				"@comunica/bus-init": "^5.2.0",
+				"@comunica/core": "^5.2.0",
 				"componentsjs": "^6.2.0",
 				"process": "^0.11.10"
 			},
@@ -5260,15 +5325,15 @@
 			}
 		},
 		"node_modules/@comunica/runner-cli": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/runner-cli/-/runner-cli-5.1.3.tgz",
-			"integrity": "sha512-58FpohUXPJSDVfHszH83SgQHcC1rSJzccarUgXFxJzJx2NwogsAGOyW6gPOyuUCrSqIEDZER0CABS4iQbbZNIA==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/runner-cli/-/runner-cli-5.2.0.tgz",
+			"integrity": "sha512-FuQRK8BvGFg3tba/ztEE0lD7rFmo+LtSRX/M4/Ag4UNZatTV535KpPrJS/wVa2gWHfoagvwqaLrqOU/oxmWU9A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/core": "^5.1.3",
-				"@comunica/runner": "^5.1.3",
-				"@comunica/types": "^5.1.3",
+				"@comunica/core": "^5.2.0",
+				"@comunica/runner": "^5.2.0",
+				"@comunica/types": "^5.2.0",
 				"process": "^0.11.10"
 			},
 			"bin": {
@@ -5280,13 +5345,13 @@
 			}
 		},
 		"node_modules/@comunica/types": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/types/-/types-5.1.3.tgz",
-			"integrity": "sha512-EbA9yYlx+49zGfmMYnQdbNfdZoUwovjKLXD4ZlpM2TDbo3MUdweyqLcDS00GB+PE5bVzFQf1I2sneEWVfzx3mQ==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/types/-/types-5.2.0.tgz",
+			"integrity": "sha512-KVDvDkAZfvXk6ymtEbS+49k39Yc1S5xIVBL+XLkn482ngvlMAyX/wMSKOa7OIAn1cSTaAoh6OiFhb1oSEnEUXQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/utils-algebra": "^5.1.3",
+				"@comunica/utils-algebra": "^5.2.0",
 				"@rdfjs/types": "*",
 				"@types/yargs": "^17.0.24",
 				"asynciterator": "^3.10.0",
@@ -5298,14 +5363,16 @@
 			}
 		},
 		"node_modules/@comunica/utils-algebra": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/utils-algebra/-/utils-algebra-5.1.3.tgz",
-			"integrity": "sha512-y1PSCLXo7rWqqclmwe0BmkxpciH5t0tDNeyb1WpSfs8gxLMlYWXndCwfUkkDH7N6NLBZ2XG3Jy6YOThwg1HU+g==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/utils-algebra/-/utils-algebra-5.2.0.tgz",
+			"integrity": "sha512-UYGwvXF8PkV72ivxkE1sjJi9v/5NPiWXjsRdkgOHkRGcUkReLTjMQPWTyQ/QmiW7SkAkbYwWLG8rn8jtAdpgVw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
+				"@rdfjs/types": "*",
 				"@traqula/algebra-transformations-1-2": "^1.0.1",
-				"@traqula/core": "^1.0.0"
+				"@traqula/core": "^1.0.0",
+				"rdf-terms": "^2.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -5313,15 +5380,15 @@
 			}
 		},
 		"node_modules/@comunica/utils-bindings-factory": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/utils-bindings-factory/-/utils-bindings-factory-5.1.3.tgz",
-			"integrity": "sha512-cj+yqKX0wlMWrPeKhc8oNqQzqT3dmhTY/MNeP1PA+GbF4+tCOjmUma71H1N89Rhu9DvN2KNXC0hzgKTRweg18g==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/utils-bindings-factory/-/utils-bindings-factory-5.2.0.tgz",
+			"integrity": "sha512-IE9f71bNyFWyQR5R5+f+FOp/1ynk4fo0IivS5w3PkvIN7hT3zWDwJEdwqFWJME5SN+bafiajTwBMro4Vp54OGw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/bus-merge-bindings-context": "^5.1.3",
-				"@comunica/core": "^5.1.3",
-				"@comunica/types": "^5.1.3",
+				"@comunica/bus-merge-bindings-context": "^5.2.0",
+				"@comunica/core": "^5.2.0",
+				"@comunica/types": "^5.2.0",
 				"@rdfjs/types": "*",
 				"immutable": "^5.1.3",
 				"rdf-string": "^2.0.1"
@@ -5332,13 +5399,13 @@
 			}
 		},
 		"node_modules/@comunica/utils-bindings-index": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/utils-bindings-index/-/utils-bindings-index-5.1.3.tgz",
-			"integrity": "sha512-SRKsQrxP59S5tvpH2v87P1zVTpIVIo6Nil7gaAs8qkEaLUEFyuc+NWAmD4RhqlJb4k1FNxrQTApQF4wEa4bVjQ==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/utils-bindings-index/-/utils-bindings-index-5.2.0.tgz",
+			"integrity": "sha512-ncTac3PuDDXk8X+4bKExLva25ce+/CkapwcbMzJyAUO3/MpYaOq0UGHBm2cdIwjNHl2TFhUL5GOaATIKlfUpiw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/types": "^5.1.3",
+				"@comunica/types": "^5.2.0",
 				"@rdfjs/types": "*"
 			},
 			"funding": {
@@ -5361,15 +5428,15 @@
 			}
 		},
 		"node_modules/@comunica/utils-expression-evaluator": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/utils-expression-evaluator/-/utils-expression-evaluator-5.1.3.tgz",
-			"integrity": "sha512-fUnkx8IG9WyzhRljqDlU8WH05ixVyCvQ8OgWDKIG0cPOoXGJxmg0Qv0z7a2te7m8klaTJiG+KY/YRzwCDY5cww==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/utils-expression-evaluator/-/utils-expression-evaluator-5.2.0.tgz",
+			"integrity": "sha512-S8t14+O8pYc6T6iG6GhVIg/uxpUFGAfAZOEZ9V+2i6lxvKoytem3ttnLAQ+jQnJIFicVL/6oo7r/sPk12TwFtw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/context-entries": "^5.1.3",
-				"@comunica/types": "^5.1.3",
-				"@comunica/utils-algebra": "^5.1.3",
+				"@comunica/context-entries": "^5.2.0",
+				"@comunica/types": "^5.2.0",
+				"@comunica/utils-algebra": "^5.2.0",
 				"@rdfjs/types": "*",
 				"lru-cache": "^11.2.2",
 				"rdf-data-factory": "^2.0.0",
@@ -5395,13 +5462,13 @@
 			}
 		},
 		"node_modules/@comunica/utils-metadata": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/utils-metadata/-/utils-metadata-5.1.3.tgz",
-			"integrity": "sha512-N+dH7J5z1RBTKc5hhrj1Vlj4hIut1dZQujXak/CHBufMTFVPC1fLstV/rWbs+xfPv+fgENBbJBmw+U8VSnfl+g==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/utils-metadata/-/utils-metadata-5.2.0.tgz",
+			"integrity": "sha512-O9++P9VI3Z2NFK1u6JFOC0yPLvKEyrgOlsR9UTBhjpcgvf27UWLQGmGIoT5mbtU/L20RfL8mYdtpDM3qlrIWnQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/types": "^5.1.3",
+				"@comunica/types": "^5.2.0",
 				"@rdfjs/types": "*",
 				"asynciterator": "^3.10.0"
 			},
@@ -5411,17 +5478,17 @@
 			}
 		},
 		"node_modules/@comunica/utils-query-operation": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@comunica/utils-query-operation/-/utils-query-operation-5.1.3.tgz",
-			"integrity": "sha512-veRNX7pDZlIk4CW8Zz/bWLHRsdAFGb3sX3bQ6lAeSdtKki9TXn5J1crMK32MXBhlnDiGnMFrzsKwXUz7ZteM1A==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@comunica/utils-query-operation/-/utils-query-operation-5.2.0.tgz",
+			"integrity": "sha512-36tQo7MA0uvUwUO8uTOJFu8BgRV45a9fgEwNyfVjH8fl3ptvBrTNWcZSrRJOnXzYo2mysxKxWfp9YylRYy24IA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@comunica/context-entries": "^5.1.3",
-				"@comunica/core": "^5.1.3",
-				"@comunica/types": "^5.1.3",
-				"@comunica/utils-algebra": "^5.1.3",
-				"@comunica/utils-bindings-factory": "^5.1.3",
+				"@comunica/context-entries": "^5.2.0",
+				"@comunica/core": "^5.2.0",
+				"@comunica/types": "^5.2.0",
+				"@comunica/utils-algebra": "^5.2.0",
+				"@comunica/utils-bindings-factory": "^5.2.0",
 				"@rdfjs/types": "*",
 				"rdf-data-factory": "^2.0.0",
 				"rdf-string": "^2.0.1",
@@ -5445,9 +5512,9 @@
 			}
 		},
 		"node_modules/@esbuild/aix-ppc64": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.3.tgz",
-			"integrity": "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==",
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+			"integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
 			"cpu": [
 				"ppc64"
 			],
@@ -5462,9 +5529,9 @@
 			}
 		},
 		"node_modules/@esbuild/android-arm": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.3.tgz",
-			"integrity": "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==",
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+			"integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
 			"cpu": [
 				"arm"
 			],
@@ -5479,9 +5546,9 @@
 			}
 		},
 		"node_modules/@esbuild/android-arm64": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.3.tgz",
-			"integrity": "sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==",
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+			"integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -5496,9 +5563,9 @@
 			}
 		},
 		"node_modules/@esbuild/android-x64": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.3.tgz",
-			"integrity": "sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==",
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+			"integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
 			"cpu": [
 				"x64"
 			],
@@ -5513,9 +5580,9 @@
 			}
 		},
 		"node_modules/@esbuild/darwin-arm64": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.3.tgz",
-			"integrity": "sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==",
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+			"integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
 			"cpu": [
 				"arm64"
 			],
@@ -5530,9 +5597,9 @@
 			}
 		},
 		"node_modules/@esbuild/darwin-x64": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.3.tgz",
-			"integrity": "sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==",
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+			"integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
 			"cpu": [
 				"x64"
 			],
@@ -5547,9 +5614,9 @@
 			}
 		},
 		"node_modules/@esbuild/freebsd-arm64": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.3.tgz",
-			"integrity": "sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==",
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+			"integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
 			"cpu": [
 				"arm64"
 			],
@@ -5564,9 +5631,9 @@
 			}
 		},
 		"node_modules/@esbuild/freebsd-x64": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.3.tgz",
-			"integrity": "sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==",
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+			"integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
 			"cpu": [
 				"x64"
 			],
@@ -5581,9 +5648,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-arm": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.3.tgz",
-			"integrity": "sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==",
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+			"integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
 			"cpu": [
 				"arm"
 			],
@@ -5598,9 +5665,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-arm64": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.3.tgz",
-			"integrity": "sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==",
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+			"integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
 			"cpu": [
 				"arm64"
 			],
@@ -5615,9 +5682,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-ia32": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.3.tgz",
-			"integrity": "sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==",
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+			"integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
 			"cpu": [
 				"ia32"
 			],
@@ -5632,9 +5699,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-loong64": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.3.tgz",
-			"integrity": "sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==",
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+			"integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
 			"cpu": [
 				"loong64"
 			],
@@ -5649,9 +5716,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-mips64el": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.3.tgz",
-			"integrity": "sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==",
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+			"integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
 			"cpu": [
 				"mips64el"
 			],
@@ -5666,9 +5733,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-ppc64": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.3.tgz",
-			"integrity": "sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==",
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+			"integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
 			"cpu": [
 				"ppc64"
 			],
@@ -5683,9 +5750,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-riscv64": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.3.tgz",
-			"integrity": "sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==",
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+			"integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
 			"cpu": [
 				"riscv64"
 			],
@@ -5700,9 +5767,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-s390x": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.3.tgz",
-			"integrity": "sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==",
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+			"integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
 			"cpu": [
 				"s390x"
 			],
@@ -5717,9 +5784,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-x64": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.3.tgz",
-			"integrity": "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==",
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+			"integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
 			"cpu": [
 				"x64"
 			],
@@ -5734,9 +5801,9 @@
 			}
 		},
 		"node_modules/@esbuild/netbsd-arm64": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.3.tgz",
-			"integrity": "sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==",
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+			"integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
 			"cpu": [
 				"arm64"
 			],
@@ -5751,9 +5818,9 @@
 			}
 		},
 		"node_modules/@esbuild/netbsd-x64": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.3.tgz",
-			"integrity": "sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==",
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+			"integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
 			"cpu": [
 				"x64"
 			],
@@ -5768,9 +5835,9 @@
 			}
 		},
 		"node_modules/@esbuild/openbsd-arm64": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.3.tgz",
-			"integrity": "sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==",
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+			"integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
 			"cpu": [
 				"arm64"
 			],
@@ -5785,9 +5852,9 @@
 			}
 		},
 		"node_modules/@esbuild/openbsd-x64": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.3.tgz",
-			"integrity": "sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==",
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+			"integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
 			"cpu": [
 				"x64"
 			],
@@ -5802,9 +5869,9 @@
 			}
 		},
 		"node_modules/@esbuild/openharmony-arm64": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.3.tgz",
-			"integrity": "sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==",
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+			"integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
 			"cpu": [
 				"arm64"
 			],
@@ -5819,9 +5886,9 @@
 			}
 		},
 		"node_modules/@esbuild/sunos-x64": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.3.tgz",
-			"integrity": "sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==",
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+			"integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
 			"cpu": [
 				"x64"
 			],
@@ -5836,9 +5903,9 @@
 			}
 		},
 		"node_modules/@esbuild/win32-arm64": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.3.tgz",
-			"integrity": "sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==",
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+			"integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
 			"cpu": [
 				"arm64"
 			],
@@ -5853,9 +5920,9 @@
 			}
 		},
 		"node_modules/@esbuild/win32-ia32": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.3.tgz",
-			"integrity": "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==",
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+			"integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
 			"cpu": [
 				"ia32"
 			],
@@ -5870,9 +5937,9 @@
 			}
 		},
 		"node_modules/@esbuild/win32-x64": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.3.tgz",
-			"integrity": "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==",
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+			"integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
 			"cpu": [
 				"x64"
 			],
@@ -6044,25 +6111,39 @@
 			}
 		},
 		"node_modules/@humanfs/core": {
-			"version": "0.19.1",
-			"resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
-			"integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
+			"version": "0.19.2",
+			"resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+			"integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
 			"dev": true,
 			"license": "Apache-2.0",
+			"dependencies": {
+				"@humanfs/types": "^0.15.0"
+			},
 			"engines": {
 				"node": ">=18.18.0"
 			}
 		},
 		"node_modules/@humanfs/node": {
-			"version": "0.16.7",
-			"resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.7.tgz",
-			"integrity": "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==",
+			"version": "0.16.8",
+			"resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+			"integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@humanfs/core": "^0.19.1",
+				"@humanfs/core": "^0.19.2",
+				"@humanfs/types": "^0.15.0",
 				"@humanwhocodes/retry": "^0.4.0"
 			},
+			"engines": {
+				"node": ">=18.18.0"
+			}
+		},
+		"node_modules/@humanfs/types": {
+			"version": "0.15.0",
+			"resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+			"integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
+			"dev": true,
+			"license": "Apache-2.0",
 			"engines": {
 				"node": ">=18.18.0"
 			}
@@ -6226,9 +6307,9 @@
 			}
 		},
 		"node_modules/@rollup/rollup-android-arm-eabi": {
-			"version": "4.59.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.59.0.tgz",
-			"integrity": "sha512-upnNBkA6ZH2VKGcBj9Fyl9IGNPULcjXRlg0LLeaioQWueH30p6IXtJEbKAgvyv+mJaMxSm1l6xwDXYjpEMiLMg==",
+			"version": "4.60.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.2.tgz",
+			"integrity": "sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw==",
 			"cpu": [
 				"arm"
 			],
@@ -6240,9 +6321,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-android-arm64": {
-			"version": "4.59.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.59.0.tgz",
-			"integrity": "sha512-hZ+Zxj3SySm4A/DylsDKZAeVg0mvi++0PYVceVyX7hemkw7OreKdCvW2oQ3T1FMZvCaQXqOTHb8qmBShoqk69Q==",
+			"version": "4.60.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.2.tgz",
+			"integrity": "sha512-OqZTwDRDchGRHHm/hwLOL7uVPB9aUvI0am/eQuWMNyFHf5PSEQmyEeYYheA0EPPKUO/l0uigCp+iaTjoLjVoHg==",
 			"cpu": [
 				"arm64"
 			],
@@ -6253,10 +6334,38 @@
 				"android"
 			]
 		},
+		"node_modules/@rollup/rollup-darwin-arm64": {
+			"version": "4.60.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.2.tgz",
+			"integrity": "sha512-UwRE7CGpvSVEQS8gUMBe1uADWjNnVgP3Iusyda1nSRwNDCsRjnGc7w6El6WLQsXmZTbLZx9cecegumcitNfpmA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			]
+		},
+		"node_modules/@rollup/rollup-darwin-x64": {
+			"version": "4.60.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.2.tgz",
+			"integrity": "sha512-gjEtURKLCC5VXm1I+2i1u9OhxFsKAQJKTVB8WvDAHF+oZlq0GTVFOlTlO1q3AlCTE/DF32c16ESvfgqR7343/g==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			]
+		},
 		"node_modules/@rollup/rollup-freebsd-arm64": {
-			"version": "4.59.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.59.0.tgz",
-			"integrity": "sha512-EsKaJ5ytAu9jI3lonzn3BgG8iRBjV4LxZexygcQbpiU0wU0ATxhNVEpXKfUa0pS05gTcSDMKpn3Sx+QB9RlTTA==",
+			"version": "4.60.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.2.tgz",
+			"integrity": "sha512-Bcl6CYDeAgE70cqZaMojOi/eK63h5Me97ZqAQoh77VPjMysA/4ORQBRGo3rRy45x4MzVlU9uZxs8Uwy7ZaKnBw==",
 			"cpu": [
 				"arm64"
 			],
@@ -6268,9 +6377,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-freebsd-x64": {
-			"version": "4.59.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.59.0.tgz",
-			"integrity": "sha512-d3DuZi2KzTMjImrxoHIAODUZYoUUMsuUiY4SRRcJy6NJoZ6iIqWnJu9IScV9jXysyGMVuW+KNzZvBLOcpdl3Vg==",
+			"version": "4.60.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.2.tgz",
+			"integrity": "sha512-LU+TPda3mAE2QB0/Hp5VyeKJivpC6+tlOXd1VMoXV/YFMvk/MNk5iXeBfB4MQGRWyOYVJ01625vjkr0Az98OJQ==",
 			"cpu": [
 				"x64"
 			],
@@ -6282,9 +6391,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-			"version": "4.59.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.59.0.tgz",
-			"integrity": "sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==",
+			"version": "4.60.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.2.tgz",
+			"integrity": "sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==",
 			"cpu": [
 				"arm"
 			],
@@ -6296,9 +6405,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-arm-musleabihf": {
-			"version": "4.59.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.59.0.tgz",
-			"integrity": "sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==",
+			"version": "4.60.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.2.tgz",
+			"integrity": "sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==",
 			"cpu": [
 				"arm"
 			],
@@ -6309,10 +6418,38 @@
 				"linux"
 			]
 		},
+		"node_modules/@rollup/rollup-linux-arm64-gnu": {
+			"version": "4.60.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.2.tgz",
+			"integrity": "sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-arm64-musl": {
+			"version": "4.60.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.2.tgz",
+			"integrity": "sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
 		"node_modules/@rollup/rollup-linux-loong64-gnu": {
-			"version": "4.59.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.59.0.tgz",
-			"integrity": "sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==",
+			"version": "4.60.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.2.tgz",
+			"integrity": "sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==",
 			"cpu": [
 				"loong64"
 			],
@@ -6324,9 +6461,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-loong64-musl": {
-			"version": "4.59.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.59.0.tgz",
-			"integrity": "sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==",
+			"version": "4.60.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.2.tgz",
+			"integrity": "sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==",
 			"cpu": [
 				"loong64"
 			],
@@ -6338,9 +6475,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-ppc64-gnu": {
-			"version": "4.59.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.59.0.tgz",
-			"integrity": "sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==",
+			"version": "4.60.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.2.tgz",
+			"integrity": "sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==",
 			"cpu": [
 				"ppc64"
 			],
@@ -6352,9 +6489,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-ppc64-musl": {
-			"version": "4.59.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.59.0.tgz",
-			"integrity": "sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==",
+			"version": "4.60.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.2.tgz",
+			"integrity": "sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==",
 			"cpu": [
 				"ppc64"
 			],
@@ -6366,9 +6503,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-riscv64-gnu": {
-			"version": "4.59.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.59.0.tgz",
-			"integrity": "sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==",
+			"version": "4.60.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.2.tgz",
+			"integrity": "sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==",
 			"cpu": [
 				"riscv64"
 			],
@@ -6380,9 +6517,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-riscv64-musl": {
-			"version": "4.59.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.59.0.tgz",
-			"integrity": "sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==",
+			"version": "4.60.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.2.tgz",
+			"integrity": "sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==",
 			"cpu": [
 				"riscv64"
 			],
@@ -6394,9 +6531,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-s390x-gnu": {
-			"version": "4.59.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.59.0.tgz",
-			"integrity": "sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==",
+			"version": "4.60.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.2.tgz",
+			"integrity": "sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==",
 			"cpu": [
 				"s390x"
 			],
@@ -6407,10 +6544,38 @@
 				"linux"
 			]
 		},
+		"node_modules/@rollup/rollup-linux-x64-gnu": {
+			"version": "4.60.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.2.tgz",
+			"integrity": "sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-x64-musl": {
+			"version": "4.60.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.2.tgz",
+			"integrity": "sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
 		"node_modules/@rollup/rollup-openbsd-x64": {
-			"version": "4.59.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.59.0.tgz",
-			"integrity": "sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==",
+			"version": "4.60.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.2.tgz",
+			"integrity": "sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==",
 			"cpu": [
 				"x64"
 			],
@@ -6422,9 +6587,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-openharmony-arm64": {
-			"version": "4.59.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.59.0.tgz",
-			"integrity": "sha512-tt9KBJqaqp5i5HUZzoafHZX8b5Q2Fe7UjYERADll83O4fGqJ49O1FsL6LpdzVFQcpwvnyd0i+K/VSwu/o/nWlA==",
+			"version": "4.60.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.2.tgz",
+			"integrity": "sha512-NetAg5iO2uN7eB8zE5qrZ3CSil+7IJt4WDFLcC75Ymywq1VZVD6qJ6EvNLjZ3rEm6gB7XW5JdT60c6MN35Z85Q==",
 			"cpu": [
 				"arm64"
 			],
@@ -6435,10 +6600,24 @@
 				"openharmony"
 			]
 		},
+		"node_modules/@rollup/rollup-win32-arm64-msvc": {
+			"version": "4.60.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.2.tgz",
+			"integrity": "sha512-NCYhOotpgWZ5kdxCZsv6Iudx0wX8980Q/oW4pNFNihpBKsDbEA1zpkfxJGC0yugsUuyDZ7gL37dbzwhR0VI7pQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			]
+		},
 		"node_modules/@rollup/rollup-win32-ia32-msvc": {
-			"version": "4.59.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.59.0.tgz",
-			"integrity": "sha512-UKFMHPuM9R0iBegwzKF4y0C4J9u8C6MEJgFuXTBerMk7EJ92GFVFYBfOZaSGLu6COf7FxpQNqhNS4c4icUPqxA==",
+			"version": "4.60.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.2.tgz",
+			"integrity": "sha512-RXsaOqXxfoUBQoOgvmmijVxJnW2IGB0eoMO7F8FAjaj0UTywUO/luSqimWBJn04WNgUkeNhh7fs7pESXajWmkg==",
 			"cpu": [
 				"ia32"
 			],
@@ -6450,9 +6629,23 @@
 			]
 		},
 		"node_modules/@rollup/rollup-win32-x64-gnu": {
-			"version": "4.59.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.59.0.tgz",
-			"integrity": "sha512-laBkYlSS1n2L8fSo1thDNGrCTQMmxjYY5G0WFWjFFYZkKPjsMBsgJfGf4TLxXrF6RyhI60L8TMOjBMvXiTcxeA==",
+			"version": "4.60.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.2.tgz",
+			"integrity": "sha512-qdAzEULD+/hzObedtmV6iBpdL5TIbKVztGiK7O3/KYSf+HIzU257+MX1EXJcyIiDbMAqmbwaufcYPvyRryeZtA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			]
+		},
+		"node_modules/@rollup/rollup-win32-x64-msvc": {
+			"version": "4.60.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.2.tgz",
+			"integrity": "sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA==",
 			"cpu": [
 				"x64"
 			],
@@ -6509,9 +6702,9 @@
 			}
 		},
 		"node_modules/@sveltejs/acorn-typescript": {
-			"version": "1.0.8",
-			"resolved": "https://registry.npmjs.org/@sveltejs/acorn-typescript/-/acorn-typescript-1.0.8.tgz",
-			"integrity": "sha512-esgN+54+q0NjB0Y/4BomT9samII7jGwNy/2a3wNZbT2A2RpmXsXwUt24LvLhx6jUq2gVk4cWEvcRO6MFQbOfNA==",
+			"version": "1.0.9",
+			"resolved": "https://registry.npmjs.org/@sveltejs/acorn-typescript/-/acorn-typescript-1.0.9.tgz",
+			"integrity": "sha512-lVJX6qEgs/4DOcRTpo56tmKzVPtoWAaVbL4hfO7t7NVwl9AAXzQR6cihesW1BmNMPl+bK6dreu2sOKBP2Q9CIA==",
 			"dev": true,
 			"license": "MIT",
 			"peerDependencies": {
@@ -6983,39 +7176,39 @@
 			}
 		},
 		"node_modules/@traqula/algebra-sparql-1-1": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/@traqula/algebra-sparql-1-1/-/algebra-sparql-1-1-1.0.5.tgz",
-			"integrity": "sha512-U1WhxjyhNPrlGQrhoZGKOq8y3xDOkPxiS318i0Psa1te0TaMx0CDPuJ5Fc6kYaM0atM8Rjan0Sxhi4FjRdksuA==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@traqula/algebra-sparql-1-1/-/algebra-sparql-1-1-1.1.0.tgz",
+			"integrity": "sha512-vCruGGkUUnIDyB2XUbwtAU4lWiYGmJk7z6RRsXYkL0pKZBkrtJwTDj6m1GHJECOpuNi51Iw4TNPZDsfxG0OAWg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@traqula/algebra-transformations-1-1": "^1.0.5",
-				"@traqula/core": "^1.0.5",
-				"@traqula/rules-sparql-1-1": "^1.0.5"
+				"@traqula/algebra-transformations-1-1": "^1.1.0",
+				"@traqula/core": "^1.1.0",
+				"@traqula/rules-sparql-1-1": "^1.1.0"
 			}
 		},
 		"node_modules/@traqula/algebra-sparql-1-2": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/@traqula/algebra-sparql-1-2/-/algebra-sparql-1-2-1.0.5.tgz",
-			"integrity": "sha512-lZj6eIIgBi4j+IDDyURUlYTAlS5rG9SVFJicSrLdMrAKrgOvSsdDKtmsqigLvhkeFs6iiqQYi3qa7PaoGQDq8A==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@traqula/algebra-sparql-1-2/-/algebra-sparql-1-2-1.1.0.tgz",
+			"integrity": "sha512-jupP4QhEu2UQ8TTrxzqAkU3zn9/ptKqKtjS5WBqq+ErYvWIPhJsXxRAnd8fI7EiBDFMx78Wt+x3gRc7+sZHfvw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@traqula/algebra-sparql-1-1": "^1.0.5",
-				"@traqula/algebra-transformations-1-1": "^1.0.5",
-				"@traqula/algebra-transformations-1-2": "^1.0.5",
-				"@traqula/core": "^1.0.5"
+				"@traqula/algebra-sparql-1-1": "^1.1.0",
+				"@traqula/algebra-transformations-1-1": "^1.1.0",
+				"@traqula/algebra-transformations-1-2": "^1.1.0",
+				"@traqula/core": "^1.1.0"
 			}
 		},
 		"node_modules/@traqula/algebra-transformations-1-1": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/@traqula/algebra-transformations-1-1/-/algebra-transformations-1-1-1.0.5.tgz",
-			"integrity": "sha512-nqbPIO5t2g7Ii2I1U8TQu5q3z4nMZMUJQmkqXa1anN2Dg27EftaQD1jpcty8mH3M7uHVr6qHnJamvJ3dED2sYA==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@traqula/algebra-transformations-1-1/-/algebra-transformations-1-1-1.1.0.tgz",
+			"integrity": "sha512-1n7NFtvGBdBcGo1UnIsUW/i+wROnLlxG9A84uINkCw2BrtoAZ/nY+gSVPSCQ/rlyve/lZryjgVvcnwIxQ+OVKg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@traqula/core": "^1.0.5",
-				"@traqula/rules-sparql-1-1": "^1.0.5",
+				"@traqula/core": "^1.1.0",
+				"@traqula/rules-sparql-1-1": "^1.1.0",
 				"fast-deep-equal": "^3.1.3",
 				"rdf-data-factory": "^2.0.1",
 				"rdf-isomorphic": "^2.0.0",
@@ -7023,98 +7216,95 @@
 			}
 		},
 		"node_modules/@traqula/algebra-transformations-1-2": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/@traqula/algebra-transformations-1-2/-/algebra-transformations-1-2-1.0.5.tgz",
-			"integrity": "sha512-W4yBWLhUpxktJXiRqhazSxrws9tmQJ9C5tyHpYAVq3eUAvzc8Fnen03EkdGXf27o7CoSlhL+JLxicfOWcjX2kQ==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@traqula/algebra-transformations-1-2/-/algebra-transformations-1-2-1.1.0.tgz",
+			"integrity": "sha512-Qi19pcUvXUYHj8jO0CXiaJwpUH9F1q7p3fRROewqr7Zzm54BCz57v9mwwSCjiS2/M/73driG02w20N9zR120mg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@traqula/algebra-transformations-1-1": "^1.0.5",
-				"@traqula/rules-sparql-1-2": "^1.0.5",
+				"@traqula/algebra-transformations-1-1": "^1.1.0",
+				"@traqula/rules-sparql-1-2": "^1.1.0",
 				"rdf-string": "^2.0.0"
 			}
 		},
 		"node_modules/@traqula/chevrotain": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/@traqula/chevrotain/-/chevrotain-1.0.5.tgz",
-			"integrity": "sha512-W1wbQJBQ1o3f7aNknuVSZJ8BlECQoSaBXoGT5uion58mFGW2npakmvXpLYb6tYFz7XFLYaPe6pHn/jA3MHHvvw==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@traqula/chevrotain/-/chevrotain-1.1.0.tgz",
+			"integrity": "sha512-VpcoQKb2ZnsOQPlPO2mE9hfR0Aidp7drwTCtaXfpdRHGkXeQ5Nv4rnxmxwUoEDRzu6b/3z4n8oTd+sYhe4fAaA==",
 			"dev": true,
 			"license": "Apache-2.0",
-			"dependencies": {
-				"chevrotain": "^11.0.3"
-			},
 			"engines": {
 				"node": "^20.19.0 || >=22.12.0"
 			}
 		},
 		"node_modules/@traqula/core": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/@traqula/core/-/core-1.0.5.tgz",
-			"integrity": "sha512-mQ/kOKfKBsNwbVWua5o0wrHesZYM1bslZh6anYEcuCdoAOrlV7slzHIdaJl30wUziDbP2kikzu4VYTHHVNldrw==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@traqula/core/-/core-1.1.0.tgz",
+			"integrity": "sha512-PxK3P/Go7KjNpEaN/mXHAEiDWLxh3u5D6MfOTXI6Lz0eq9iRduUAXGnWnCuZ7VygxEHSSxpO0ZDYLPa4OIeBYQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@traqula/chevrotain": "^1.0.5"
+				"@traqula/chevrotain": "^1.1.0"
 			},
 			"engines": {
 				"node": "^20.19.0 || >=22.12.0"
 			}
 		},
 		"node_modules/@traqula/generator-sparql-1-1": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/@traqula/generator-sparql-1-1/-/generator-sparql-1-1-1.0.5.tgz",
-			"integrity": "sha512-11O6L0DfgHOkppycYFGx0CReLopVkVUwg9uBxZDsFw38Biycii5l1NJhAmH2olDG3YgaPTNMGOuAx47SN4sM7Q==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@traqula/generator-sparql-1-1/-/generator-sparql-1-1-1.1.0.tgz",
+			"integrity": "sha512-VcFqE/qOXKzPwYgqHscyTUKczhRCL2YucH1/S4iis6evlWFDcTQW79F9Xre+CdLF/K/Tsolk5k75jqzTq4Cvbg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@traqula/core": "^1.0.5",
-				"@traqula/rules-sparql-1-1": "^1.0.5"
+				"@traqula/core": "^1.1.0",
+				"@traqula/rules-sparql-1-1": "^1.1.0"
 			},
 			"engines": {
 				"node": "^20.19.0 || >=22.12.0"
 			}
 		},
 		"node_modules/@traqula/generator-sparql-1-2": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/@traqula/generator-sparql-1-2/-/generator-sparql-1-2-1.0.5.tgz",
-			"integrity": "sha512-1ud3rdfAb5wooQ8OJMcVOtXY/n6BByaqN0Jt2OuLvkFshri9ztlJyIjj6lQ2vXJRe51FynGjc2iSqERMEoKB4g==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@traqula/generator-sparql-1-2/-/generator-sparql-1-2-1.1.0.tgz",
+			"integrity": "sha512-rMUvGoCkvmK4qgKi31F8fB5sEYSPwJBpd4xKFkBj/C+toewSsFtv5VqievAD/vz/PyR/k1g2BPtUFjutdD9zPQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@traqula/core": "^1.0.5",
-				"@traqula/generator-sparql-1-1": "^1.0.5",
-				"@traqula/rules-sparql-1-1": "^1.0.5",
-				"@traqula/rules-sparql-1-2": "^1.0.5"
+				"@traqula/core": "^1.1.0",
+				"@traqula/generator-sparql-1-1": "^1.1.0",
+				"@traqula/rules-sparql-1-1": "^1.1.0",
+				"@traqula/rules-sparql-1-2": "^1.1.0"
 			},
 			"engines": {
 				"node": "^20.19.0 || >=22.12.0"
 			}
 		},
 		"node_modules/@traqula/parser-sparql-1-1": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/@traqula/parser-sparql-1-1/-/parser-sparql-1-1-1.0.5.tgz",
-			"integrity": "sha512-ed6M6UOr3lEGCRONUY0DlbRiYRioXSmDGJugn0BzmTuHMmBgdRn8QzTZ/OeP4vBxkmDqcyDnY8f+W3msc/Q24A==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@traqula/parser-sparql-1-1/-/parser-sparql-1-1-1.1.0.tgz",
+			"integrity": "sha512-HLWuQv/Z+0POkWPCocT7mEOtbQ4QT+G71w4YH/srelXdOXGhuchO+aPBkHausIKh2imWu0bz+flmj+ap0IQjDQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@traqula/core": "^1.0.5",
-				"@traqula/rules-sparql-1-1": "^1.0.5"
+				"@traqula/core": "^1.1.0",
+				"@traqula/rules-sparql-1-1": "^1.1.0"
 			},
 			"engines": {
 				"node": "^20.19.0 || >=22.12.0"
 			}
 		},
 		"node_modules/@traqula/parser-sparql-1-2": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/@traqula/parser-sparql-1-2/-/parser-sparql-1-2-1.0.5.tgz",
-			"integrity": "sha512-KxQxw7LWb09ETOz8PFw1uh/be4HP4IeUFsYqEPPTzdiCiAZJMReNVHtdo8l9m1t3v7kNHN3Zq98vPiurL2wDeg==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@traqula/parser-sparql-1-2/-/parser-sparql-1-2-1.1.0.tgz",
+			"integrity": "sha512-mb2NonXBSkbBmTbd7xj0p37z6F9nek8hhu2W5O9ftLeWMJEP+zLR1wfJ7KW8on/WIRh23sV0KeBwvxqNp64Dzg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@traqula/core": "^1.0.5",
-				"@traqula/parser-sparql-1-1": "^1.0.5",
-				"@traqula/rules-sparql-1-1": "^1.0.5",
-				"@traqula/rules-sparql-1-2": "^1.0.5",
+				"@traqula/core": "^1.1.0",
+				"@traqula/parser-sparql-1-1": "^1.1.0",
+				"@traqula/rules-sparql-1-1": "^1.1.0",
+				"@traqula/rules-sparql-1-2": "^1.1.0",
 				"rdf-data-factory": "^2.0.1"
 			},
 			"engines": {
@@ -7122,28 +7312,28 @@
 			}
 		},
 		"node_modules/@traqula/rules-sparql-1-1": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/@traqula/rules-sparql-1-1/-/rules-sparql-1-1-1.0.5.tgz",
-			"integrity": "sha512-h+w7elejjNFeW+bixrhr+zczBSkz7WRGVIMVAvFCJdVRiP+qIqRzDEAbRYXmkwkQpSorzPOiRTwhJcYT3bCBgg==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@traqula/rules-sparql-1-1/-/rules-sparql-1-1-1.1.0.tgz",
+			"integrity": "sha512-MKB2oBWKr1+vYxy6tROcNsHxlH5aM8FS9VvfyPKAkbRqKS/zgOMFIigJ0DGlfgfoIm3Hyn+NintFWfRRXiBaGw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@traqula/chevrotain": "^1.0.5",
-				"@traqula/core": "^1.0.5"
+				"@traqula/chevrotain": "^1.1.0",
+				"@traqula/core": "^1.1.0"
 			},
 			"engines": {
 				"node": "^20.19.0 || >=22.12.0"
 			}
 		},
 		"node_modules/@traqula/rules-sparql-1-2": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/@traqula/rules-sparql-1-2/-/rules-sparql-1-2-1.0.5.tgz",
-			"integrity": "sha512-izS88424SscXglQBDBkWvdqSPF4isR6K5WdykKflXXVJrtmh6ujcaxH+1KyxeDjNvLOfYNFhnozQmzdiGP93Ig==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@traqula/rules-sparql-1-2/-/rules-sparql-1-2-1.1.0.tgz",
+			"integrity": "sha512-vFTI8YhkNZw0JdyY+nj0lWwp1TnkfMYf/SM6jxXCM176A7j0qjkuVbFP5tKTC9hgj02VQWV9Edo/mKaVf8C/1A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@traqula/core": "^1.0.5",
-				"@traqula/rules-sparql-1-1": "^1.0.5"
+				"@traqula/core": "^1.1.0",
+				"@traqula/rules-sparql-1-1": "^1.1.0"
 			},
 			"engines": {
 				"node": "^20.19.0 || >=22.12.0"
@@ -7260,13 +7450,13 @@
 			}
 		},
 		"node_modules/@types/node": {
-			"version": "25.2.2",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-25.2.2.tgz",
-			"integrity": "sha512-BkmoP5/FhRYek5izySdkOneRyXYN35I860MFAGupTdebyE66uZaR+bXLHq8k4DirE5DwQi3NuhvRU1jqTVwUrQ==",
+			"version": "25.6.0",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
+			"integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"undici-types": "~7.16.0"
+				"undici-types": "~7.19.0"
 			}
 		},
 		"node_modules/@types/readable-stream": {
@@ -7648,16 +7838,16 @@
 			}
 		},
 		"node_modules/@ukic/fonts": {
-			"version": "3.2.11",
-			"resolved": "https://registry.npmjs.org/@ukic/fonts/-/fonts-3.2.11.tgz",
-			"integrity": "sha512-gajgaqJkSbs+wwKhGy5BMgT7nWM264C02oC9PlghJSn/y/vdqgdzkVOwuBDK8z7NMFdl0s1uUy7le/MFh8cKfw==",
+			"version": "3.2.12",
+			"resolved": "https://registry.npmjs.org/@ukic/fonts/-/fonts-3.2.12.tgz",
+			"integrity": "sha512-LLCK6qs+wfNgMSMkN8e+fe6ZCyyZLRlg7smNXUJOqqGTA/kakAihS73I8N8wtp5fRy3Op+Z9/Dp31bRe/RXaZg==",
 			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@ukic/web-components": {
-			"version": "3.24.0",
-			"resolved": "https://registry.npmjs.org/@ukic/web-components/-/web-components-3.24.0.tgz",
-			"integrity": "sha512-04MKV2qfJUtXkoDqPW7MefWmIpofgq8OINsVARIE4uF71oiWySmMwoAYk5E+8RISK0HH0YYAa3OQkRXX7TzirQ==",
+			"version": "3.25.0",
+			"resolved": "https://registry.npmjs.org/@ukic/web-components/-/web-components-3.25.0.tgz",
+			"integrity": "sha512-SuPepL39PMpUM2IRH3UGYK4544Ty3aykmqobo/MIwBrbZrH8F0kYZClWwdzj3lhywmH9kWP4tmbe3IJ/UY0KMA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -7827,9 +8017,9 @@
 			}
 		},
 		"node_modules/acorn": {
-			"version": "8.15.0",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
-			"integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+			"version": "8.16.0",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+			"integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
 			"dev": true,
 			"license": "MIT",
 			"bin": {
@@ -7850,9 +8040,9 @@
 			}
 		},
 		"node_modules/ajv": {
-			"version": "6.14.0",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
-			"integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
+			"version": "6.15.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+			"integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -8010,9 +8200,9 @@
 			}
 		},
 		"node_modules/axe-core": {
-			"version": "4.11.3",
-			"resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.3.tgz",
-			"integrity": "sha512-zBQouZixDTbo3jMGqHKyePxYxr1e5W8UdTmBQ7sNtaA9M2bE32daxxPLS/jojhKOHxQ7LWwPjfiwf/fhaJWzlg==",
+			"version": "4.11.4",
+			"resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.4.tgz",
+			"integrity": "sha512-KunSNx+TVpkAw/6ULfhnx+HWRecjqZGTOyquAoWHYLRSdK1tB5Ihce1ZW+UY3fj33bYAFWPu7W/GRSmmrCGuxA==",
 			"dev": true,
 			"license": "MPL-2.0",
 			"engines": {
@@ -8058,9 +8248,9 @@
 			"license": "MIT"
 		},
 		"node_modules/baseline-browser-mapping": {
-			"version": "2.10.23",
-			"resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.23.tgz",
-			"integrity": "sha512-xwVXGqevyKPsiuQdLj+dZMVjidjJV508TBqexND5HrF89cGdCYCJFB3qhcxRHSeMctdCfbR1jrxBajhDy7o29g==",
+			"version": "2.10.24",
+			"resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.24.tgz",
+			"integrity": "sha512-I2NkZOOrj2XuguvWCK6OVh9GavsNjZjK908Rq3mIBK25+GD8vPX5w2WdxVqnQ7xx3SrZJiCiZFu+/Oz50oSYSA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"bin": {
@@ -8071,19 +8261,16 @@
 			}
 		},
 		"node_modules/bignumber.js": {
-			"version": "9.3.1",
-			"resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
-			"integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+			"version": "10.0.2",
+			"resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-10.0.2.tgz",
+			"integrity": "sha512-E8Wp9O06QA6lneJ4aRUXKYf/1GIomqUEmUMwtIOMtDxf1U52ffJY+y7JBk/8wRafA8qOIqLnXQGqonYXZdBnFQ==",
 			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": "*"
-			}
+			"license": "MIT"
 		},
 		"node_modules/brace-expansion": {
-			"version": "1.1.13",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-			"integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+			"version": "1.1.14",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+			"integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -8213,21 +8400,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/chalk/chalk?sponsor=1"
-			}
-		},
-		"node_modules/chevrotain": {
-			"version": "11.2.0",
-			"resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-11.2.0.tgz",
-			"integrity": "sha512-mHCHTxM51nCklUw9RzRVc0DLjAh/SAUPM4k/zMInlTIo25ldWXOZoPt7XEIk/LwoT4lFVmJcu9g5MHtx371x3A==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@chevrotain/cst-dts-gen": "11.2.0",
-				"@chevrotain/gast": "11.2.0",
-				"@chevrotain/regexp-to-ast": "11.2.0",
-				"@chevrotain/types": "11.2.0",
-				"@chevrotain/utils": "11.2.0",
-				"lodash-es": "4.17.23"
 			}
 		},
 		"node_modules/chokidar": {
@@ -8484,9 +8656,9 @@
 			}
 		},
 		"node_modules/cytoscape": {
-			"version": "3.33.2",
-			"resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.33.2.tgz",
-			"integrity": "sha512-sj4HXd3DokGhzZAdjDejGvTPLqlt84vNFN8m7bGsOzDY5DyVcxIb2ejIXat2Iy7HxWhdT/N1oKyheJ5YdpsGuw==",
+			"version": "3.33.3",
+			"resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.33.3.tgz",
+			"integrity": "sha512-Gej7U+OKR+LZ8kvX7rb2HhCYJ0IhvEFsnkud4SB1PR+BUY/TsSO0dmOW59WEVLu51b1Rm+gQRKoz4bLYxGSZ2g==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -8549,9 +8721,9 @@
 			}
 		},
 		"node_modules/devalue": {
-			"version": "5.6.4",
-			"resolved": "https://registry.npmjs.org/devalue/-/devalue-5.6.4.tgz",
-			"integrity": "sha512-Gp6rDldRsFh/7XuouDbxMH3Mx8GMCcgzIb1pDTvNyn8pZGQ22u+Wa+lGV9dQCltFQ7uVw0MhRyb8XDskNFOReA==",
+			"version": "5.8.0",
+			"resolved": "https://registry.npmjs.org/devalue/-/devalue-5.8.0.tgz",
+			"integrity": "sha512-2zA9pFEsnp7vWBZbXF5JAgAq0fsUIt/1XPbRiAmRV3lp/2C3upzH+sADiyy66aFCihoLEsrQHxNM5w1gIDfsBg==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -8620,14 +8792,11 @@
 			}
 		},
 		"node_modules/dompurify": {
-			"version": "3.3.2",
-			"resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.2.tgz",
-			"integrity": "sha512-6obghkliLdmKa56xdbLOpUZ43pAR6xFy1uOrxBaIDjT+yaRuuybLjGS9eVBoSR/UPU5fq3OXClEHLJNGvbxKpQ==",
+			"version": "3.4.2",
+			"resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.2.tgz",
+			"integrity": "sha512-lHeS9SA/IKeIFFyYciHBr2n0v1VMPlSj843HdLOwjb2OxNwdq9Xykxqhk+FE42MzAdHvInbAolSE4mhahPpjXA==",
 			"dev": true,
 			"license": "(MPL-2.0 OR Apache-2.0)",
-			"engines": {
-				"node": ">=20"
-			},
 			"optionalDependencies": {
 				"@types/trusted-types": "^2.0.7"
 			}
@@ -8648,9 +8817,9 @@
 			}
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.5.344",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.344.tgz",
-			"integrity": "sha512-4MxfbmNDm+KPh066EZy+eUnkcDPcZ35wNmOWzFuh/ijvHsve6kbLTLURy88uCNK5FbpN+yk2nQY6BYh1GEt+wg==",
+			"version": "1.5.348",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.348.tgz",
+			"integrity": "sha512-QC2X59nRlycQQMc4ZXjSVBX+tSgJfgRtcrYHbIZLgOV2dCvefoQGegLR7lLXKgpPpSuVmJU19LMzGrSa2C7k3Q==",
 			"dev": true,
 			"license": "ISC"
 		},
@@ -8696,16 +8865,16 @@
 			}
 		},
 		"node_modules/es-module-lexer": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
-			"integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+			"integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
 			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/esbuild": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
-			"integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+			"integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
@@ -8716,32 +8885,32 @@
 				"node": ">=18"
 			},
 			"optionalDependencies": {
-				"@esbuild/aix-ppc64": "0.27.3",
-				"@esbuild/android-arm": "0.27.3",
-				"@esbuild/android-arm64": "0.27.3",
-				"@esbuild/android-x64": "0.27.3",
-				"@esbuild/darwin-arm64": "0.27.3",
-				"@esbuild/darwin-x64": "0.27.3",
-				"@esbuild/freebsd-arm64": "0.27.3",
-				"@esbuild/freebsd-x64": "0.27.3",
-				"@esbuild/linux-arm": "0.27.3",
-				"@esbuild/linux-arm64": "0.27.3",
-				"@esbuild/linux-ia32": "0.27.3",
-				"@esbuild/linux-loong64": "0.27.3",
-				"@esbuild/linux-mips64el": "0.27.3",
-				"@esbuild/linux-ppc64": "0.27.3",
-				"@esbuild/linux-riscv64": "0.27.3",
-				"@esbuild/linux-s390x": "0.27.3",
-				"@esbuild/linux-x64": "0.27.3",
-				"@esbuild/netbsd-arm64": "0.27.3",
-				"@esbuild/netbsd-x64": "0.27.3",
-				"@esbuild/openbsd-arm64": "0.27.3",
-				"@esbuild/openbsd-x64": "0.27.3",
-				"@esbuild/openharmony-arm64": "0.27.3",
-				"@esbuild/sunos-x64": "0.27.3",
-				"@esbuild/win32-arm64": "0.27.3",
-				"@esbuild/win32-ia32": "0.27.3",
-				"@esbuild/win32-x64": "0.27.3"
+				"@esbuild/aix-ppc64": "0.27.7",
+				"@esbuild/android-arm": "0.27.7",
+				"@esbuild/android-arm64": "0.27.7",
+				"@esbuild/android-x64": "0.27.7",
+				"@esbuild/darwin-arm64": "0.27.7",
+				"@esbuild/darwin-x64": "0.27.7",
+				"@esbuild/freebsd-arm64": "0.27.7",
+				"@esbuild/freebsd-x64": "0.27.7",
+				"@esbuild/linux-arm": "0.27.7",
+				"@esbuild/linux-arm64": "0.27.7",
+				"@esbuild/linux-ia32": "0.27.7",
+				"@esbuild/linux-loong64": "0.27.7",
+				"@esbuild/linux-mips64el": "0.27.7",
+				"@esbuild/linux-ppc64": "0.27.7",
+				"@esbuild/linux-riscv64": "0.27.7",
+				"@esbuild/linux-s390x": "0.27.7",
+				"@esbuild/linux-x64": "0.27.7",
+				"@esbuild/netbsd-arm64": "0.27.7",
+				"@esbuild/netbsd-x64": "0.27.7",
+				"@esbuild/openbsd-arm64": "0.27.7",
+				"@esbuild/openbsd-x64": "0.27.7",
+				"@esbuild/openharmony-arm64": "0.27.7",
+				"@esbuild/sunos-x64": "0.27.7",
+				"@esbuild/win32-arm64": "0.27.7",
+				"@esbuild/win32-ia32": "0.27.7",
+				"@esbuild/win32-x64": "0.27.7"
 			}
 		},
 		"node_modules/escalade": {
@@ -8990,14 +9159,21 @@
 			}
 		},
 		"node_modules/esrap": {
-			"version": "2.2.4",
-			"resolved": "https://registry.npmjs.org/esrap/-/esrap-2.2.4.tgz",
-			"integrity": "sha512-suICpxAmZ9A8bzJjEl/+rLJiDKC0X4gYWUxT6URAWBLvlXmtbZd5ySMu/N2ZGEtMCAmflUDPSehrP9BQcsGcSg==",
+			"version": "2.2.5",
+			"resolved": "https://registry.npmjs.org/esrap/-/esrap-2.2.5.tgz",
+			"integrity": "sha512-/yLB1538mag+dn0wsePTe8C0rDIjUOaJpMs2McodSzmM2msWcZsBSdRtg6HOBt0A/r82BN+Md3pgwSc/uWt2Ig==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@jridgewell/sourcemap-codec": "^1.4.15",
+				"@jridgewell/sourcemap-codec": "^1.4.15"
+			},
+			"peerDependencies": {
 				"@typescript-eslint/types": "^8.2.0"
+			},
+			"peerDependenciesMeta": {
+				"@typescript-eslint/types": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/esrecurse": {
@@ -9292,9 +9468,9 @@
 			"license": "ISC"
 		},
 		"node_modules/graphql": {
-			"version": "15.10.1",
-			"resolved": "https://registry.npmjs.org/graphql/-/graphql-15.10.1.tgz",
-			"integrity": "sha512-BL/Xd/T9baO6NFzoMpiMD7YUZ62R6viR5tp/MULVEnbYJXZA//kRNW7J0j1w/wXArgL0sCxhDfK5dczSKn3+cg==",
+			"version": "15.10.2",
+			"resolved": "https://registry.npmjs.org/graphql/-/graphql-15.10.2.tgz",
+			"integrity": "sha512-1PRqdDPAmViWr4h1GVBT8RoPZfWSGZa7kDzleTilOfVIslsgf+cia3Nl95v1KDmR4iERPaT7WzQ+tN4MJmbg3w==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -10169,13 +10345,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/lodash-es": {
-			"version": "4.17.23",
-			"resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.23.tgz",
-			"integrity": "sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/lodash.merge": {
 			"version": "4.6.2",
 			"resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -10202,9 +10371,9 @@
 			}
 		},
 		"node_modules/lru-cache": {
-			"version": "11.2.5",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.5.tgz",
-			"integrity": "sha512-vFrFJkWtJvJnD5hg+hJvVE8Lh/TcMzKnTgCWmtBipwI5yLX/iX+5UB2tfuyODF5E7k9xEzMdYgGqaSb1c0c5Yw==",
+			"version": "11.3.5",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
+			"integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
 			"dev": true,
 			"license": "BlueOak-1.0.0",
 			"engines": {
@@ -10391,9 +10560,9 @@
 			}
 		},
 		"node_modules/nanoid": {
-			"version": "3.3.11",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-			"integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+			"version": "3.3.12",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+			"integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
 			"dev": true,
 			"funding": [
 				{
@@ -10627,9 +10796,9 @@
 			}
 		},
 		"node_modules/postcss": {
-			"version": "8.5.12",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
-			"integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
+			"version": "8.5.13",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.13.tgz",
+			"integrity": "sha512-qif0+jGGZoLWdHey3UFHHWP0H7Gbmsk8T5VEqyYFbWqPr1XqvLGBbk/sl8V5exGmcYJklJOhOQq1pV9IcsiFag==",
 			"dev": true,
 			"funding": [
 				{
@@ -11697,9 +11866,9 @@
 			}
 		},
 		"node_modules/rdf-stores": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/rdf-stores/-/rdf-stores-2.1.1.tgz",
-			"integrity": "sha512-wYovM7q+12K+dV3AsPbBiAY63Dy1eoOBJ69XoL757Pqwimz2LLCrSwrjMyqc4AB+/wPgDwPeNiQA7IzD6zeAZg==",
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/rdf-stores/-/rdf-stores-2.2.0.tgz",
+			"integrity": "sha512-HEZblb6LQA+yiZrlO96HQeFRVjpEQUeCZ7rmCoN64bBQ6eHamKWPIh0vxMLe7h8a8AF23wbA3jpLG3pHRPk1mQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -11897,11 +12066,15 @@
 			}
 		},
 		"node_modules/relative-to-absolute-iri": {
-			"version": "1.0.7",
-			"resolved": "https://registry.npmjs.org/relative-to-absolute-iri/-/relative-to-absolute-iri-1.0.7.tgz",
-			"integrity": "sha512-Xjyl4HmIzg2jzK/Un2gELqbcE8Fxy85A/aLSHE6PE/3+OGsFwmKVA1vRyGaz6vLWSqLDMHA+5rjD/xbibSQN1Q==",
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/relative-to-absolute-iri/-/relative-to-absolute-iri-1.0.8.tgz",
+			"integrity": "sha512-U1TmhrhCmXKkDL9mI8gBbF5TN6TKcuv28k5+H3gMCAjoz0TyyHAICHlaGDZsTEBSu2Y3HhDKc8e6X9n33qeIqA==",
 			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"funding": {
+				"type": "individual",
+				"url": "https://github.com/sponsors/rubensworks/"
+			}
 		},
 		"node_modules/require-directory": {
 			"version": "2.1.1",
@@ -11924,9 +12097,9 @@
 			}
 		},
 		"node_modules/rollup": {
-			"version": "4.59.0",
-			"resolved": "https://registry.npmjs.org/rollup/-/rollup-4.59.0.tgz",
-			"integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
+			"version": "4.60.2",
+			"resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.2.tgz",
+			"integrity": "sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -11940,145 +12113,33 @@
 				"npm": ">=8.0.0"
 			},
 			"optionalDependencies": {
-				"@rollup/rollup-android-arm-eabi": "4.59.0",
-				"@rollup/rollup-android-arm64": "4.59.0",
-				"@rollup/rollup-darwin-arm64": "4.59.0",
-				"@rollup/rollup-darwin-x64": "4.59.0",
-				"@rollup/rollup-freebsd-arm64": "4.59.0",
-				"@rollup/rollup-freebsd-x64": "4.59.0",
-				"@rollup/rollup-linux-arm-gnueabihf": "4.59.0",
-				"@rollup/rollup-linux-arm-musleabihf": "4.59.0",
-				"@rollup/rollup-linux-arm64-gnu": "4.59.0",
-				"@rollup/rollup-linux-arm64-musl": "4.59.0",
-				"@rollup/rollup-linux-loong64-gnu": "4.59.0",
-				"@rollup/rollup-linux-loong64-musl": "4.59.0",
-				"@rollup/rollup-linux-ppc64-gnu": "4.59.0",
-				"@rollup/rollup-linux-ppc64-musl": "4.59.0",
-				"@rollup/rollup-linux-riscv64-gnu": "4.59.0",
-				"@rollup/rollup-linux-riscv64-musl": "4.59.0",
-				"@rollup/rollup-linux-s390x-gnu": "4.59.0",
-				"@rollup/rollup-linux-x64-gnu": "4.59.0",
-				"@rollup/rollup-linux-x64-musl": "4.59.0",
-				"@rollup/rollup-openbsd-x64": "4.59.0",
-				"@rollup/rollup-openharmony-arm64": "4.59.0",
-				"@rollup/rollup-win32-arm64-msvc": "4.59.0",
-				"@rollup/rollup-win32-ia32-msvc": "4.59.0",
-				"@rollup/rollup-win32-x64-gnu": "4.59.0",
-				"@rollup/rollup-win32-x64-msvc": "4.59.0",
+				"@rollup/rollup-android-arm-eabi": "4.60.2",
+				"@rollup/rollup-android-arm64": "4.60.2",
+				"@rollup/rollup-darwin-arm64": "4.60.2",
+				"@rollup/rollup-darwin-x64": "4.60.2",
+				"@rollup/rollup-freebsd-arm64": "4.60.2",
+				"@rollup/rollup-freebsd-x64": "4.60.2",
+				"@rollup/rollup-linux-arm-gnueabihf": "4.60.2",
+				"@rollup/rollup-linux-arm-musleabihf": "4.60.2",
+				"@rollup/rollup-linux-arm64-gnu": "4.60.2",
+				"@rollup/rollup-linux-arm64-musl": "4.60.2",
+				"@rollup/rollup-linux-loong64-gnu": "4.60.2",
+				"@rollup/rollup-linux-loong64-musl": "4.60.2",
+				"@rollup/rollup-linux-ppc64-gnu": "4.60.2",
+				"@rollup/rollup-linux-ppc64-musl": "4.60.2",
+				"@rollup/rollup-linux-riscv64-gnu": "4.60.2",
+				"@rollup/rollup-linux-riscv64-musl": "4.60.2",
+				"@rollup/rollup-linux-s390x-gnu": "4.60.2",
+				"@rollup/rollup-linux-x64-gnu": "4.60.2",
+				"@rollup/rollup-linux-x64-musl": "4.60.2",
+				"@rollup/rollup-openbsd-x64": "4.60.2",
+				"@rollup/rollup-openharmony-arm64": "4.60.2",
+				"@rollup/rollup-win32-arm64-msvc": "4.60.2",
+				"@rollup/rollup-win32-ia32-msvc": "4.60.2",
+				"@rollup/rollup-win32-x64-gnu": "4.60.2",
+				"@rollup/rollup-win32-x64-msvc": "4.60.2",
 				"fsevents": "~2.3.2"
 			}
-		},
-		"node_modules/rollup/node_modules/@rollup/rollup-darwin-arm64": {
-			"version": "4.59.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.59.0.tgz",
-			"integrity": "sha512-W2Psnbh1J8ZJw0xKAd8zdNgF9HRLkdWwwdWqubSVk0pUuQkoHnv7rx4GiF9rT4t5DIZGAsConRE3AxCdJ4m8rg==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"darwin"
-			]
-		},
-		"node_modules/rollup/node_modules/@rollup/rollup-darwin-x64": {
-			"version": "4.59.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.59.0.tgz",
-			"integrity": "sha512-ZW2KkwlS4lwTv7ZVsYDiARfFCnSGhzYPdiOU4IM2fDbL+QGlyAbjgSFuqNRbSthybLbIJ915UtZBtmuLrQAT/w==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"darwin"
-			]
-		},
-		"node_modules/rollup/node_modules/@rollup/rollup-linux-arm64-gnu": {
-			"version": "4.59.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.59.0.tgz",
-			"integrity": "sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			]
-		},
-		"node_modules/rollup/node_modules/@rollup/rollup-linux-arm64-musl": {
-			"version": "4.59.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.59.0.tgz",
-			"integrity": "sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			]
-		},
-		"node_modules/rollup/node_modules/@rollup/rollup-linux-x64-gnu": {
-			"version": "4.59.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.59.0.tgz",
-			"integrity": "sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			]
-		},
-		"node_modules/rollup/node_modules/@rollup/rollup-linux-x64-musl": {
-			"version": "4.59.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.59.0.tgz",
-			"integrity": "sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			]
-		},
-		"node_modules/rollup/node_modules/@rollup/rollup-win32-arm64-msvc": {
-			"version": "4.59.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.59.0.tgz",
-			"integrity": "sha512-V5B6mG7OrGTwnxaNUzZTDTjDS7F75PO1ae6MJYdiMu60sq0CqN5CVeVsbhPxalupvTX8gXVSU9gq+Rx1/hvu6A==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"win32"
-			]
-		},
-		"node_modules/rollup/node_modules/@rollup/rollup-win32-x64-msvc": {
-			"version": "4.59.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.59.0.tgz",
-			"integrity": "sha512-2HRCml6OztYXyJXAvdDXPKcawukWY2GpR5/nxKp4iBgiO3wcoEGkAaqctIbZcNB6KlUQBIqt8VYkNSj2397EfA==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"win32"
-			]
 		},
 		"node_modules/sade": {
 			"version": "1.8.1",
@@ -12138,9 +12199,9 @@
 			}
 		},
 		"node_modules/set-cookie-parser": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-3.0.1.tgz",
-			"integrity": "sha512-n7Z7dXZhJbwuAHhNzkTti6Aw9QDDjZtm3JTpTGATIdNzdQz5GuFs22w90BcvF4INfnrL5xrX3oGsuqO5Dx3A1Q==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-3.1.0.tgz",
+			"integrity": "sha512-kjnC1DXBHcxaOaOXBHBeRtltsDG2nUiUni+jP92M9gYdW12rsmx92UsfpH7o5tDRs7I1ZZPSQJQGv3UaRfCiuw==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -12264,9 +12325,10 @@
 			}
 		},
 		"node_modules/sparqljs": {
-			"version": "3.7.3",
-			"resolved": "https://registry.npmjs.org/sparqljs/-/sparqljs-3.7.3.tgz",
-			"integrity": "sha512-FQfHUhfwn5PD9WH6xPU7DhFfXMgqK/XoDrYDVxz/grhw66Il0OjRg3JBgwuEvwHnQt7oSTiKWEiCZCPNaUbqgg==",
+			"version": "3.7.4",
+			"resolved": "https://registry.npmjs.org/sparqljs/-/sparqljs-3.7.4.tgz",
+			"integrity": "sha512-hb4C84gf7KM7vz+iG595mPwvqxOvBJCm9L3dCxtV2zZDht6ZMmMG0tHeeqFeqwb9875yU9U4lhYe4LYRvWj0BQ==",
+			"deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -12427,9 +12489,9 @@
 			"license": "MIT"
 		},
 		"node_modules/std-env": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/std-env/-/std-env-4.0.0.tgz",
-			"integrity": "sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==",
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+			"integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -12556,9 +12618,9 @@
 			}
 		},
 		"node_modules/svelte-check": {
-			"version": "4.4.6",
-			"resolved": "https://registry.npmjs.org/svelte-check/-/svelte-check-4.4.6.tgz",
-			"integrity": "sha512-kP1zG81EWaFe9ZyTv4ZXv44Csi6Pkdpb7S3oj6m+K2ec/IcDg/a8LsFsnVLqm2nxtkSwsd5xPj/qFkTBgXHXjg==",
+			"version": "4.4.7",
+			"resolved": "https://registry.npmjs.org/svelte-check/-/svelte-check-4.4.7.tgz",
+			"integrity": "sha512-JRafFTRmaPUOqmri4u1WuIKgBLiHi6wIaB57i99pmHq5BAc3ioIpzdUN/RX32ij9GhI6ALMHKvnVxu68sFZlag==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -12580,9 +12642,9 @@
 			}
 		},
 		"node_modules/svelte-eslint-parser": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/svelte-eslint-parser/-/svelte-eslint-parser-1.4.1.tgz",
-			"integrity": "sha512-1eqkfQ93goAhjAXxZiu1SaKI9+0/sxp4JIWQwUpsz7ybehRE5L8dNuz7Iry7K22R47p5/+s9EM+38nHV2OlgXA==",
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/svelte-eslint-parser/-/svelte-eslint-parser-1.6.0.tgz",
+			"integrity": "sha512-qoB1ehychT6OxEtQAqc/guSqLS20SlA53Uijl7x375s8nlUT0lb9ol/gzraEEatQwsyPTJo87s2CmKL9Xab+Uw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -12591,11 +12653,12 @@
 				"espree": "^10.0.0",
 				"postcss": "^8.4.49",
 				"postcss-scss": "^4.0.9",
-				"postcss-selector-parser": "^7.0.0"
+				"postcss-selector-parser": "^7.0.0",
+				"semver": "^7.7.2"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0",
-				"pnpm": "10.24.0"
+				"pnpm": "10.30.3"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ota-meshi"
@@ -12678,9 +12741,9 @@
 			"license": "MIT"
 		},
 		"node_modules/tinyexec": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.2.tgz",
-			"integrity": "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==",
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.2.tgz",
+			"integrity": "sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -12688,14 +12751,14 @@
 			}
 		},
 		"node_modules/tinyglobby": {
-			"version": "0.2.15",
-			"resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
-			"integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+			"version": "0.2.16",
+			"resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+			"integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"fdir": "^6.5.0",
-				"picomatch": "^4.0.3"
+				"picomatch": "^4.0.4"
 			},
 			"engines": {
 				"node": ">=12.0.0"
@@ -12813,9 +12876,9 @@
 			}
 		},
 		"node_modules/undici": {
-			"version": "7.24.1",
-			"resolved": "https://registry.npmjs.org/undici/-/undici-7.24.1.tgz",
-			"integrity": "sha512-5xoBibbmnjlcR3jdqtY2Lnx7WbrD/tHlT01TmvqZUFVc9Q1w4+j5hbnapTqbcXITMH1ovjq/W7BkqBilHiVAaA==",
+			"version": "7.25.0",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
+			"integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -12823,9 +12886,9 @@
 			}
 		},
 		"node_modules/undici-types": {
-			"version": "7.16.0",
-			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
-			"integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+			"version": "7.19.2",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+			"integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -12884,9 +12947,9 @@
 			"license": "MIT"
 		},
 		"node_modules/uuid": {
-			"version": "13.0.0",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.0.tgz",
-			"integrity": "sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==",
+			"version": "13.0.1",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.1.tgz",
+			"integrity": "sha512-9ezox2roIft6ExBVTVqibSd5dc5/47Sw/uY6b4SjQUT2TzQ0tltNquWA46y4xPQmdZYqvnio22SgWd41M86+jw==",
 			"dev": true,
 			"funding": [
 				"https://github.com/sponsors/broofa",
@@ -12995,9 +13058,9 @@
 			}
 		},
 		"node_modules/vitefu": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/vitefu/-/vitefu-1.1.1.tgz",
-			"integrity": "sha512-B/Fegf3i8zh0yFbpzZ21amWzHmuNlLlmJT6n7bu5e+pCHUKQIfXSYokrqOBGEMMe9UG2sostKQF9mml/vYaWJQ==",
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/vitefu/-/vitefu-1.1.3.tgz",
+			"integrity": "sha512-ub4okH7Z5KLjb6hDyjqrGXqWtWvoYdU3IGm/NorpgHncKoLTCfRIbvlhBm7r0YstIaQRYlp4yEbFqDcKSzXSSg==",
 			"dev": true,
 			"license": "MIT",
 			"workspaces": [
@@ -13006,7 +13069,7 @@
 				"tests/projects/workspace/packages/*"
 			],
 			"peerDependencies": {
-				"vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0-beta.0"
+				"vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
 			},
 			"peerDependenciesMeta": {
 				"vite": {
@@ -13262,9 +13325,9 @@
 			}
 		},
 		"node_modules/ws": {
-			"version": "8.19.0",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
-			"integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+			"version": "8.20.0",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+			"integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {

--- a/package.json
+++ b/package.json
@@ -32,9 +32,9 @@
 	},
 	"devDependencies": {
 		"@axe-core/playwright": "^4.11.2",
-		"@comunica/query-sparql": "^5.1.3",
-		"@comunica/types": "^5.1.3",
-		"@comunica/utils-bindings-factory": "^5.1.3",
+		"@comunica/query-sparql": "^5.2.1",
+		"@comunica/types": "^5.2.0",
+		"@comunica/utils-bindings-factory": "^5.2.0",
 		"@playwright/test": "^1.59.1",
 		"@sveltejs/adapter-static": "^3.0.10",
 		"@sveltejs/kit": "^2.58.0",

--- a/src/lib/stores/logger.store.ts
+++ b/src/lib/stores/logger.store.ts
@@ -63,7 +63,18 @@ export const comunicaLogger: Logger = {
 	},
 	fatal: function (message: string, data?: LogEntryMetadata): void {
 		logger.addErrorMessage('Comunica', message, data);
-	}
+	},
+	// The functionality below introduced in comunica 5.2.1 is required by any logger that is
+	// passed to comunica and is basically a way of reducing console spam.
+	// https://github.com/comunica/comunica/blob/master/packages/types/lib/Logger.ts#L56
+	// It's stubbed out for now - we've wrapped the logger to use it elsewhere and our verison
+	// does not support this functionality (yet).
+	// @ts-expect-error see above
+	activeLogGroups: undefined,
+	repetitionCounter: 0,
+	groupedLogLimit: 5,
+	logGrouped: () => {},
+	flush: () => {}
 };
 
 export const recentLogs = derived(logger, ($logger) =>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -11,6 +11,9 @@ const pkg = JSON.parse(json);
 
 export default defineConfig({
 	plugins: [sveltekit(), svelteTesting(), tailwindcss()],
+	resolve: {
+		conditions: ['browser', 'import']
+	},
 	define: {
 		PUBLIC_VERSION: JSON.stringify(pkg.version)
 	},


### PR DESCRIPTION
The upgrade to [comunica@5.2.0](https://comunica.dev/blog/2026-04-14-release_5_2/) turned out to have a few breaking changes, which are addressed by this PR.

## Logger

This project has a logger that is used for "general logging" but also passed to comunica's engine so it can also write to the same logs. This has worked fine up to now because both loggers followed a fairly standard pattern , however comunica has now introduced a performance enhancement that expects the engine's logger to have a `flush` function among other things, which our logger doens't. These have been stubbed out for now (which means we don't get that functionality) - will revisit in the future.

## Vite and LRU-CACHE

We started getting a warning after upgrading:

```
app:Module "node:diagnostics_channel" has been externalized for browser compatibility. Cannot access "node:diagnostics_channel.channel" in client code. See https://vite.dev/guide/troubleshooting.html#module-externalized-for-browser-compatibility for more details.
```

Which eventually manifested as an error when we instantiated a Comunica engine. After a bit of research it turned out to be related to the [`lru-cache`](https://github.com/isaacs/node-lru-cache/) module, which has introduced conditional exports that were incompatible with the vite defaults, meaning some kind of node-specific functionality that was being picked up in the browser (almost certainly this was caused by [this commit](https://github.com/isaacs/node-lru-cache/commit/43b758355774d3213346af17850424c0ef7953b8) from a few weeks ago). Comunica's new release must've bumped this version and they've picked up the issue.

This was one of those **really nasty bugs** where the cause did not match the symptom, and how it manifests/the error it gives may differ depending on what the app is doing - bad news for anyone who misses the original warning. 

The fix was just to be a bit more explicit in the vite config (see PR).