### PR TITLE
Add SHACL validation for local sources

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42,6 +42,7 @@
 				"prettier": "^3.9.6",
 				"prettier-plugin-svelte": "^4.1.1",
 				"rdf-data-factory": "^2.0.2",
+				"rdf-validate-shacl": "^0.6.5",
 				"rdfa-streaming-parser": "^3.0.2",
 				"shadow-dom-testing-library": "^1.14.1",
 				"svelte": "^5.57.0",
@@ -5883,6 +5884,70 @@
 				"url": "https://opencollective.com/popperjs"
 			}
 		},
+		"node_modules/@rdfjs/data-model": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/@rdfjs/data-model/-/data-model-2.1.2.tgz",
+			"integrity": "sha512-yoSVlyCltqbaCTse3uSdf5Vo3q4UskcTm+3klaUQTwOq7Z5aCZLtLPZatXTPzr+S0WEcjTZvD++A+r3QmgamsA==",
+			"dev": true,
+			"license": "MIT",
+			"bin": {
+				"rdfjs-data-model-test": "bin/test.js"
+			}
+		},
+		"node_modules/@rdfjs/dataset": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/@rdfjs/dataset/-/dataset-2.0.3.tgz",
+			"integrity": "sha512-Ur6M0nDFXMJWNYe1IBDBaQV/nIwRbe3+I58syOHnzZNbe7ZHumUOS/0XQ1+9WYF31tmQU7w741MRn6W3J+OTeg==",
+			"dev": true,
+			"license": "MIT",
+			"bin": {
+				"rdfjs-dataset-test": "bin/test.js"
+			}
+		},
+		"node_modules/@rdfjs/environment": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@rdfjs/environment/-/environment-1.0.0.tgz",
+			"integrity": "sha512-+S5YjSvfoQR5r7YQCRCCVHvIEyrWia7FJv2gqM3s5EDfotoAQmFeBagApa9c/eQFi5EiNhmBECE5nB8LIxTaHg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@rdfjs/namespace": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/@rdfjs/namespace/-/namespace-2.0.1.tgz",
+			"integrity": "sha512-U85NWVGnL3gWvOZ4eXwUcv3/bom7PAcutSBQqmVWvOaslPy+kDzAJCH1WYBLpdQd4yMmJ+bpJcDl9rcHtXeixg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@rdfjs/data-model": "^2.0.1"
+			}
+		},
+		"node_modules/@rdfjs/term-map": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/@rdfjs/term-map/-/term-map-2.0.2.tgz",
+			"integrity": "sha512-EJ2FmmdEUsSR/tU1nrizRLWzH24YzhuvesrbUWxC3Fs0ilYNdtTbg0RaFJDUnJF3HkbNBQe8Zrt/uvU/hcKnHg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@rdfjs/to-ntriples": "^3.0.1"
+			}
+		},
+		"node_modules/@rdfjs/term-set": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/@rdfjs/term-set/-/term-set-2.0.3.tgz",
+			"integrity": "sha512-DyXrKWEx+mtAFUZVU7bc3Va6/KZ8PsIp0RVdyWT9jfDgI/HCvNisZaBtAcm+SYTC45o+7WLkbudkk1bfaKVB0A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@rdfjs/to-ntriples": "^3.0.1"
+			}
+		},
+		"node_modules/@rdfjs/to-ntriples": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/@rdfjs/to-ntriples/-/to-ntriples-3.0.1.tgz",
+			"integrity": "sha512-gjoPAvh4j7AbGMjcDn/8R4cW+d/FPtbfbMM0uQXkyfBFtNUW2iVgrqsgJ65roLc54Y9A2TTFaeeTGSvY9a0HCQ==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/@rdfjs/types": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/@rdfjs/types/-/types-2.0.1.tgz",
@@ -6684,6 +6749,20 @@
 				"@testing-library/dom": ">=7.21.4"
 			}
 		},
