### PR TITLE
Support named graphs in Explore queries

### DIFF
--- a/src/lib/querying/queries/describeResource.test.ts
+++ b/src/lib/querying/queries/describeResource.test.ts
@@ -6,7 +6,14 @@ describe('sparql queries', () => {
 	describe(describeResource.createQuery, () => {
 		it('produces the expected sparql', () => {
 			const query = describeResource.createQuery('http://www.example.com/foobar');
-			expect(query).toMatchInlineSnapshot('"DESCRIBE <http://www.example.com/foobar>"');
+			expect(query).toMatchInlineSnapshot(`
+				"CONSTRUCT { <http://www.example.com/foobar> ?p ?o }
+				WHERE {
+				      { <http://www.example.com/foobar> ?p ?o }
+				      UNION
+				      { GRAPH ?ldExplorerGraph { <http://www.example.com/foobar> ?p ?o } }
+				}"
+			`);
 		});
 	});
 });

--- a/src/lib/querying/queries/describeResource.ts
+++ b/src/lib/querying/queries/describeResource.ts
@@ -4,12 +4,17 @@
  * describeResource
  * @returns {string}
  *
- * Run a DESCRIBE query for a specific IRI
+ * Return outgoing statements for an IRI from the default graph and named graphs.
  *
  */
 
 export default { createQuery: describeResource };
 
 function describeResource(iri: string) {
-	return `DESCRIBE <${iri}>`;
+	return `CONSTRUCT { <${iri}> ?p ?o }
+WHERE {
+      { <${iri}> ?p ?o }
+      UNION
+      { GRAPH ?ldExplorerGraph { <${iri}> ?p ?o } }
+}`;
 }

