### PR TITLE
Fix issue with dollar in IRI search

### DIFF
--- a/e2e/fixtures/pageFixtures.ts
+++ b/e2e/fixtures/pageFixtures.ts
@@ -11,6 +11,8 @@ import AddRemoteDataSourcePage from '$e2e/pages/data-sources/AddRemoteDataSource
 import ExploreClassesPage from '$e2e/pages/explore/ExploreClassesPage';
 import ExploreIndividualsPage from '$e2e/pages/explore/ExploreIndividualsPage';
 import ExploreTriplesPage from '$e2e/pages/explore/ExploreTriplesPage';
+import ExploreIRISearchPage from '$e2e/pages/explore/ExploreIRISearchPage';
+import ExploreIRIDetailPage from '$e2e/pages/explore/ExploreIRIDetailPage';
 import GeneralSettingsPage from '$e2e/pages/settings/GeneralSettingsPage';
 import LogsPage from '$e2e/pages/LogsPage';
 import ImportToLocalDataSourcePage from '$e2e/pages/data-sources/ImportToLocalDataSourcePage';
@@ -30,6 +32,8 @@ const pages = {
 	exploreClassesPage: ExploreClassesPage,
 	exploreIndividualsPage: ExploreIndividualsPage,
 	exploreTriplesPage: ExploreTriplesPage,
+	exploreIriSearchPage: ExploreIRISearchPage,
+	exploreIriDetailPage: ExploreIRIDetailPage,
 	generalSettingsPage: GeneralSettingsPage
 };
 

--- a/e2e/pages/explore/ExploreIRIDetailPage.ts
+++ b/e2e/pages/explore/ExploreIRIDetailPage.ts
@@ -1,0 +1,15 @@
+/* (c) Crown Copyright GCHQ */
+
+import { QuadsViewPage } from '../BasePages';
+
+export default class ExploreIRISearchPage extends QuadsViewPage {
+	readonly baseUrl = '/explore/iris/detail';
+
+	async goto() {
+		await this.page.goto(this.baseUrl);
+	}
+
+	async navigateTo() {
+		throw new Error('Not Implemented');
+	}
+}

--- a/e2e/pages/explore/ExploreIRISearchPage.ts
+++ b/e2e/pages/explore/ExploreIRISearchPage.ts
@@ -1,0 +1,33 @@
+/* (c) Crown Copyright GCHQ */
+
+import { Locator, Page } from '@playwright/test';
+import { QuadsViewPage } from '../BasePages';
+import { navigateTo } from '$e2e/helpers/navigation';
+
+export default class ExploreIRISearchPage extends QuadsViewPage {
+	readonly baseUrl = '/explore/iris';
+	private readonly iriInput: Locator;
+	private readonly submitButton: Locator;
+
+	constructor(public readonly page: Page) {
+		super(page);
+		this.iriInput = page.getByLabel('IRI');
+		this.submitButton = page.getByRole('button', { name: 'Submit' });
+	}
+
+	async goto() {
+		await this.page.goto(this.baseUrl);
+	}
+
+	async navigateTo() {
+		await navigateTo(this.page, /Explore$/, /IRI Search$/);
+	}
+
+	async fillIriValue(iri: string) {
+		await this.iriInput.fill(iri);
+	}
+
+	async clickSubmit() {
+		await this.submitButton.click();
+	}
+}

--- a/e2e/tests/features/explore-pages/explore-search-iri.test.ts
+++ b/e2e/tests/features/explore-pages/explore-search-iri.test.ts
@@ -1,0 +1,32 @@
+/* (c) Crown Copyright GCHQ */
+
+import { expect, test } from '$e2e/test';
+
+/**
+ * Tests relating to any "bindings" views, such as the "Explore classes" page.
+ */
+test.describe('Explore Search IRI page tests', () => {
+	test.beforeEach(({ page }) => page.goto('/'));
+
+	test('has the right headings', async ({ exploreIriSearchPage }) => {
+		await exploreIriSearchPage.navigateTo();
+		await expect(exploreIriSearchPage.mainHeading.getByText('IRI Search')).toBeVisible();
+	});
+
+	test('allows you to search for a specific IRI', async ({
+		page,
+		exploreIriSearchPage,
+		exploreIriDetailPage
+	}) => {
+		await exploreIriSearchPage.navigateTo();
+
+		const exampleIri = 'http://www.example.com/my-iri';
+		await exploreIriSearchPage.fillIriValue(exampleIri);
+		await exploreIriSearchPage.clickSubmit();
+
+		// Navigates us to that IRI's describe page
+		await expect(page).toHaveURL(
+			exploreIriDetailPage.baseUrl + `?iri=${encodeURIComponent(exampleIri)}`
+		);
+	});
+});

--- a/src/routes/explore/iris/+page.svelte
+++ b/src/routes/explore/iris/+page.svelte
@@ -11,7 +11,7 @@
 	function handleSubmit(iri: string) {
 		if (iri && iri.length) {
 			// eslint-disable-next-line svelte/no-navigation-without-resolve
-			goto(`${resolve('/explore/iris/detail')}?$iri=${encodeURIComponent(iri)}`);
+			goto(`${resolve('/explore/iris/detail')}?iri=${encodeURIComponent(iri)}`);
 		}
 	}
 


### PR DESCRIPTION
At some point in the past, a stray dollar sign ended up in the URI search textbox - this is an area that wasn't covered by existing tests (e2e tests really only cover the major journeys, and this is functionality that is hardly ever used) so never got picked up.

This PR fixes the problem and adds tests to catch issues in the future.

Fixes #263 