+		"node_modules/@tpluscode/rdf-ns-builders": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/@tpluscode/rdf-ns-builders/-/rdf-ns-builders-5.0.0.tgz",
+			"integrity": "sha512-rtMFbArdief+s0z2A3TOb/gNe5O5xn9LDiEpilCf6lGYCUIfyqoOvZY80fS/eILwcF2Mj6cUQN1WBQ+1neJmaw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@rdfjs/data-model": "^2.1.0",
+				"@rdfjs/namespace": "^2.0.1",
+				"@rdfjs/types": "^2",
+				"@types/rdfjs__namespace": "^2.0.10",
+				"@zazuko/prefixes": "^2.3.0"
+			}
+		},
 		"node_modules/@traqula/algebra-sparql-1-1": {
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/@traqula/algebra-sparql-1-1/-/algebra-sparql-1-1-1.2.2.tgz",
@@ -6962,6 +7041,16 @@
 			"license": "MIT",
 			"dependencies": {
 				"undici-types": "~8.3.0"
+			}
+		},
+		"node_modules/@types/rdfjs__namespace": {
+			"version": "2.0.10",
+			"resolved": "https://registry.npmjs.org/@types/rdfjs__namespace/-/rdfjs__namespace-2.0.10.tgz",
+			"integrity": "sha512-xoVzEIOxcpyteEmzaj94MSBbrBFs+vqv05joMhzLEiPRwsBBDnhkdBCaaDxR1Tf7wOW0kB2R1IYe4C3vEBFPgA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@rdfjs/types": "*"
 			}
 		},
 		"node_modules/@types/readable-stream": {
@@ -7413,6 +7502,23 @@
 				"url": "https://opencollective.com/vitest"
 			}
 		},
+		"node_modules/@vocabulary/sh": {
+			"version": "1.1.6",
+			"resolved": "https://registry.npmjs.org/@vocabulary/sh/-/sh-1.1.6.tgz",
+			"integrity": "sha512-8IfAQoKh57THz8LA2+n1jaY/VC2XaqMNSsJgzBKSSrj20y5PSMAawb6dMsxoLxqDIPBDs1TFRl/9CijUnwbBUA==",
+			"dev": true,
+			"license": "MIT",
+			"peerDependencies": {
+				"@rdfjs/types": "^2.0.0"
+			}
+		},
+		"node_modules/@zazuko/prefixes": {
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/@zazuko/prefixes/-/prefixes-2.6.1.tgz",
+			"integrity": "sha512-fbOadP7twxt0ZYT9mgIC+xQMk6f3pYYLI5a/2UJ/mc/ygqb/NoVv2ryK3lTtoi74xwkdpUeDwIuFQSosowzUgg==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/abort-controller": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
@@ -7731,6 +7837,18 @@
 			},
 			"engines": {
 				"node": ">=12"
+			}
+		},
+		"node_modules/clownface": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/clownface/-/clownface-2.0.3.tgz",
+			"integrity": "sha512-E76TBJ7CgU9+/5paSAvuNdMO+fzFThnvRVtidosktYppYkXM8V7tid8Ezzo8S1OmoWxKUam3yfkZlfCid4OiJQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@rdfjs/data-model": "^2.0.1",
+				"@rdfjs/environment": "0 - 1",
+				"@rdfjs/namespace": "^2.0.0"
 			}
 		},
 		"node_modules/clsx": {
@@ -10144,6 +10262,19 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/rdf-canonize": {
+			"version": "3.4.0",
+			"resolved": "https://registry.npmjs.org/rdf-canonize/-/rdf-canonize-3.4.0.tgz",
+			"integrity": "sha512-fUeWjrkOO0t1rg7B2fdyDTvngj+9RlUyL92vOdiB7c0FPguWVsniIMjEtHH+meLBO9rzkUlUzBVXgWrjI8P9LA==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"setimmediate": "^1.0.5"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
 		"node_modules/rdf-data-factory": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/rdf-data-factory/-/rdf-data-factory-2.0.2.tgz",
@@ -10156,6 +10287,18 @@
 			"funding": {
 				"type": "individual",
 				"url": "https://github.com/sponsors/rubensworks/"
+			}
+		},
+		"node_modules/rdf-dataset-ext": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/rdf-dataset-ext/-/rdf-dataset-ext-1.1.0.tgz",
+			"integrity": "sha512-CH85RfRKN9aSlbju8T7aM8hgCSWMBsh2eh/tGxUUtWMN+waxi6iFDt8/r4PAEmKaEA82guimZJ4ISbmJ2rvWQg==",
+			"deprecated": "rdf-dataset-ext is deprecated. Switching to rdf-ext is recommended.",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"rdf-canonize": "^3.0.0",
+				"readable-stream": "3 - 4"
 			}
 		},
 		"node_modules/rdf-isomorphic": {
@@ -11025,6 +11168,38 @@
 				"url": "https://github.com/sponsors/rubensworks/"
 			}
 		},