--- a/src/lib/querying/queries/getAppearances.test.ts
+++ b/src/lib/querying/queries/getAppearances.test.ts
@@ -19,9 +19,15 @@ describe('sparql queries', () => {
 					WHERE {
 					      { <http://www.example.com/foobar> ?p0 ?o0 }
 					UNION
+					      { GRAPH ?ldExplorerGraph { <http://www.example.com/foobar> ?p0 ?o0 } }
+					UNION
 					      { ?s1 <http://www.example.com/foobar> ?o1 }
 					UNION
+					      { GRAPH ?ldExplorerGraph { ?s1 <http://www.example.com/foobar> ?o1 } }
+					UNION
 					      { ?s2 ?p2 <http://www.example.com/foobar> }
+					UNION
+					      { GRAPH ?ldExplorerGraph { ?s2 ?p2 <http://www.example.com/foobar> } }
 					}
 					LIMIT 100"
 				`);
@@ -41,9 +47,15 @@ describe('sparql queries', () => {
 					WHERE {
 					      { <http://www.example.com/foobar> ?p0 ?o0 }
 					UNION
+					      { GRAPH ?ldExplorerGraph { <http://www.example.com/foobar> ?p0 ?o0 } }
+					UNION
 					      { ?s1 <http://www.example.com/foobar> ?o1 }
 					UNION
+					      { GRAPH ?ldExplorerGraph { ?s1 <http://www.example.com/foobar> ?o1 } }
+					UNION
 					      { ?s2 ?p2 <http://www.example.com/foobar> }
+					UNION
+					      { GRAPH ?ldExplorerGraph { ?s2 ?p2 <http://www.example.com/foobar> } }
 					}
 					LIMIT 123"
 				`);

--- a/src/lib/querying/queries/getAppearances.ts
+++ b/src/lib/querying/queries/getAppearances.ts
@@ -27,9 +27,15 @@ CONSTRUCT {
 WHERE {
       { <${iri}> ?p0 ?o0 }
 UNION
+      { GRAPH ?ldExplorerGraph { <${iri}> ?p0 ?o0 } }
+UNION
       { ?s1 <${iri}> ?o1 }
 UNION
+      { GRAPH ?ldExplorerGraph { ?s1 <${iri}> ?o1 } }
+UNION
       { ?s2 ?p2 <${iri}> }
+UNION
+      { GRAPH ?ldExplorerGraph { ?s2 ?p2 <${iri}> } }
 }
 LIMIT ${limit}`;
 }

--- a/src/lib/querying/queries/getBaseClasses.test.ts
+++ b/src/lib/querying/queries/getBaseClasses.test.ts
@@ -14,8 +14,15 @@ describe('sparql queries', () => {
 
 					SELECT DISTINCT ?class
 					WHERE {
-					      ?s a ?class .
-					      FILTER NOT EXISTS { ?class rdfs:subClassOf ?parent . FILTER( ?parent != owl:Thing ) }
+					      { ?s a ?class . }
+					      UNION
+					      { GRAPH ?ldExplorerGraph { ?s a ?class . } }
+					      FILTER NOT EXISTS {
+					            { ?class rdfs:subClassOf ?parent . }
+					            UNION
+					            { GRAPH ?ldExplorerParentGraph { ?class rdfs:subClassOf ?parent . } }
+					            FILTER( ?parent != owl:Thing )
+					      }
 					}
 					LIMIT 100"
 				`);
@@ -32,8 +39,15 @@ describe('sparql queries', () => {
 
 					SELECT DISTINCT ?class
 					WHERE {
-					      ?s a ?class .
-					      FILTER NOT EXISTS { ?class rdfs:subClassOf ?parent . FILTER( ?parent != owl:Thing ) }
+					      { ?s a ?class . }
+					      UNION
+					      { GRAPH ?ldExplorerGraph { ?s a ?class . } }
+					      FILTER NOT EXISTS {
+					            { ?class rdfs:subClassOf ?parent . }
+					            UNION
+					            { GRAPH ?ldExplorerParentGraph { ?class rdfs:subClassOf ?parent . } }
+					            FILTER( ?parent != owl:Thing )
+					      }
 					}
 					LIMIT 123"
 				`);

--- a/src/lib/querying/queries/getBaseClasses.ts
+++ b/src/lib/querying/queries/getBaseClasses.ts
@@ -26,8 +26,15 @@ PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 
 SELECT DISTINCT ?class
 WHERE {
-      ?s a ?class .
-      FILTER NOT EXISTS { ?class rdfs:subClassOf ?parent . FILTER( ?parent != owl:Thing ) }
+      { ?s a ?class . }
+      UNION
+      { GRAPH ?ldExplorerGraph { ?s a ?class . } }
+      FILTER NOT EXISTS {
+            { ?class rdfs:subClassOf ?parent . }
+            UNION
+            { GRAPH ?ldExplorerParentGraph { ?class rdfs:subClassOf ?parent . } }
+            FILTER( ?parent != owl:Thing )
+      }
 }
 LIMIT ${limit}`;
 }

--- a/src/lib/querying/queries/getClassInstances.test.ts
+++ b/src/lib/querying/queries/getClassInstances.test.ts
@@ -11,7 +11,9 @@ describe('sparql queries', () => {
 					"
 					SELECT DISTINCT ?instance
 					WHERE {
-					      ?instance a <http://www.example.com/> .
+					      { ?instance a <http://www.example.com/> . }
+					      UNION
+					      { GRAPH ?ldExplorerGraph { ?instance a <http://www.example.com/> . } }
 					}
 					LIMIT 100"
 				`);
@@ -25,7 +27,9 @@ describe('sparql queries', () => {
 					"
 					SELECT DISTINCT ?instance
 					WHERE {
-					      ?instance a <http://www.example.com/> .
+					      { ?instance a <http://www.example.com/> . }
+					      UNION
+					      { GRAPH ?ldExplorerGraph { ?instance a <http://www.example.com/> . } }
 					}
 					LIMIT 123"
 				`);

--- a/src/lib/querying/queries/getClassInstances.ts
+++ b/src/lib/querying/queries/getClassInstances.ts
@@ -21,7 +21,9 @@ function getClassInstances(iri: string, limit = 100) {
 	return `
 SELECT DISTINCT ?instance
 WHERE {
-      ?instance a <${iri}> .
+      { ?instance a <${iri}> . }
+      UNION
+      { GRAPH ?ldExplorerGraph { ?instance a <${iri}> . } }
 }
 LIMIT ${limit}`;
 }

--- a/src/lib/querying/queries/getClasses.test.ts
+++ b/src/lib/querying/queries/getClasses.test.ts
@@ -11,11 +11,23 @@ describe('sparql queries', () => {
 					"
 					SELECT DISTINCT ?className
 					WHERE {
-					      { ?individual a ?className . }
+					      {
+					            { ?individual a ?className . }
+					            UNION
+					            { ?className a owl:Class . }
+					            UNION
+					            { ?className a rdfs:Class . }
+					      }
 					      UNION
-					      { ?className a owl:Class . } 
-					      UNION
-					      { ?className a rdfs:Class . }
+					      {
+					            GRAPH ?ldExplorerGraph {
+					                  { ?individual a ?className . }
+					                  UNION
+					                  { ?className a owl:Class . }
+					                  UNION
+					                  { ?className a rdfs:Class . }
+					            }
+					      }
 					}
 					LIMIT 100"
 				`);
@@ -29,11 +41,23 @@ describe('sparql queries', () => {
 					"
 					SELECT DISTINCT ?className
 					WHERE {
-					      { ?individual a ?className . }
+					      {
+					            { ?individual a ?className . }
+					            UNION
+					            { ?className a owl:Class . }
+					            UNION
+					            { ?className a rdfs:Class . }
+					      }
 					      UNION
-					      { ?className a owl:Class . } 
-					      UNION
-					      { ?className a rdfs:Class . }
+					      {
+					            GRAPH ?ldExplorerGraph {
+					                  { ?individual a ?className . }
+					                  UNION
+					                  { ?className a owl:Class . }
+					                  UNION
+					                  { ?className a rdfs:Class . }
+					            }
+					      }
 					}
 					LIMIT 123"
 				`);

--- a/src/lib/querying/queries/getClasses.ts
+++ b/src/lib/querying/queries/getClasses.ts
@@ -18,11 +18,23 @@ function getClasses(limit = 100): string {
 	return `
 SELECT DISTINCT ?className
 WHERE {
-      { ?individual a ?className . }
+      {
+            { ?individual a ?className . }
+            UNION
+            { ?className a owl:Class . }
+            UNION
+            { ?className a rdfs:Class . }
+      }
       UNION
-      { ?className a owl:Class . } 
-      UNION
-      { ?className a rdfs:Class . }
+      {
+            GRAPH ?ldExplorerGraph {
+                  { ?individual a ?className . }
+                  UNION
+                  { ?className a owl:Class . }
+                  UNION
+                  { ?className a rdfs:Class . }
+            }
+      }
 }
 LIMIT ${limit}`;
 }

--- a/src/lib/querying/queries/getDomains.test.ts
+++ b/src/lib/querying/queries/getDomains.test.ts
@@ -11,8 +11,12 @@ describe('sparql queries', () => {
 					"
 					PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 
-					SELECT ?property ?domain 
-					WHERE { ?property rdfs:domain ?domain . } 
+					SELECT DISTINCT ?property ?domain
+					WHERE {
+					      { ?property rdfs:domain ?domain . }
+					      UNION
+					      { GRAPH ?ldExplorerGraph { ?property rdfs:domain ?domain . } }
+					}
 					LIMIT 100"
 				`);
 			});
@@ -25,8 +29,12 @@ describe('sparql queries', () => {
 					"
 					PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 
-					SELECT ?property ?domain 
-					WHERE { ?property rdfs:domain ?domain . } 
+					SELECT DISTINCT ?property ?domain
+					WHERE {
+					      { ?property rdfs:domain ?domain . }
+					      UNION
+					      { GRAPH ?ldExplorerGraph { ?property rdfs:domain ?domain . } }
+					}
 					LIMIT 123"
 				`);
 			});

--- a/src/lib/querying/queries/getDomains.ts
+++ b/src/lib/querying/queries/getDomains.ts
@@ -17,7 +17,11 @@ function getDomains(limit = 100): string {
 	return `
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 
-SELECT ?property ?domain 
-WHERE { ?property rdfs:domain ?domain . } 
+SELECT DISTINCT ?property ?domain
+WHERE {
+      { ?property rdfs:domain ?domain . }
+      UNION
+      { GRAPH ?ldExplorerGraph { ?property rdfs:domain ?domain . } }
+}
 LIMIT ${limit}`;
 }

--- a/src/lib/querying/queries/getIndividuals.test.ts
+++ b/src/lib/querying/queries/getIndividuals.test.ts
@@ -11,7 +11,9 @@ describe('sparql queries', () => {
 					"
 					SELECT DISTINCT ?individual ?className
 					WHERE {
-					      ?individual a ?className
+					      { ?individual a ?className }
+					      UNION
+					      { GRAPH ?ldExplorerGraph { ?individual a ?className } }
 					} 
 					LIMIT 100"
 				`);
@@ -25,7 +27,9 @@ describe('sparql queries', () => {
 					"
 					SELECT DISTINCT ?individual ?className
 					WHERE {
-					      ?individual a ?className
+					      { ?individual a ?className }
+					      UNION
+					      { GRAPH ?ldExplorerGraph { ?individual a ?className } }
 					} 
 					LIMIT 123"
 				`);

--- a/src/lib/querying/queries/getIndividuals.ts
+++ b/src/lib/querying/queries/getIndividuals.ts
@@ -20,7 +20,9 @@ function getIndividuals(limit = 100): string {
 	return `
 SELECT DISTINCT ?individual ?className
 WHERE {
-      ?individual a ?className
+      { ?individual a ?className }
+      UNION
+      { GRAPH ?ldExplorerGraph { ?individual a ?className } }
 } 
 LIMIT ${limit}`;
 }

--- a/src/lib/querying/queries/getLabels.test.ts
+++ b/src/lib/querying/queries/getLabels.test.ts
@@ -13,7 +13,9 @@ describe('sparql queries', () => {
 
 					SELECT DISTINCT ?resource ?label
 					WHERE {
-					      ?resource rdfs:label ?label
+					      { ?resource rdfs:label ?label }
+					      UNION
+					      { GRAPH ?ldExplorerGraph { ?resource rdfs:label ?label } }
 					      FILTER (LANGMATCHES(LANG(?label), "en"))
 					} 
 					LIMIT 100"
@@ -30,7 +32,9 @@ describe('sparql queries', () => {
 
 					SELECT DISTINCT ?resource ?label
 					WHERE {
-					      ?resource rdfs:label ?label
+					      { ?resource rdfs:label ?label }
+					      UNION
+					      { GRAPH ?ldExplorerGraph { ?resource rdfs:label ?label } }
 					      FILTER (LANGMATCHES(LANG(?label), "en"))
 					} 
 					LIMIT 123"
@@ -47,7 +51,9 @@ describe('sparql queries', () => {
 
 					SELECT DISTINCT ?resource ?label
 					WHERE {
-					      ?resource rdfs:label ?label
+					      { ?resource rdfs:label ?label }
+					      UNION
+					      { GRAPH ?ldExplorerGraph { ?resource rdfs:label ?label } }
 					      FILTER (LANGMATCHES(LANG(?label), "fr"))
 					} 
 					LIMIT 100"

--- a/src/lib/querying/queries/getLabels.ts
+++ b/src/lib/querying/queries/getLabels.ts
@@ -19,7 +19,9 @@ PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 
 SELECT DISTINCT ?resource ?label
 WHERE {
-      ?resource rdfs:label ?label
+      { ?resource rdfs:label ?label }
+      UNION
+      { GRAPH ?ldExplorerGraph { ?resource rdfs:label ?label } }
       FILTER (LANGMATCHES(LANG(?label), "${languageTag}"))
 } 
 LIMIT ${limit}`;

--- a/src/lib/querying/queries/getProperties.test.ts
+++ b/src/lib/querying/queries/getProperties.test.ts
@@ -11,13 +11,27 @@ describe('sparql queries', () => {
 					"
 					SELECT DISTINCT ?propertyName
 					WHERE {
-					      { ?s ?propertyName ?o }
+					      {
+					            { ?s ?propertyName ?o }
+					            UNION
+					            { ?propertyName a owl:ObjectProperty . }
+					            UNION
+					            { ?propertyName a owl:DatatypeProperty . }
+					            UNION
+					            { ?propertyName a rdf:Property . }
+					      }
 					      UNION
-					      { ?propertyName a owl:ObjectProperty . } 
-					      UNION
-					      { ?propertyName a owl:DatatypeProperty . }
-					      UNION
-					      { ?propertyName a rdf:Property . }
+					      {
+					            GRAPH ?ldExplorerGraph {
+					                  { ?s ?propertyName ?o }
+					                  UNION
+					                  { ?propertyName a owl:ObjectProperty . }
+					                  UNION
+					                  { ?propertyName a owl:DatatypeProperty . }
+					                  UNION
+					                  { ?propertyName a rdf:Property . }
+					            }
+					      }
 					} 
 					LIMIT 100"
 				`);
@@ -31,13 +45,27 @@ describe('sparql queries', () => {
 					"
 					SELECT DISTINCT ?propertyName
 					WHERE {
-					      { ?s ?propertyName ?o }
+					      {
+					            { ?s ?propertyName ?o }
+					            UNION
+					            { ?propertyName a owl:ObjectProperty . }
+					            UNION
+					            { ?propertyName a owl:DatatypeProperty . }
+					            UNION
+					            { ?propertyName a rdf:Property . }
+					      }
 					      UNION
-					      { ?propertyName a owl:ObjectProperty . } 
-					      UNION
-					      { ?propertyName a owl:DatatypeProperty . }
-					      UNION
-					      { ?propertyName a rdf:Property . }
+					      {
+					            GRAPH ?ldExplorerGraph {
+					                  { ?s ?propertyName ?o }
+					                  UNION
+					                  { ?propertyName a owl:ObjectProperty . }
+					                  UNION
+					                  { ?propertyName a owl:DatatypeProperty . }
+					                  UNION
+					                  { ?propertyName a rdf:Property . }
+					            }
+					      }
 					} 
 					LIMIT 123"
 				`);

--- a/src/lib/querying/queries/getProperties.ts
+++ b/src/lib/querying/queries/getProperties.ts
@@ -20,13 +20,27 @@ function getProperties(limit = 100): string {
 	return `
 SELECT DISTINCT ?propertyName
 WHERE {
-      { ?s ?propertyName ?o }
+      {
+            { ?s ?propertyName ?o }
+            UNION
+            { ?propertyName a owl:ObjectProperty . }
+            UNION
+            { ?propertyName a owl:DatatypeProperty . }
+            UNION
+            { ?propertyName a rdf:Property . }
+      }
       UNION
-      { ?propertyName a owl:ObjectProperty . } 
-      UNION
-      { ?propertyName a owl:DatatypeProperty . }
-      UNION
-      { ?propertyName a rdf:Property . }
+      {
+            GRAPH ?ldExplorerGraph {
+                  { ?s ?propertyName ?o }
+                  UNION
+                  { ?propertyName a owl:ObjectProperty . }
+                  UNION
+                  { ?propertyName a owl:DatatypeProperty . }
+                  UNION
+                  { ?propertyName a rdf:Property . }
+            }
+      }
 } 
 LIMIT ${limit}`;
 }

--- a/src/lib/querying/queries/getRanges.test.ts
+++ b/src/lib/querying/queries/getRanges.test.ts
@@ -11,8 +11,12 @@ describe('sparql queries', () => {
 					"
 					PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 
-					SELECT ?property ?range 
-					WHERE { ?property rdfs:range ?range . } 
+					SELECT DISTINCT ?property ?range
+					WHERE {
+					      { ?property rdfs:range ?range . }
+					      UNION
+					      { GRAPH ?ldExplorerGraph { ?property rdfs:range ?range . } }
+					}
 					LIMIT 100"
 				`);
 			});
@@ -25,8 +29,12 @@ describe('sparql queries', () => {
 					"
 					PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 
-					SELECT ?property ?range 
-					WHERE { ?property rdfs:range ?range . } 
+					SELECT DISTINCT ?property ?range
+					WHERE {
+					      { ?property rdfs:range ?range . }
+					      UNION
+					      { GRAPH ?ldExplorerGraph { ?property rdfs:range ?range . } }
+					}
 					LIMIT 123"
 				`);
 			});

--- a/src/lib/querying/queries/getRanges.ts
+++ b/src/lib/querying/queries/getRanges.ts
@@ -17,7 +17,11 @@ function getRanges(limit = 100): string {
 	return `
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 
-SELECT ?property ?range 
-WHERE { ?property rdfs:range ?range . } 
+SELECT DISTINCT ?property ?range
+WHERE {
+      { ?property rdfs:range ?range . }
+      UNION
+      { GRAPH ?ldExplorerGraph { ?property rdfs:range ?range . } }
+}
 LIMIT ${limit}`;
 }

--- a/src/lib/querying/queries/getSubclasses.test.ts
+++ b/src/lib/querying/queries/getSubclasses.test.ts
@@ -13,8 +13,17 @@ describe('sparql queries', () => {
 
 					CONSTRUCT { ?subClass rdfs:subClassOf ?superClass . }
 					WHERE {
-					    ?subClass rdfs:subClassOf* <http://www.example.com/> .
-					    ?subClass rdfs:subClassOf ?superClass .
+					    {
+					        ?subClass rdfs:subClassOf* <http://www.example.com/> .
+					        ?subClass rdfs:subClassOf ?superClass .
+					    }
+					    UNION
+					    {
+					        GRAPH ?ldExplorerGraph {
+					            ?subClass rdfs:subClassOf* <http://www.example.com/> .
+					            ?subClass rdfs:subClassOf ?superClass .
+					        }
+					    }
 					    FILTER (?subClass != <http://www.example.com/>)
 					}
 					LIMIT 100
@@ -32,8 +41,17 @@ describe('sparql queries', () => {
 
 					CONSTRUCT { ?subClass rdfs:subClassOf ?superClass . }
 					WHERE {
-					    ?subClass rdfs:subClassOf* <http://www.example.com/> .
-					    ?subClass rdfs:subClassOf ?superClass .
+					    {
+					        ?subClass rdfs:subClassOf* <http://www.example.com/> .
+					        ?subClass rdfs:subClassOf ?superClass .
+					    }
+					    UNION
+					    {
+					        GRAPH ?ldExplorerGraph {
+					            ?subClass rdfs:subClassOf* <http://www.example.com/> .
+					            ?subClass rdfs:subClassOf ?superClass .
+					        }
+					    }
 					    FILTER (?subClass != <http://www.example.com/>)
 					}
 					LIMIT 123

--- a/src/lib/querying/queries/getSubclasses.ts
+++ b/src/lib/querying/queries/getSubclasses.ts
@@ -21,8 +21,17 @@ PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 
 CONSTRUCT { ?subClass rdfs:subClassOf ?superClass . }
 WHERE {
-    ?subClass rdfs:subClassOf* <${iri}> .
-    ?subClass rdfs:subClassOf ?superClass .
+    {
+        ?subClass rdfs:subClassOf* <${iri}> .
+        ?subClass rdfs:subClassOf ?superClass .
+    }
+    UNION
+    {
+        GRAPH ?ldExplorerGraph {
+            ?subClass rdfs:subClassOf* <${iri}> .
+            ?subClass rdfs:subClassOf ?superClass .
+        }
+    }
     FILTER (?subClass != <${iri}>)
 }
 LIMIT ${limit}

--- a/src/lib/querying/queries/getSuperclasses.test.ts
+++ b/src/lib/querying/queries/getSuperclasses.test.ts
@@ -13,8 +13,17 @@ describe('sparql queries', () => {
 
 					SELECT DISTINCT ?superClass 
 					WHERE {
-					    <http://www.example.com/> rdfs:subClassOf* ?superClass .
-					    ?subClass rdfs:subClassOf ?superClass .
+					    {
+					        <http://www.example.com/> rdfs:subClassOf* ?superClass .
+					        ?subClass rdfs:subClassOf ?superClass .
+					    }
+					    UNION
+					    {
+					        GRAPH ?ldExplorerGraph {
+					            <http://www.example.com/> rdfs:subClassOf* ?superClass .
+					            ?subClass rdfs:subClassOf ?superClass .
+					        }
+					    }
 					    FILTER (?superClass != <http://www.example.com/>)
 					}
 					LIMIT 100"
@@ -31,8 +40,17 @@ describe('sparql queries', () => {
 
 					SELECT DISTINCT ?superClass 
 					WHERE {
-					    <http://www.example.com/> rdfs:subClassOf* ?superClass .
-					    ?subClass rdfs:subClassOf ?superClass .
+					    {
+					        <http://www.example.com/> rdfs:subClassOf* ?superClass .
+					        ?subClass rdfs:subClassOf ?superClass .
+					    }
+					    UNION
+					    {
+					        GRAPH ?ldExplorerGraph {
+					            <http://www.example.com/> rdfs:subClassOf* ?superClass .
+					            ?subClass rdfs:subClassOf ?superClass .
+					        }
+					    }
 					    FILTER (?superClass != <http://www.example.com/>)
 					}
 					LIMIT 123"

--- a/src/lib/querying/queries/getSuperclasses.ts
+++ b/src/lib/querying/queries/getSuperclasses.ts
@@ -21,8 +21,17 @@ PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 
 SELECT DISTINCT ?superClass 
 WHERE {
-    <${iri}> rdfs:subClassOf* ?superClass .
-    ?subClass rdfs:subClassOf ?superClass .
+    {
+        <${iri}> rdfs:subClassOf* ?superClass .
+        ?subClass rdfs:subClassOf ?superClass .
+    }
+    UNION
+    {
+        GRAPH ?ldExplorerGraph {
+            <${iri}> rdfs:subClassOf* ?superClass .
+            ?subClass rdfs:subClassOf ?superClass .
+        }
+    }
     FILTER (?superClass != <${iri}>)
 }
 LIMIT ${limit}`;

--- a/src/lib/querying/queries/getTriples.test.ts
+++ b/src/lib/querying/queries/getTriples.test.ts
@@ -9,7 +9,12 @@ describe('sparql queries', () => {
 				const query = getTriples.createQuery();
 				expect(query).toMatchInlineSnapshot(`
 					"
-					CONSTRUCT WHERE { ?s ?p ?o }
+					CONSTRUCT { ?s ?p ?o }
+					WHERE {
+					      { ?s ?p ?o }
+					      UNION
+					      { GRAPH ?ldExplorerGraph { ?s ?p ?o } }
+					}
 					LIMIT 100"
 				`);
 			});
@@ -20,7 +25,12 @@ describe('sparql queries', () => {
 				const query = getTriples.createQuery(123);
 				expect(query).toMatchInlineSnapshot(`
 					"
-					CONSTRUCT WHERE { ?s ?p ?o }
+					CONSTRUCT { ?s ?p ?o }
+					WHERE {
+					      { ?s ?p ?o }
+					      UNION
+					      { GRAPH ?ldExplorerGraph { ?s ?p ?o } }
+					}
 					LIMIT 123"
 				`);
 			});

--- a/src/lib/querying/queries/getTriples.ts
+++ b/src/lib/querying/queries/getTriples.ts
@@ -7,7 +7,7 @@ import { CommonCodeComments } from '../sparqlUtils';
  * @param {number} limit
  * @returns {string}
  *
- * Return triples from default graph
+ * Return triples from default and named graphs
  *
  */
 
@@ -15,6 +15,11 @@ export default { createQuery: getTriples, codeComment: CommonCodeComments.Change
 
 function getTriples(limit = 100): string {
 	return `
-CONSTRUCT WHERE { ?s ?p ?o }
+CONSTRUCT { ?s ?p ?o }
+WHERE {
+      { ?s ?p ?o }
+      UNION
+      { GRAPH ?ldExplorerGraph { ?s ?p ?o } }
+}
 LIMIT ${limit}`;
 }

--- a/src/lib/querying/queries/namedGraphQueries.test.ts
+++ b/src/lib/querying/queries/namedGraphQueries.test.ts
@@ -1,0 +1,125 @@
+/* (c) Crown Copyright GCHQ */
+
+import { QueryEngine } from '@comunica/query-sparql';
+import { DataFactory, Store } from 'n3';
+import {
+	describeResource,
+	getAppearances,
+	getBaseClasses,
+	getClassInstances,
+	getClasses,
+	getDomains,
+	getIndividuals,
+	getLabels,
+	getProperties,
+	getRanges,
+	getSubclasses,
+	getSuperclasses,
+	getTriples
+} from '.';
+
+const { literal, namedNode, quad } = DataFactory;
+const RDF_TYPE = namedNode('http://www.w3.org/1999/02/22-rdf-syntax-ns#type');
+const RDF_PROPERTY = namedNode('http://www.w3.org/1999/02/22-rdf-syntax-ns#Property');
+const RDFS_CLASS = namedNode('http://www.w3.org/2000/01/rdf-schema#Class');
+const RDFS_DOMAIN = namedNode('http://www.w3.org/2000/01/rdf-schema#domain');
+const RDFS_LABEL = namedNode('http://www.w3.org/2000/01/rdf-schema#label');
+const RDFS_RANGE = namedNode('http://www.w3.org/2000/01/rdf-schema#range');
+const RDFS_SUBCLASS = namedNode('http://www.w3.org/2000/01/rdf-schema#subClassOf');
+
+const person = namedNode('http://example.org/Person');
+const student = namedNode('http://example.org/Student');
+const knows = namedNode('http://example.org/knows');
+const alice = namedNode('http://example.org/Alice');
+const bob = namedNode('http://example.org/Bob');
+const ontologyGraph = namedNode('http://example.org/ontology');
+const dataGraph = namedNode('http://example.org/data');
+
+const store = new Store([
+	quad(person, RDF_TYPE, RDFS_CLASS, ontologyGraph),
+	quad(student, RDF_TYPE, RDFS_CLASS, ontologyGraph),
+	quad(student, RDFS_SUBCLASS, person, ontologyGraph),
+	quad(knows, RDF_TYPE, RDF_PROPERTY, ontologyGraph),
+	quad(knows, RDFS_DOMAIN, person, ontologyGraph),
+	quad(knows, RDFS_RANGE, person, ontologyGraph),
+	quad(alice, RDF_TYPE, student, dataGraph),
+	quad(alice, knows, bob, dataGraph),
+	quad(alice, RDFS_LABEL, literal('Alice', 'en'), dataGraph),
+	quad(bob, RDF_TYPE, person, dataGraph)
+]);
+
+const engine = new QueryEngine();
+const context = { sources: [store], unionDefaultGraph: false };
+
+async function values(query: string, variable: string): Promise<string[]> {
+	const stream = await engine.queryBindings(query, context);
+	return (await stream.toArray())
+		.map((bindings) => bindings.get(variable)?.value)
+		.filter((value): value is string => value !== undefined);
+}
+
+async function quadsFor(query: string) {
+	return (await engine.queryQuads(query, context)).toArray();
+}
+
+describe('exploration queries with named-graph-only data', () => {
+	it('finds classes', async () => {
+		expect(await values(getClasses.createQuery(), 'className')).toEqual(
+			expect.arrayContaining([person.value, student.value])
+		);
+	});
+
+	it('finds class instances', async () => {
+		expect(await values(getClassInstances.createQuery(student.value), 'instance')).toContain(
+			alice.value
+		);
+	});
+
+	it('finds individuals', async () => {
+		expect(await values(getIndividuals.createQuery(), 'individual')).toEqual(
+			expect.arrayContaining([alice.value, bob.value])
+		);
+	});
+
+	it('finds properties', async () => {
+		expect(await values(getProperties.createQuery(), 'propertyName')).toContain(knows.value);
+	});
+
+	it('finds labels', async () => {
+		expect(await values(getLabels.createQuery(), 'resource')).toContain(alice.value);
+	});
+
+	it('finds domains and ranges', async () => {
+		expect(await values(getDomains.createQuery(), 'property')).toContain(knows.value);
+		expect(await values(getRanges.createQuery(), 'property')).toContain(knows.value);
+	});
+
+	it('finds base classes using subclass relationships in named graphs', async () => {
+		const classes = await values(getBaseClasses.createQuery(), 'class');
+		expect(classes).toContain(person.value);
+		expect(classes).not.toContain(student.value);
+	});
+
+	it('finds subclass and superclass relationships', async () => {
+		const subclasses = await quadsFor(getSubclasses.createQuery(person.value));
+		expect(subclasses.some((result) => result.subject.equals(student))).toBe(true);
+		expect(await values(getSuperclasses.createQuery(student.value), 'superClass')).toContain(
+			person.value
+		);
+	});
+
+	it('describes a resource from a named graph', async () => {
+		const description = await quadsFor(describeResource.createQuery(alice.value));
+		expect(description.some((result) => result.predicate.equals(knows))).toBe(true);
+	});
+
+	it('finds resource appearances in named graphs', async () => {
+		const appearances = await quadsFor(getAppearances.createQuery(alice.value));
+		expect(appearances.some((result) => result.predicate.equals(knows))).toBe(true);
+	});
+
+	it('returns triples from named graphs', async () => {
+		const triples = await quadsFor(getTriples.createQuery());
+		expect(triples.some((result) => result.predicate.equals(knows))).toBe(true);
+	});
+});

--- a/src/routes/explore/+page.svelte
+++ b/src/routes/explore/+page.svelte
@@ -32,9 +32,9 @@
 			Explore the raw data by interrogating <Link href={resolve('/explore/triples')}>Triples</Link> directly.
 		</ListItem>
 		<ListItem>
-			LD Explorer queries within the explore section only query the default graph, however you can
-			still see any <Link href={resolve('/explore/named-graphs')}>Named Graphs</Link> within your selected
-			data sources.
+			Explore queries inspect both the default graph and any <Link
+				href={resolve('/explore/named-graphs')}>Named Graphs</Link
+			> within your selected data sources.
 		</ListItem>
 		<ListItem>
 			Search for a specific <Link href={resolve('/explore/iris')}>IRI</Link>.


### PR DESCRIPTION
Fixes #176.

Update the stock Explore queries to read both the default graph and named graphs without relying on `unionDefaultGraph`. The IRI detail query now uses an explicit `CONSTRUCT` so named-graph-only statements are included, and the Explore guidance reflects the new behaviour.

Validation:
- 302 unit/component tests passed
- 11 named-graph-only execution tests run with `unionDefaultGraph: false`
- `svelte-check`: 0 errors, 0 warnings
- lint and copyright checks pass
- production build succeeds
