### PR TITLE
Visualise named graph context

### DIFF
--- a/src/lib/util/cytoscape/__snapshots__/style.test.ts.snap
+++ b/src/lib/util/cytoscape/__snapshots__/style.test.ts.snap
@@ -23,6 +23,20 @@ exports[`style > matches the dark-mode snapshot 1`] = `
     },
   },
   {
+    "selector": "node[isGraph]",
+    "style": {
+      "background-color": "#333",
+      "background-opacity": 0.6,
+      "border-color": "#aaa",
+      "border-width": 1,
+      "font-size": "8px",
+      "padding": "16px",
+      "shape": "roundrectangle",
+      "text-halign": "center",
+      "text-valign": "top",
+    },
+  },
+  {
     "selector": "label",
     "style": {
       "color": "#fff",
@@ -63,6 +77,20 @@ exports[`style > matches the light-mode snapshot 1`] = `
     "selector": "node[termType = "Literal"]",
     "style": {
       "background-color": "#000",
+    },
+  },
+  {
+    "selector": "node[isGraph]",
+    "style": {
+      "background-color": "#f5f5f5",
+      "background-opacity": 0.6,
+      "border-color": "#555",
+      "border-width": 1,
+      "font-size": "8px",
+      "padding": "16px",
+      "shape": "roundrectangle",
+      "text-halign": "center",
+      "text-valign": "top",
     },
   },
   {

--- a/src/lib/util/cytoscape/cytoscape.spec.ts
+++ b/src/lib/util/cytoscape/cytoscape.spec.ts
@@ -280,4 +280,87 @@ describe(getCytoscapeElementsForQuads, () => {
 			);
 		});
 	});
+
+	describe('when quads belong to named graphs', () => {
+		it("groups a named graph's nodes inside a graph container", () => {
+			const graphName = namedNode('urn:graph:people');
+			const bob = namedNode('urn:example:Bob');
+			const alice = namedNode('urn:example:Alice');
+			const elements = getCytoscapeElementsForQuads([
+				quad(bob, namedNode('urn:example:knows'), alice, graphName)
+			]);
+			const graph = cytoscape({ headless: true, elements });
+			try {
+				const container = graph.nodes().filter((node) => node.data('isGraph'));
+				expect(container).toHaveLength(1);
+				expect(container[0].data('label')).toBe(graphName.value);
+				expect(container[0].children()).toHaveLength(2);
+				expect(
+					container[0]
+						.children()
+						.map((node) => node.data('label'))
+						.sort()
+				).toEqual([alice.value, bob.value]);
+				expect(graph.edges()).toHaveLength(1);
+				expect(graph.edges()[0].source().parent()[0].id()).toBe(container[0].id());
+				expect(graph.edges()[0].target().parent()[0].id()).toBe(container[0].id());
+			} finally {
+				graph.destroy();
+			}
+		});
+
+		it('keeps appearances of the same resource separate across named graphs', () => {
+			const bob = namedNode('urn:example:Bob');
+			const elements = getCytoscapeElementsForQuads([
+				quad(bob, namedNode('urn:example:name'), literal('Bob'), namedNode('urn:graph:one')),
+				quad(bob, namedNode('urn:example:name'), literal('Robert'), namedNode('urn:graph:two'))
+			]);
+			const bobNodes = elements.filter(
+				(element) => !element.data.isGraph && element.data.label === bob.value
+			);
+
+			expect(bobNodes).toHaveLength(2);
+			expect(new Set(bobNodes.map((element) => element.data.parent)).size).toBe(2);
+		});
+
+		it('keeps squashed rdf:type labels scoped to their named graph', () => {
+			const bob = namedNode('urn:example:Bob');
+			const rdfType = namedNode('http://www.w3.org/1999/02/22-rdf-syntax-ns#type');
+			const elements = getCytoscapeElementsForQuads(
+				[
+					quad(bob, rdfType, namedNode('urn:example:Person'), namedNode('urn:graph:one')),
+					quad(bob, rdfType, namedNode('urn:example:Agent'), namedNode('urn:graph:two'))
+				],
+				false,
+				[],
+				true
+			);
+			const bobLabels = elements
+				.filter((element) => !element.data.isGraph && element.data.termType === 'NamedNode')
+				.map((element) => element.data.label)
+				.sort();
+
+			expect(bobLabels).toEqual([
+				'urn:example:Bob (a urn:example:Agent)',
+				'urn:example:Bob (a urn:example:Person)'
+			]);
+		});
+
+		it('abbreviates named graph labels using the configured prefixes', () => {
+			const elements = getCytoscapeElementsForQuads(
+				[
+					quad(
+						namedNode('urn:example:Bob'),
+						namedNode('urn:example:name'),
+						literal('Bob'),
+						namedNode('http://example.com/graphs/people')
+					)
+				],
+				true,
+				[{ label: 'graphs', iri: 'http://example.com/graphs/' }]
+			);
+
+			expect(elements.find((element) => element.data.isGraph)?.data.label).toBe('graphs:people');
+		});
+	});
 });

