### PR TITLE
chore: migrate SPARQL validation to Traqula

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
 				"@testing-library/jest-dom": "^6.9.1",
 				"@testing-library/svelte": "^5.4.2",
 				"@testing-library/user-event": "^14.6.6",
+				"@traqula/parser-sparql-1-2": "^1.2.1",
 				"@types/cytoscape": "^3.31.0",
 				"@types/eslint": "^9.6.1",
 				"@ukic/fonts": "^3.2.16",
@@ -7388,9 +7389,9 @@
 			}
 		},
 		"node_modules/@traqula/core": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/@traqula/core/-/core-1.1.4.tgz",
-			"integrity": "sha512-oSY1Ig2CDKoVflW87oaLvQuPYYbkknwLjIkGE1TsMpYYcbxUiVfN5KCqP2qhRIZPdLTjWUd07HxYhZ7K07ERDw==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@traqula/core/-/core-1.2.0.tgz",
+			"integrity": "sha512-4NEYjNKD31u1DMbccRNXBnpEQsoeVrTTrJfxbDU11/5zHQdcyrXYlJ7Dq2t3hlZgStMbVJrZbZJsr6p+lZBeZA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -7431,30 +7432,30 @@
 			}
 		},
 		"node_modules/@traqula/parser-sparql-1-1": {
-			"version": "1.1.8",
-			"resolved": "https://registry.npmjs.org/@traqula/parser-sparql-1-1/-/parser-sparql-1-1-1.1.8.tgz",
-			"integrity": "sha512-gvfX6BjGADxqU1pBUX453mk9+dnK5SOEnWRpT1WcMX53z1cE+qsja0Lk3XRAW7YcYP7OF5gHO9YtZrv/PWEA1A==",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@traqula/parser-sparql-1-1/-/parser-sparql-1-1-1.2.1.tgz",
+			"integrity": "sha512-z6t9pzGpScFqBnJcGAbCdh24EnxDpZjirobpJ1Y73Q17T1/qtb6L8T9DaEysX2e7i3O6qnbbiaOdLDKKte4PuA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@traqula/core": "^1.1.4",
-				"@traqula/rules-sparql-1-1": "^1.1.4"
+				"@traqula/core": "^1.2.0",
+				"@traqula/rules-sparql-1-1": "^1.2.1"
 			},
 			"engines": {
 				"node": "^20.19.0 || >=22.12.0"
 			}
 		},
 		"node_modules/@traqula/parser-sparql-1-2": {
-			"version": "1.1.8",
-			"resolved": "https://registry.npmjs.org/@traqula/parser-sparql-1-2/-/parser-sparql-1-2-1.1.8.tgz",
-			"integrity": "sha512-mmSzL34x6AIcVZruhhZaYUW+rn0+XSes/OPDYb2oHn8wnPIZRN6q2OAqV9QjGQMYWYP+3R3DX8eHOYJ2oRrjAw==",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@traqula/parser-sparql-1-2/-/parser-sparql-1-2-1.2.1.tgz",
+			"integrity": "sha512-tYt9gFY75fqd17nXQN3cS0viauaNykFXWbM0SWCQvNWrFPwvRk/eUxt7yvTM9IpujK2205FYO7uPTSZOjUTSVQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@traqula/core": "^1.1.4",
-				"@traqula/parser-sparql-1-1": "^1.1.8",
-				"@traqula/rules-sparql-1-1": "^1.1.4",
-				"@traqula/rules-sparql-1-2": "^1.1.6",
+				"@traqula/core": "^1.2.0",
+				"@traqula/parser-sparql-1-1": "^1.2.1",
+				"@traqula/rules-sparql-1-1": "^1.2.1",
+				"@traqula/rules-sparql-1-2": "^1.2.1",
 				"rdf-data-factory": "^2.0.1"
 			},
 			"engines": {
@@ -7462,28 +7463,28 @@
 			}
 		},
 		"node_modules/@traqula/rules-sparql-1-1": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/@traqula/rules-sparql-1-1/-/rules-sparql-1-1-1.1.4.tgz",
