### PR TITLE
Handle query promise rejections in the results store

### DIFF
--- a/src/lib/stores/streamedQuery.store.errors.test.ts
+++ b/src/lib/stores/streamedQuery.store.errors.test.ts
@@ -1,0 +1,55 @@
+/* (c) Crown Copyright GCHQ */
+
+import { get } from 'svelte/store';
+import { createEngine } from '$lib/querying/engine';
+import { QueryStatus } from '$lib/types';
+import { logger } from '$stores/logger.store';
+import { createQueryStore } from './streamedQuery.store';
+import type { QuerySources } from './sources/sources.store';
+
+vi.mock('$lib/querying/engine', () => ({ createEngine: vi.fn() }));
+
+const query = 'ASK { ?s ?p ?o }';
+const sources: QuerySources = ['https://example.com/data.ttl'];
+const error = new Error('Query failed');
+const queryEngine = { query: vi.fn() };
+
+beforeEach(() => {
+	vi.resetAllMocks();
+	vi.mocked(createEngine).mockResolvedValue(
+		queryEngine as unknown as Awaited<ReturnType<typeof createEngine>>
+	);
+	vi.spyOn(logger, 'addError').mockImplementation(() => undefined);
+});
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+async function expectQueryFailure() {
+	const store = createQueryStore(query, sources);
+	await vi.waitFor(() => expect(get(store).status).toBe(QueryStatus.Error));
+	expect(get(store).results).toEqual([]);
+	expect(logger.addError).toHaveBeenCalledWith('Query', error, {
+		sparqlQuery: query,
+		sourceCount: '1'
+	});
+}
+
+it('reports engine initialisation failures', async () => {
+	vi.mocked(createEngine).mockRejectedValue(error);
+	await expectQueryFailure();
+});
+
+it('reports query planning failures', async () => {
+	queryEngine.query.mockRejectedValue(error);
+	await expectQueryFailure();
+});
+
+it.each(['bindings', 'quads', 'boolean'])('reports %s execution failures', async (resultType) => {
+	queryEngine.query.mockResolvedValue({
+		resultType,
+		execute: vi.fn().mockRejectedValue(error)
+	});
+	await expectQueryFailure();
+});

--- a/src/lib/stores/streamedQuery.store.test.ts
+++ b/src/lib/stores/streamedQuery.store.test.ts
@@ -59,6 +59,20 @@ describe(createQueryStore, () => {
 	});
 
 	describe('when running any query', () => {
+		it('reports malformed SPARQL instead of leaving the query initialised', async () => {
+			const addError = vi.spyOn(logger, 'addError').mockImplementation(() => undefined);
+			try {
+				const queryStore = createQueryStore('SELECT WHERE {', get(sourceList));
+				await vi.waitFor(() => expect(get(queryStore).status).toBe(QueryStatus.Error));
+				expect(addError).toHaveBeenCalledWith('Query', expect.any(Error), {
+					sparqlQuery: 'SELECT WHERE {',
+					sourceCount: '1'
+				});
+			} finally {
+				addError.mockRestore();
+			}
+		});
+
 		it('Starts off with a status of initialized', () => {
 			const queryStore = createQueryStore('SELECT * WHERE { ?s ?p ?o } LIMIT 100', get(sourceList));
 			expect(get(queryStore).status).toEqual(QueryStatus.Initialized);

--- a/src/lib/stores/streamedQuery.store.ts
+++ b/src/lib/stores/streamedQuery.store.ts
@@ -93,14 +93,14 @@ export function createQueryStore(sparqlQuery: string, sources: QuerySources): St
 				// quads are the result of CONSTRUCT or DESCRIBE queries.
 				queryStream = (await result.execute()) as unknown as QuadsStream;
 				break;
-			case 'boolean':
+			case 'boolean': {
 				// booleans are the result of ASK queries
-				result.execute().then((booleanResult) => {
-					update((current) => ({ ...current, results: [booleanResult], status: QueryStatus.Done }));
-				});
+				const booleanResult = await result.execute();
+				update((current) => ({ ...current, results: [booleanResult], status: QueryStatus.Done }));
 				// Boolean results are not "streamed" like the other two, so we don't need to proceed once
 				// we have this result, we can just return.
 				return;
+			}
 			default:
 				update((current) => ({ ...current, status: QueryStatus.Error }));
 
@@ -149,7 +149,13 @@ export function createQueryStore(sparqlQuery: string, sources: QuerySources): St
 				});
 			});
 		}
-	})();
+	})().catch((error: unknown) => {
+		update((current) => ({ ...current, status: QueryStatus.Error }));
+		logger.addError('Query', error instanceof Error ? error : new Error(String(error)), {
+			sparqlQuery,
+			sourceCount: sources.length.toString()
+		});
+	});
 
 	return {
 		subscribe,


### PR DESCRIPTION
## Summary
Fixes #257.

Handle promise rejections during engine initialisation, query planning, and result execution. Await ASK execution in the same task so its failures also reach the existing query logger and set the store to `Error`.

## Validation
- Six new regression cases: a malformed query against the real Comunica engine, plus initialisation, planning, bindings, quads, and boolean failures. All failed on the original code.
- **276 unit/component tests passed** across 74 files, with coverage enabled.
- ESLint, Svelte/TypeScript checks, and production build passed.

Browser end-to-end tests were not run locally. GitHub Actions has since passed the build, unit/component tests, and end-to-end tests.