+		"node_modules/rdf-validate-datatype": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/rdf-validate-datatype/-/rdf-validate-datatype-0.2.2.tgz",
+			"integrity": "sha512-mH9qL8i0WBbZ6HJCA26BB6V+WV2MraKvitez3SV0QegBWVQ4wYO49CgfFBzoAYg6tlnhFXl9MkrOAQ07X2N1FA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@rdfjs/term-map": "^2.0.0",
+				"@tpluscode/rdf-ns-builders": "3 - 5"
+			}
+		},
+		"node_modules/rdf-validate-shacl": {
+			"version": "0.6.5",
+			"resolved": "https://registry.npmjs.org/rdf-validate-shacl/-/rdf-validate-shacl-0.6.5.tgz",
+			"integrity": "sha512-rwIibopSixDE8ecA9x0c7oTVxdMWxGiJh7h3uJ+WS2h4lq2nx3DZVO7rJvwa5kZpDq9QEFPoyZINAUyfaaoN4Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@rdfjs/data-model": "^2.1.0",
+				"@rdfjs/dataset": "^2.0.2",
+				"@rdfjs/environment": "^1.0.0",
+				"@rdfjs/namespace": "^2.0.1",
+				"@rdfjs/term-set": "^2.0.3",
+				"@rdfjs/types": "1 - 2",
+				"@vocabulary/sh": "^1.1.6",
+				"clownface": "^2.0.3",
+				"debug": "^4.3.2",
+				"rdf-dataset-ext": "^1.1.0",
+				"rdf-literal": "^2.0.0",
+				"rdf-validate-datatype": "^0.2.2"
+			}
+		},
 		"node_modules/rdfa-streaming-parser": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/rdfa-streaming-parser/-/rdfa-streaming-parser-3.0.2.tgz",
