### PR TITLE
Expose unionDefaultGraph as a query setting

### DIFF
--- a/src/lib/stores/labelLookup.svelte.ts
+++ b/src/lib/stores/labelLookup.svelte.ts
@@ -4,6 +4,7 @@ import { get } from 'svelte/store';
 import { createEngine } from '$lib/querying/engine';
 import { sourceList } from '$stores/sources/sources.store';
 import defaultLabels from '$lib/data/labels.json';
+import { settings } from '$stores/settings.store';
 
 interface LabelLookup {
 	[iri: string]: string;
@@ -86,7 +87,8 @@ async function processLabelsQueue() {
 	const results = await engine.queryBindings(sparql, {
 		sources: get(sourceList),
 		readonly: true,
-		lenient: true
+		lenient: true,
+		unionDefaultGraph: get(settings).general__unionDefaultGraph
 	});
 
 	for await (const result of results) {

--- a/src/lib/stores/settings.store.test.ts
+++ b/src/lib/stores/settings.store.test.ts
@@ -6,5 +6,6 @@ import { settings } from './settings.store';
 describe('settings', () => {
 	it('has some sensible defaults', () => {
 		expect(Object.keys(get(settings))).not.toHaveLength(0);
+		expect(get(settings).general__unionDefaultGraph).toBe(true);
 	});
 });

--- a/src/lib/stores/settings.store.ts
+++ b/src/lib/stores/settings.store.ts
@@ -7,6 +7,7 @@ interface GeneralSettings {
 	general__defaultLimit: number;
 	general__showQuads: boolean;
 	general__showRDFSLabels: boolean;
+	general__unionDefaultGraph: boolean;
 }
 
 export interface TermSettings {
@@ -25,6 +26,7 @@ const defaultSettings: Settings = {
 	general__defaultLimit: 1000,
 	general__showQuads: false,
 	general__showRDFSLabels: false,
+	general__unionDefaultGraph: true,
 	term__showNodeType: true,
 	term__abbreviateCommonPrefixes: false,
 	term__squashRdfTypeInGraph: false,

--- a/src/lib/stores/streamedQuery.store.test.ts
+++ b/src/lib/stores/streamedQuery.store.test.ts
@@ -9,6 +9,7 @@ import { QueryStatus } from '$lib/types';
 import { get } from 'svelte/store';
 import { importRdfDocument } from '$lib/util/source.util';
 import { logger } from '$stores/logger.store';
+import { settings } from '$stores/settings.store';
 
 const document = `
 PREFIX : <http://www.example.com/> 
@@ -299,6 +300,32 @@ describe(createQueryStore, () => {
 					expect.objectContaining({ resultType: 'void', sparqlQuery: query })
 				);
 			});
+		});
+	});
+
+	describe('when querying named graphs', () => {
+		it('respects the union default graph setting', async () => {
+			const source = get(sources)[0];
+			await importRdfDocument(
+				source,
+				`@prefix : <http://www.example.com/> .
+:namedGraph { :Carol :name "Carol" . }`
+			);
+
+			const query =
+				'SELECT ?o WHERE { <http://www.example.com/Carol> <http://www.example.com/name> ?o }';
+			const execute = async () =>
+				new Promise<StreamedQuery>((resolve) => {
+					createQueryStore(query, get(sourceList)).subscribe((result) => {
+						if (result.status === QueryStatus.Done) resolve(result);
+					});
+				});
+
+			settings.update((current) => ({ ...current, general__unionDefaultGraph: false }));
+			expect((await execute()).results).toHaveLength(0);
+
+			settings.update((current) => ({ ...current, general__unionDefaultGraph: true }));
+			expect((await execute()).results).toHaveLength(1);
 		});
 	});
 });

--- a/src/lib/stores/streamedQuery.store.ts
+++ b/src/lib/stores/streamedQuery.store.ts
@@ -19,7 +19,7 @@
  */
 
 import type { Bindings, BindingsStream } from '@comunica/types';
-import { type Readable, writable } from 'svelte/store';
+import { get, type Readable, writable } from 'svelte/store';
 import { comunicaLogger, logger } from '$stores/logger.store';
 import type { AsyncIterator } from 'asynciterator';
 import type { Quad } from '@rdfjs/types';
@@ -27,6 +27,7 @@ import { QueryStatus } from '$lib/types';
 import type { QuerySources } from './sources/sources.store';
 import type { ResultStream } from '@rdfjs/types';
 import { createEngine } from '$lib/querying/engine';
+import { settings } from '$stores/settings.store';
 
 type QuadsStream = AsyncIterator<Quad> & ResultStream<Quad>;
 type QueryStream = BindingsStream | QuadsStream;
@@ -86,6 +87,7 @@ export function createQueryStore(sparqlQuery: string, sources: QuerySources): St
 			sources,
 			readonly: true,
 			lenient: true,
+			unionDefaultGraph: get(settings).general__unionDefaultGraph,
 			log: comunicaLogger,
 			httpAbortSignal: abortController.signal
 		});

--- a/src/routes/settings/+page.svelte
+++ b/src/routes/settings/+page.svelte
@@ -10,7 +10,8 @@
 		general__darkMode: $settings.general__darkMode,
 		general__defaultLimit: $settings.general__defaultLimit,
 		general__showQuads: $settings.general__showQuads,
-		general__showRDFSLabels: $settings.general__showRDFSLabels
+		general__showRDFSLabels: $settings.general__showRDFSLabels,
+		general__unionDefaultGraph: $settings.general__unionDefaultGraph
 	};
 
 	let dirty = false;
@@ -46,6 +47,13 @@
 			label="Display Labels"
 			helperText="Attempt to fetch and display RDFS labels from active data sources when viewing terms."
 			bind:checked={dirtySettings.general__showRDFSLabels}
+			onchange={() => (dirty = true)}
+		/>
+
+		<Switch
+			label="Union Default Graph"
+			helperText="Treat the union of named graphs as the default graph when running queries."
+			bind:checked={dirtySettings.general__unionDefaultGraph}
 			onchange={() => (dirty = true)}
 		/>
 


### PR DESCRIPTION
Fixes #265

## Summary
- add a general setting for Comunica `unionDefaultGraph`
- apply the setting to streamed queries and label lookups
- preserve the current enabled behavior by default
- add regression coverage for named-graph-only data

## Validation
- `npm run test:unit+component` (292 tests passed)
- `npm run check`
- `npm run lint`
- `npm run build`