### PR TITLE
chore: remove redundant Cytoscape types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,6 @@
 				"@testing-library/jest-dom": "^6.9.1",
 				"@testing-library/svelte": "^5.4.2",
 				"@testing-library/user-event": "^14.6.6",
-				"@types/cytoscape": "^3.31.0",
 				"@types/eslint": "^9.6.1",
 				"@ukic/fonts": "^3.2.16",
 				"@ukic/web-components": "^3.30.0",
@@ -7513,17 +7512,6 @@
 			"integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==",
 			"dev": true,
 			"license": "MIT"
-		},
-		"node_modules/@types/cytoscape": {
-			"version": "3.31.0",
-			"resolved": "https://registry.npmjs.org/@types/cytoscape/-/cytoscape-3.31.0.tgz",
-			"integrity": "sha512-EXHOHxqQjGxLDEh5cP4te6J0bi7LbCzmZkzsR6f703igUac8UGMdEohMyU3GHAayCTZrLQOMnaE/lqB2Ekh8Ww==",
-			"deprecated": "This is a stub types definition. cytoscape provides its own type definitions, so you do not need this installed.",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"cytoscape": "*"
-			}
 		},
 		"node_modules/@types/deep-eql": {
 			"version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
 		"@testing-library/jest-dom": "^6.9.1",
 		"@testing-library/svelte": "^5.4.2",
 		"@testing-library/user-event": "^14.6.6",
-		"@types/cytoscape": "^3.31.0",
 		"@types/eslint": "^9.6.1",
 		"@ukic/fonts": "^3.2.16",
 		"@ukic/web-components": "^3.30.0",


### PR DESCRIPTION
## Summary

Removes the deprecated `@types/cytoscape` development dependency. Cytoscape ships its own type definitions, so the stub package is redundant and produces a deprecation warning during install.

Fixes #214.

## Validation

- Clean `npm ci` no longer reports the `@types/cytoscape` deprecation warning
- `npm audit --audit-level=critical`
- `npm run check`
- `npm run copyright:check`
- `npm run lint`
- `npm run test:unit+component` on Node 24
- `npm run build`
- `git diff --check`