@@ -11281,6 +11456,13 @@
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-3.1.2.tgz",
 			"integrity": "sha512-5/r/lTwbJ3zQ+qwdUFZYeRNqda7P5HD8zQKqlSjdGt1/S0cjLAphHusj4Y58ahDtWn/g32xrIS58/ikOvwl0Lw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/setimmediate": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+			"integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -12722,22 +12904,6 @@
 			"license": "ISC",
 			"engines": {
 				"node": ">=10"
-			}
-		},
-		"node_modules/yaml": {
-			"version": "2.9.0",
-			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
-			"integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
-			"extraneous": true,
-			"license": "ISC",
-			"bin": {
-				"yaml": "bin.mjs"
-			},
-			"engines": {
-				"node": ">= 14.6"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/eemeli"
 			}
 		},
 		"node_modules/yargs": {

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
 		"prettier": "^3.9.6",
 		"prettier-plugin-svelte": "^4.1.1",
 		"rdf-data-factory": "^2.0.2",
+		"rdf-validate-shacl": "^0.6.5",
 		"rdfa-streaming-parser": "^3.0.2",
 		"shadow-dom-testing-library": "^1.14.1",
 		"svelte": "^5.57.0",

--- a/src/lib/navigation/sub-navigation.ts
+++ b/src/lib/navigation/sub-navigation.ts
@@ -53,6 +53,12 @@ export const subNavItems: SubNavItem<string>[] = [
 		href: resolve('/explore/named-graphs')
 	},
 	{
+		id: 'subnav-explore-shacl',
+		parentId: 'explore',
+		title: 'SHACL Validation',
+		href: resolve('/explore/shacl')
+	},
+	{
 		id: 'subnav-explore-iris',
 		parentId: 'explore',
 		title: 'IRI Search',

--- a/src/lib/util/shacl.test.ts
+++ b/src/lib/util/shacl.test.ts
@@ -1,0 +1,99 @@
+/* (c) Crown Copyright GCHQ */
+
+import { Parser, Store as N3Store } from 'n3';
+import type { LocalSource } from '$stores/sources/local-sources.store';
+import {
+	combineEnabledLocalSources,
+	parseShaclShapes,
+	validateLocalSourcesWithShacl
+} from './shacl';
+
+const shapes = `
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix ex: <http://example.org/> .
+
+ex:PersonShape a sh:NodeShape ;
+    sh:targetClass ex:Person ;
+    sh:property [
+        sh:path ex:name ;
+        sh:minCount 1
+    ] .
+`;
+
+function localSource(name: string, document: string, enabled = true): LocalSource {
+	return {
+		id: name,
+		name,
+		description: '',
+		type: 'LOCAL',
+		enabled,
+		n3Store: new N3Store(new Parser().parse(document))
+	};
+}
+
+describe('SHACL validation', () => {
+	it('parses SHACL shapes from RDF text', () => {
+		expect(parseShaclShapes(shapes).size).toBeGreaterThan(0);
+	});
+
+	it('rejects an empty shapes document', () => {
+		expect(() => parseShaclShapes('')).toThrow('contains no RDF statements');
+	});
+
+	it('combines only enabled local sources', () => {
+		const { dataset, sourceCount } = combineEnabledLocalSources([
+			localSource(
+				'enabled',
+				'<http://example.org/A> <http://example.org/p> <http://example.org/B> .'
+			),
+			localSource(
+				'disabled',
+				'<http://example.org/C> <http://example.org/p> <http://example.org/D> .',
+				false
+			)
+		]);
+
+		expect(sourceCount).toBe(1);
+		expect(dataset.size).toBe(1);
+	});
+
+	it('rejects validation when no local source is enabled', async () => {
+		await expect(
+			validateLocalSourcesWithShacl([localSource('disabled', '', false)], shapes)
+		).rejects.toThrow('No enabled local data sources');
+	});
+
+	it('reports conforming data', async () => {
+		const report = await validateLocalSourcesWithShacl(
+			[
+				localSource(
+					'people',
+					'@prefix ex: <http://example.org/> . ex:Alice a ex:Person ; ex:name "Alice" .'
+				)
+			],
+			shapes
+		);
+
+		expect(report.conforms).toBe(true);
+		expect(report.results).toHaveLength(0);
+		expect(report.sourceCount).toBe(1);
+		expect(report.dataQuadCount).toBe(2);
+	});
+
+	it('returns useful details for constraint violations', async () => {
+		const report = await validateLocalSourcesWithShacl(
+			[localSource('people', '@prefix ex: <http://example.org/> . ex:Alice a ex:Person .')],
+			shapes
+		);
+
+		expect(report.conforms).toBe(false);
+		expect(report.results).toHaveLength(1);
+		expect(report.results[0]).toMatchObject({
+			focusNode: 'http://example.org/Alice',
+			path: 'http://example.org/name',
+			severity: 'sh:Violation',
+			message: 'Less than 1 values',
+			sourceConstraintComponent: 'sh:MinCountConstraintComponent'
+		});
+	});
+});

--- a/src/lib/util/shacl.ts
+++ b/src/lib/util/shacl.ts
@@ -1,0 +1,80 @@
+/* (c) Crown Copyright GCHQ */
+
+import type { Term } from '@rdfjs/types';
+import type { LocalSource } from '$stores/sources/local-sources.store';
+import { Parser, Store as N3Store } from 'n3';
+import SHACLValidator from 'rdf-validate-shacl';
+
+const SHACL_NAMESPACE = 'http://www.w3.org/ns/shacl#';
+
+export interface ShaclValidationResult {
+	focusNode: string;
+	path: string;
+	severity: string;
+	message: string;
+	sourceConstraintComponent: string;
+	sourceShape: string;
+}
+
+export interface ShaclValidationSummary {
+	conforms: boolean;
+	results: ShaclValidationResult[];
+	dataQuadCount: number;
+	shapeQuadCount: number;
+	sourceCount: number;
+}
+
+function displayTerm(term: Term | undefined): string {
+	if (!term) return '';
+	if (term.termType === 'BlankNode') return `_:${term.value}`;
+	if (term.termType === 'Literal') return term.value;
+	if (term.termType === 'NamedNode' && term.value.startsWith(SHACL_NAMESPACE)) {
+		return `sh:${term.value.slice(SHACL_NAMESPACE.length)}`;
+	}
+	return term.value;
+}
+
+export function parseShaclShapes(document: string): N3Store {
+	const shapes = new N3Store(new Parser().parse(document));
+	if (shapes.size === 0) throw new Error('The SHACL shapes document contains no RDF statements.');
+	return shapes;
+}
+
+export function combineEnabledLocalSources(sources: LocalSource[]): {
+	dataset: N3Store;
+	sourceCount: number;
+} {
+	const enabledSources = sources.filter((source) => source.enabled && source.n3Store);
+	if (enabledSources.length === 0) throw new Error('No enabled local data sources are available.');
+
+	const dataset = new N3Store();
+	for (const source of enabledSources) {
+		const store = source.n3Store as N3Store;
+		dataset.addQuads(store.getQuads(null, null, null, null));
+	}
+	return { dataset, sourceCount: enabledSources.length };
+}
+
+export async function validateLocalSourcesWithShacl(
+	sources: LocalSource[],
+	shapesDocument: string
+): Promise<ShaclValidationSummary> {
+	const shapes = parseShaclShapes(shapesDocument);
+	const { dataset, sourceCount } = combineEnabledLocalSources(sources);
+	const report = await new SHACLValidator(shapes).validate(dataset);
+
+	return {
+		conforms: report.conforms,
+		results: report.results.map((result) => ({
+			focusNode: displayTerm(result.focusNode),
+			path: displayTerm(result.path),
+			severity: displayTerm(result.severity),
+			message: result.message.map(displayTerm).join('; ') || 'SHACL constraint violation',
+			sourceConstraintComponent: displayTerm(result.sourceConstraintComponent),
+			sourceShape: displayTerm(result.sourceShape)
+		})),
+		dataQuadCount: dataset.size,
+		shapeQuadCount: shapes.size,
+		sourceCount
+	};
+}

--- a/src/routes/explore/+page.svelte
+++ b/src/routes/explore/+page.svelte
@@ -37,6 +37,11 @@
 			data sources.
 		</ListItem>
 		<ListItem>
+			Validate enabled local data sources against <Link href={resolve('/explore/shacl')}
+				>SHACL shapes</Link
+			>.
+		</ListItem>
+		<ListItem>
 			Search for a specific <Link href={resolve('/explore/iris')}>IRI</Link>.
 		</ListItem>
 	</List>

--- a/src/routes/explore/shacl/+page.svelte
+++ b/src/routes/explore/shacl/+page.svelte
@@ -1,0 +1,133 @@
+<!-- (c) Crown Copyright GCHQ -->
+
+<script lang="ts">
+	import {
+		Alert,
+		Button,
+		Heading,
+		Paragraph as P,
+		Table,
+		TableBody,
+		TableData,
+		TableHead,
+		TableHeading,
+		TableRow,
+		TextField
+	} from '$lib/components';
+	import { PageView } from '$lib/components/views';
+	import { sources as localSources } from '$stores/sources/local-sources.store';
+	import { validateLocalSourcesWithShacl, type ShaclValidationSummary } from '$lib/util/shacl';
+
+	let shapesDocument = $state('');
+	let report = $state<ShaclValidationSummary | undefined>();
+	let error = $state('');
+	let validationEnabled = $state(false);
+	let validating = $state(false);
+	let enabledLocalSources = $derived(
+		$localSources.filter((source) => source.enabled && source.n3Store)
+	);
+	let validShapesDocument = $derived(shapesDocument.trim().length > 0);
+
+	async function handleSubmit(event: SubmitEvent) {
+		event.preventDefault();
+		validationEnabled = true;
+		error = '';
+		report = undefined;
+		if (!validShapesDocument || enabledLocalSources.length === 0) return;
+
+		validating = true;
+		try {
+			report = await validateLocalSourcesWithShacl($localSources, shapesDocument);
+		} catch (err) {
+			error = err instanceof Error ? err.message : 'SHACL validation failed.';
+		} finally {
+			validating = false;
+		}
+	}
+</script>
+
+<PageView
+	heading="SHACL Validation"
+	subheading="Validate enabled local RDF sources against SHACL shapes."
+>
+	<P>
+		Paste a SHACL shapes document below. Validation runs in the browser against enabled local data
+		sources. Remote SPARQL sources are not included. Core SHACL constraints are supported;
+		SHACL-SPARQL constraints are not.
+	</P>
+
+	{#if enabledLocalSources.length === 0}
+		<Alert
+			variant="warning"
+			heading="No enabled local sources"
+			message="Enable or add a local data source before running SHACL validation."
+		/>
+	{:else}
+		<P>
+			Validating {enabledLocalSources.length} enabled local source{enabledLocalSources.length === 1
+				? ''
+				: 's'}: <strong>{enabledLocalSources.map((source) => source.name).join(', ')}</strong>.
+		</P>
+	{/if}
+
+	<form onsubmit={handleSubmit}>
+		<TextField
+			codeEditor
+			required
+			rows={14}
+			label="SHACL shapes"
+			helperText="Supported RDF syntaxes are Turtle, TriG, N-Triples, and N-Quads."
+			bind:value={shapesDocument}
+			{validationEnabled}
+			isValid={validShapesDocument}
+			validationErrorMessage="Please provide a SHACL shapes document."
+		/>
+		<Button
+			label={validating ? 'Validating' : 'Validate'}
+			type="submit"
+			disabled={validating || enabledLocalSources.length === 0}
+		/>
+	</form>
+
+	{#if error}
+		<Alert variant="error" heading="SHACL validation error" message={error} />
+	{/if}
+
+	{#if report}
+		<Heading text="Validation results" tag="h2" />
+		{#if report.conforms}
+			<Alert
+				variant="success"
+				heading="Data conforms"
+				message={`Validated ${report.dataQuadCount} data quads against ${report.shapeQuadCount} shape quads.`}
+			/>
+		{:else}
+			<Alert
+				variant="warning"
+				heading="Data does not conform"
+				message={`${report.results.length} SHACL validation result${report.results.length === 1 ? '' : 's'} found.`}
+			/>
+
+			<Table>
+				<TableHead>
+					<TableHeading value="Focus node" />
+					<TableHeading value="Path" />
+					<TableHeading value="Severity" />
+					<TableHeading value="Constraint" />
+					<TableHeading value="Message" />
+				</TableHead>
+				<TableBody>
+					{#each report.results as result, index (index)}
+						<TableRow>
+							<TableData>{result.focusNode}</TableData>
+							<TableData>{result.path}</TableData>
+							<TableData>{result.severity}</TableData>
+							<TableData>{result.sourceConstraintComponent}</TableData>
+							<TableData>{result.message}</TableData>
+						</TableRow>
+					{/each}
+				</TableBody>
+			</Table>
+		{/if}
+	{/if}
+</PageView>


### PR DESCRIPTION
Fixes #110.

Add an Explore page for validating enabled local RDF sources against pasted SHACL shapes. The page reports conformance and validation details including focus node, path, severity, constraint and message. It also makes the current scope explicit: remote SPARQL sources and SHACL-SPARQL constraints are not included.

Validation:
- 76 unit/component test files, 297 tests passed
- `npm run check`
- `npm run lint`
- `npm run copyright:check`
- `npm run build`