### PR TITLE
Prevent stopped queries from resuming

### DIFF
--- a/src/lib/stores/streamedQuery.store.lifecycle.test.ts
+++ b/src/lib/stores/streamedQuery.store.lifecycle.test.ts
@@ -1,0 +1,159 @@
+/* (c) Crown Copyright GCHQ */
+
+import { ArrayIterator } from 'asynciterator';
+import { get } from 'svelte/store';
+import { createEngine } from '$lib/querying/engine';
+import { QueryStatus } from '$lib/types';
+import { logger } from '$stores/logger.store';
+import { createQueryStore } from './streamedQuery.store';
+import type { QuerySources } from './sources/sources.store';
+
+vi.mock('$lib/querying/engine', () => ({ createEngine: vi.fn() }));
+
+const query = 'SELECT * WHERE { ?s ?p ?o }';
+const sources: QuerySources = ['https://example.com/data.ttl'];
+const engine = { query: vi.fn() };
+const execute = vi.fn();
+let subscriptions: (() => void)[];
+
+function deferred<T>() {
+	let resolve!: (value: T) => void;
+	let reject!: (reason: unknown) => void;
+	const promise = new Promise<T>((res, rej) => {
+		resolve = res;
+		reject = rej;
+	});
+	return { promise, resolve, reject };
+}
+
+function watch() {
+	const store = createQueryStore(query, sources);
+	const unsubscribe = store.subscribe(() => undefined);
+	subscriptions.push(unsubscribe);
+	return { store, unsubscribe };
+}
+
+async function flush() {
+	// Drain the engine, planning and execution continuations deterministically.
+	for (let i = 0; i < 10; i++) await Promise.resolve();
+}
+
+beforeEach(() => {
+	subscriptions = [];
+	vi.resetAllMocks();
+	vi.mocked(createEngine).mockResolvedValue(
+		engine as unknown as Awaited<ReturnType<typeof createEngine>>
+	);
+	engine.query.mockResolvedValue({ resultType: 'bindings', execute });
+	vi.spyOn(logger, 'addError').mockImplementation(() => undefined);
+});
+
+afterEach(() => {
+	subscriptions.forEach((unsubscribe) => unsubscribe());
+	vi.restoreAllMocks();
+});
+
+it('does not plan a query stopped while the engine loads', async () => {
+	const pending = deferred<Awaited<ReturnType<typeof createEngine>>>();
+	vi.mocked(createEngine).mockReturnValue(pending.promise);
+	const { store } = watch();
+	store.stop();
+	pending.resolve(engine as unknown as Awaited<ReturnType<typeof createEngine>>);
+	await flush();
+	expect(engine.query).not.toHaveBeenCalled();
+	expect(get(store).status).toBe(QueryStatus.Halted);
+});
+
+it('aborts pending HTTP work and does not execute a stopped query plan', async () => {
+	const pending = deferred<{ resultType: string; execute: typeof execute }>();
+	engine.query.mockReturnValue(pending.promise);
+	const { store } = watch();
+	await flush();
+	const context = engine.query.mock.calls[0][1];
+	store.stop();
+	pending.resolve({ resultType: 'bindings', execute });
+	await flush();
+	expect(context.httpAbortSignal?.aborted).toBe(true);
+	expect(execute).not.toHaveBeenCalled();
+	expect(get(store).status).toBe(QueryStatus.Halted);
+});
+
+it('does not execute after a subscriber stops the Fetching transition', async () => {
+	const { store } = watch();
+	subscriptions.push(
+		store.subscribe((value) => {
+			if (value.status === QueryStatus.Fetching) store.stop();
+		})
+	);
+	await flush();
+	expect(execute).not.toHaveBeenCalled();
+	expect(get(store).status).toBe(QueryStatus.Halted);
+});
+
+it.each(['bindings', 'quads'])(
+	'destroys a late %s stream without consuming it',
+	async (resultType) => {
+		const pending = deferred<ArrayIterator<never>>();
+		execute.mockReturnValue(pending.promise);
+		engine.query.mockResolvedValue({ resultType, execute });
+		const { store } = watch();
+		await flush();
+		expect(execute).toHaveBeenCalledOnce();
+		store.stop();
+		const stream = new ArrayIterator<never>([], { autoStart: false });
+		const destroy = vi.spyOn(stream, 'destroy');
+		pending.resolve(stream);
+		await flush();
+		expect(destroy).toHaveBeenCalledOnce();
+		expect(get(store).status).toBe(QueryStatus.Halted);
+		expect(get(store).results).toEqual([]);
+	}
+);
+
+it('ignores a boolean result that resolves after stopping', async () => {
+	const pending = deferred<boolean>();
+	execute.mockReturnValue(pending.promise);
+	engine.query.mockResolvedValue({ resultType: 'boolean', execute });
+	const { store } = watch();
+	await flush();
+	store.stop();
+	pending.resolve(true);
+	await flush();
+	expect(get(store).status).toBe(QueryStatus.Halted);
+	expect(get(store).results).toEqual([]);
+});
+
+it.each(['engine', 'planning', 'execution'])(
+	'ignores late %s rejection after stopping',
+	async (stage) => {
+		const pending = deferred<never>();
+		if (stage === 'engine') vi.mocked(createEngine).mockReturnValue(pending.promise);
+		else if (stage === 'planning') engine.query.mockReturnValue(pending.promise);
+		else execute.mockReturnValue(pending.promise);
+		const { store } = watch();
+		await flush();
+		store.stop();
+		pending.reject(new Error('Cancelled query'));
+		await flush();
+		expect(get(store).status).toBe(QueryStatus.Halted);
+		expect(logger.addError).not.toHaveBeenCalled();
+	}
+);
+
+it('discards buffered results when stopped from a data notification', async () => {
+	const stream = new ArrayIterator([true, false, true]);
+	const destroy = vi.spyOn(stream, 'destroy');
+	execute.mockResolvedValue(stream);
+	const { store } = watch();
+	subscriptions.push(
+		store.subscribe((value) => {
+			if (value.status === QueryStatus.Fetching && value.results.length === 1) store.stop();
+		})
+	);
+	await vi.waitFor(() => expect(get(store).status).toBe(QueryStatus.Halted));
+	await new Promise((resolve) => setTimeout(resolve, 0));
+	expect(get(store).results).toEqual([true]);
+	expect(destroy).toHaveBeenCalledOnce();
+	store.stop();
+	expect(destroy).toHaveBeenCalledOnce();
+});