-			"integrity": "sha512-E/IbmR7PM50yLDHlWP19amsAf2X0+KBb8lYI8lRQH92/rhVCP7QYEhSZksJ75+w6jm/l+OQvmQKolCZaMF7JHA==",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@traqula/rules-sparql-1-1/-/rules-sparql-1-1-1.2.1.tgz",
+			"integrity": "sha512-rSf/Lck9taQgz5r/6Hds4uBDiL8UVbF05aT8Tv7no9NvqAbGfRA01nyzYTVU+p+JLMnbjfZWaS1ZPOSBnh00zg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@traqula/chevrotain": "^1.1.0",
-				"@traqula/core": "^1.1.4"
+				"@traqula/core": "^1.2.0"
 			},
 			"engines": {
 				"node": "^20.19.0 || >=22.12.0"
 			}
 		},
 		"node_modules/@traqula/rules-sparql-1-2": {
-			"version": "1.1.6",
-			"resolved": "https://registry.npmjs.org/@traqula/rules-sparql-1-2/-/rules-sparql-1-2-1.1.6.tgz",
-			"integrity": "sha512-oAvTdBly6g/4yOywpwLeU2v2LjmJsquxMaDr+3vhHwbk2a62EhJQiP1zyuhdnTmO6Kzap3QV8Phds2YXi9bExQ==",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@traqula/rules-sparql-1-2/-/rules-sparql-1-2-1.2.1.tgz",
+			"integrity": "sha512-4RlakXIDca0shH1rRJyZyjHooTSJVK6kWgoX1hKj8x0NHTQaIBV0JDTnHlQh5u9TsF9uMcuKwqUoutIqkBxEIA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@traqula/core": "^1.1.4",
-				"@traqula/rules-sparql-1-1": "^1.1.4"
+				"@traqula/core": "^1.2.0",
+				"@traqula/rules-sparql-1-1": "^1.2.1"
 			},
 			"engines": {
 				"node": "^20.19.0 || >=22.12.0"

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
 		"@testing-library/jest-dom": "^6.9.1",
 		"@testing-library/svelte": "^5.4.2",
 		"@testing-library/user-event": "^14.6.6",
+		"@traqula/parser-sparql-1-2": "^1.2.1",
 		"@types/cytoscape": "^3.31.0",
 		"@types/eslint": "^9.6.1",
 		"@ukic/fonts": "^3.2.16",

--- a/src/lib/querying/sparqlUtils.test.ts
+++ b/src/lib/querying/sparqlUtils.test.ts
@@ -10,6 +10,12 @@ describe('validateSparql', () => {
 			expect(() => validateSparql(sparqlQuery)).not.toThrowError();
 		});
 	});
+	describe('when given a SPARQL-star query', () => {
+		it('does not throw an error', () => {
+			const query = 'SELECT * WHERE { << ?s ?p ?o >> ?q ?r }';
+			expect(() => validateSparql(query)).not.toThrowError();
+		});
+	});
 	describe('when given an invalid sparql query', () => {
 		it('throws an error', () => {
 			const query = 'I am a totally invalid sparql query';

--- a/src/lib/querying/sparqlUtils.ts
+++ b/src/lib/querying/sparqlUtils.ts
@@ -1,6 +1,6 @@
 /* (c) Crown Copyright GCHQ */
 
-import { Parser as SparqlParser, type SparqlQuery } from 'sparqljs';
+import { Parser as SparqlParser } from '@traqula/parser-sparql-1-2';
 
 /**
  * Takes a string, returns a parsed object. We never use this function outside of this file,
@@ -8,10 +8,9 @@ import { Parser as SparqlParser, type SparqlQuery } from 'sparqljs';
  * valid.
  *
  * @param {string} sparqlQuery
- * @returns SparqlQuery (sparqljs instance)
  */
-function parseSparql(sparqlQuery: string): SparqlQuery {
-	const parser = new SparqlParser({ sparqlStar: true });
+function parseSparql(sparqlQuery: string) {
+	const parser = new SparqlParser();
 	return parser.parse(sparqlQuery);
 }
 


### PR DESCRIPTION
## Summary

Migrates LD Explorer's SPARQL syntax validation from deprecated SPARQLjs to Traqula.

The validation path does not consume the parser AST, so this follows Traqula's documented drop-in migration path for validation-only use. `@traqula/parser-sparql-1-2` is used rather than the 1.1 parser to preserve the existing SPARQL-star support that LD Explorer enabled via `sparqlStar: true`.

SPARQLjs still exists transitively inside Comunica via `sparqlalgebrajs`; this change removes LD Explorer's direct import and reliance on it.

Fixes #210.

## Validation

- Added regression coverage for ordinary SPARQL and SPARQL-star syntax
- `npm audit --audit-level=critical`
- `npm run check`
- `npm run copyright:check`
- `npm run lint`
- `npm run test:unit+component` on Node 24 — 73 files / 268 tests passed
- `npm run build`
- `git diff --check`