--- a/src/lib/util/cytoscape/cytoscape.ts
+++ b/src/lib/util/cytoscape/cytoscape.ts
@@ -10,10 +10,18 @@ import createCytoscapeStyles from './style';
 const MAX_LABEL_LENGTH = 40;
 const RDF_TYPE_IRI = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type';
 
-type TermType = 'NamedNode' | 'BlankNode' | 'Literal' | 'Variable' | 'Quad';
+type TermType = 'NamedNode' | 'BlankNode' | 'Literal' | 'Variable' | 'Quad' | 'DefaultGraph';
 
 export type LinkedDataElement = ElementDefinition & {
-	data: { label: string; termType: TermType };
+	data: {
+		id?: string;
+		label: string;
+		termType: TermType;
+		parent?: string;
+		isGraph?: boolean;
+		source?: string;
+		target?: string;
+	};
 };
 
 // TODO: This code is in need of a refactor, but is also potentially useful outside of this project.
@@ -27,6 +35,7 @@ export function getCytoscapeElementsForQuads(
 ): LinkedDataElement[] {
 	const elements: LinkedDataElement[] = [];
 	const resources = new Set<string>();
+	const graphs = new Set<string>();
 
 	// Get label, abbreviating if necessary
 	function formatLabel(label: string) {
@@ -35,21 +44,42 @@ export function getCytoscapeElementsForQuads(
 
 	const rdfTypesBySubject = new Map<string, Set<string>>();
 	if (squashRdfType) {
-		for (const { subject, predicate, object } of quads) {
+		for (const { subject, predicate, object, graph } of quads) {
 			if (
 				(subject.termType as TermType) !== 'Quad' &&
 				predicate.value === RDF_TYPE_IRI &&
 				(object.termType === 'NamedNode' || object.termType === 'BlankNode')
 			) {
-				const types = rdfTypesBySubject.get(resourceId(subject)) ?? new Set<string>();
+				const subjectId = contextualResourceId(subject, graph);
+				const types = rdfTypesBySubject.get(subjectId) ?? new Set<string>();
 				types.add(formatLabel(object.value));
-				rdfTypesBySubject.set(resourceId(subject), types);
+				rdfTypesBySubject.set(subjectId, types);
 			}
 		}
 	}
 
-	// Add resource node to graph, ensuring duplicates are not added
-	function addResourceNode(id: string, label: string, termType: TermType) {
+	function addGraphNode(graph: Term) {
+		if (graph.termType === 'DefaultGraph') return;
+		const id = graphId(graph);
+		if (graphs.has(id)) return;
+		graphs.add(id);
+		elements.push({
+			data: {
+				id,
+				label: formatLabel(graph.value),
+				termType: graph.termType as TermType,
+				isGraph: true
+			}
+		});
+	}
+
+	// Add resource node to graph, ensuring duplicates are not added within the same RDF graph.
+	function addResourceNode(
+		id: string,
+		label: string,
+		termType: TermType,
+		parent: string | undefined = undefined
+	) {
 		if (resources.has(id)) return;
 
 		resources.add(id);
@@ -59,12 +89,13 @@ export function getCytoscapeElementsForQuads(
 			data: {
 				id,
 				label: types?.size ? `${formattedLabel} (a ${[...types].join(', ')})` : formattedLabel,
-				termType
+				termType,
+				...(parent ? { parent } : {})
 			}
 		});
 	}
 
-	for (const [idx, { subject, predicate, object }] of quads.entries()) {
+	for (const [idx, { subject, predicate, object, graph }] of quads.entries()) {
 		if ((subject.termType as TermType) == 'Quad') {
 			console.warn(
 				'Graph contains a triple term - these are not supported for graph visualization.'
@@ -72,9 +103,12 @@ export function getCytoscapeElementsForQuads(
 			continue;
 		}
 
+		addGraphNode(graph);
+		const parent = graph.termType === 'DefaultGraph' ? undefined : graphId(graph);
+
 		// Add subject as node - subjects will always be IRIs (either blank nodes or named nodes)
-		const subjectId = resourceId(subject);
-		addResourceNode(subjectId, subject.value, subject.termType);
+		const subjectId = contextualResourceId(subject, graph);
+		addResourceNode(subjectId, subject.value, subject.termType, parent);
 
 		if (
 			squashRdfType &&
@@ -84,12 +118,12 @@ export function getCytoscapeElementsForQuads(
 			continue;
 		}
 
-		const edgeId = `E${idx}`;
+		const edgeId = contextualElementId(`E${idx}`, graph);
 
 		if (object.termType == 'NamedNode' || object.termType == 'BlankNode') {
 			// Add named nodes or blank nodes from the OBJECT portion of triple
-			const objectId = resourceId(object);
-			addResourceNode(objectId, object.value, object.termType);
+			const objectId = contextualResourceId(object, graph);
+			addResourceNode(objectId, object.value, object.termType, parent);
 			elements.push({
 				data: {
 					id: edgeId,
@@ -100,7 +134,7 @@ export function getCytoscapeElementsForQuads(
 				}
 			});
 		} else if (object.termType == 'Literal') {
-			const literalId = `L${idx}`;
+			const literalId = contextualElementId(`L${idx}`, graph);
 			elements.push({
 				data: {
 					id: literalId,
@@ -108,7 +142,8 @@ export function getCytoscapeElementsForQuads(
 						object.value.length > MAX_LABEL_LENGTH
 							? object.value.substring(0, MAX_LABEL_LENGTH - 3) + '...'
 							: object.value,
-					termType: object.termType
+					termType: object.termType,
+					...(parent ? { parent } : {})
 				}
 			});
 			elements.push({
@@ -127,6 +162,18 @@ export function getCytoscapeElementsForQuads(
 
 function resourceId(term: Term): string {
 	return `${term.termType}:${term.value}`;
+}
+
+function graphId(graph: Term): string {
+	return `G:${resourceId(graph)}`;
+}
+
+function contextualElementId(id: string, graph: Term): string {
+	return graph.termType === 'DefaultGraph' ? id : `${graphId(graph)}|${id}`;
+}
+
+function contextualResourceId(term: Term, graph: Term): string {
+	return contextualElementId(resourceId(term), graph);
 }
 
 type CytoscapeSettingsOpts = {

--- a/src/lib/util/cytoscape/style.ts
+++ b/src/lib/util/cytoscape/style.ts
@@ -1,6 +1,8 @@
 /* (c) Crown Copyright GCHQ */
 
-export default function createCytoscapeStyles(darkMode: boolean = false) {
+import type cytoscape from 'cytoscape';
+
+export default function createCytoscapeStyles(darkMode: boolean = false): cytoscape.StylesheetJson {
 	return [
 		// the stylesheet for the graph
 		{
@@ -21,6 +23,20 @@ export default function createCytoscapeStyles(darkMode: boolean = false) {
 			selector: 'node[termType = "Literal"]',
 			style: {
 				'background-color': darkMode ? '#aaa' : '#000'
+			}
+		},
+		{
+			selector: 'node[isGraph]',
+			style: {
+				'background-color': darkMode ? '#333' : '#f5f5f5',
+				'background-opacity': 0.6,
+				'border-color': darkMode ? '#aaa' : '#555',
+				'border-width': 1,
+				'font-size': '8px',
+				padding: '16px',
+				shape: 'roundrectangle',
+				'text-halign': 'center',
+				'text-valign': 'top'
 			}
 		},
 		{


### PR DESCRIPTION
Fixes #138.

Group quads from named graphs into labelled Cytoscape compound nodes so graph context remains visible in the graph visualisation. Scope resource IDs and squashed `rdf:type` metadata to each named graph, while leaving default-graph rendering unchanged. Graph labels continue to respect configured prefix abbreviation.

Validation:
- `npm run test:unit+component`: 295 tests passed
- `npm run check`
- `npm run lint`
- `npm run copyright:check`
- `npm run build`
- `git diff --check`