--- a/src/lib/stores/streamedQuery.store.ts
+++ b/src/lib/stores/streamedQuery.store.ts
@@ -48,6 +48,8 @@ function isBindings(r: QueryResult): r is Bindings {
 
 export function createQueryStore(sparqlQuery: string, sources: QuerySources): StreamedQueryStore {
 	let queryStream: QueryStream | undefined = undefined;
+	let stopped = false;
+	const abortController = new AbortController();
 
 	const { subscribe, update } = writable<StreamedQuery>(
 		{
@@ -56,13 +58,20 @@ export function createQueryStore(sparqlQuery: string, sources: QuerySources): St
 			results: [],
 			variables: new Set()
 		},
-		() => {
-			return () => {
-				// Close down the binding stream when nobody subscribe end
-				if (queryStream) queryStream.close();
-			};
-		}
+		() => () => queryStream?.destroy()
 	);
+
+	function stop() {
+		if (stopped) return;
+		stopped = true;
+		update((current) =>
+			current.status === QueryStatus.Initialized || current.status === QueryStatus.Fetching
+				? { ...current, status: QueryStatus.Halted }
+				: current
+		);
+		abortController.abort();
+		queryStream?.destroy();
+	}
 
 	(async function () {
 		// User is attempting to run a query before they've added any data sources - abort
@@ -72,15 +81,20 @@ export function createQueryStore(sparqlQuery: string, sources: QuerySources): St
 		}
 
 		const engine = await createEngine();
+		if (stopped) return;
 		const result = await engine.query(sparqlQuery, {
 			sources,
 			readonly: true,
 			lenient: true,
-			log: comunicaLogger
+			log: comunicaLogger,
+			httpAbortSignal: abortController.signal
 		});
+
+		if (stopped) return;
 
 		// The engine will now have established the type of query, so we can update this
 		update((current) => ({ ...current, type: result.resultType, status: QueryStatus.Fetching }));
+		if (stopped) return;
 
 		// Comunica engines can return one of three types of result based on the SPARQL query that
 		// was run: bindings, quads or booleans.
@@ -96,6 +110,7 @@ export function createQueryStore(sparqlQuery: string, sources: QuerySources): St
 			case 'boolean': {
 				// booleans are the result of ASK queries
 				const booleanResult = await result.execute();
+				if (stopped) return;
 				update((current) => ({ ...current, results: [booleanResult], status: QueryStatus.Done }));
 				// Boolean results are not "streamed" like the other two, so we don't need to proceed once
 				// we have this result, we can just return.
@@ -114,8 +129,13 @@ export function createQueryStore(sparqlQuery: string, sources: QuerySources): St
 		// Note that ASK queries (which return a single boolean) will not be streamed, so this part
 		// will only run for bindings or quad streams.
 		if (queryStream) {
+			if (stopped) {
+				queryStream.destroy();
+				return;
+			}
 			// emitted when stream receives data
 			queryStream.on('data', (r: QueryResult) => {
+				if (stopped) return;
 				update((current) => ({
 					...current,
 					results: [...current.results, r],
@@ -142,6 +162,7 @@ export function createQueryStore(sparqlQuery: string, sources: QuerySources): St
 			});
 			// emitted when stream receives an error
 			queryStream.on('error', (error: Error) => {
+				if (stopped) return;
 				update((current) => ({ ...current, status: QueryStatus.Error }));
 				logger.addError('Query', error, {
 					sparqlQuery,
@@ -150,6 +171,7 @@ export function createQueryStore(sparqlQuery: string, sources: QuerySources): St
 			});
 		}
 	})().catch((error: unknown) => {
+		if (stopped) return;
 		update((current) => ({ ...current, status: QueryStatus.Error }));
 		logger.addError('Query', error instanceof Error ? error : new Error(String(error)), {
 			sparqlQuery,
@@ -159,9 +181,6 @@ export function createQueryStore(sparqlQuery: string, sources: QuerySources): St
 
 	return {
 		subscribe,
-		stop() {
-			if (queryStream) queryStream.close();
-			update((current) => ({ ...current, status: QueryStatus.Halted }));
-		}
+		stop
 	};
 }


### PR DESCRIPTION
Fixes #259.

Make query cancellation permanent across asynchronous engine, planning and execution boundaries. Pass an abort signal into Comunica, destroy late or buffered streams, and ignore results or errors that arrive after a query is halted.

Validation:
- 286 unit/component tests passed.
- `npm run check`, `npm run lint`, `npm run copyright:check` and `npm run build` passed.
